### PR TITLE
fix(tracelens): configure TracerProvider directly so broken OTel cont…

### DIFF
--- a/tracelens/src/tracelens/launcher/otel_setup.py
+++ b/tracelens/src/tracelens/launcher/otel_setup.py
@@ -135,41 +135,88 @@ def load_contrib_instrumenters() -> dict[str, str]:
     return status
 
 
-def bootstrap_autoinstrumentation(*, load_instrumentors: bool = True) -> dict[str, str]:
-    """Configure OTel auto-instrumentation in-process; return per-instrumenter load status.
+def core_sdk_missing() -> str | None:
+    """Preflight: name the missing core OTel distribution, or ``None`` when present.
 
-    Combines two paths:
-        1. The official OTel ``_load_instrumentors`` (entry-point-based, what
+    Uses ``find_spec`` (no imports) so the check is safe to run before any hook is
+    installed. Only ``opentelemetry-api`` + ``opentelemetry-sdk`` are *core* — the
+    contrib ``opentelemetry-instrumentation`` package is optional and its absence
+    (or breakage) must never block span capture.
+    """
+    core = (("opentelemetry", "opentelemetry-api"), ("opentelemetry.sdk", "opentelemetry-sdk"))
+    for mod, dist in core:
+        try:
+            if importlib.util.find_spec(mod) is None:
+                return dist
+        except (ImportError, ValueError):
+            return dist
+    return None
+
+
+def configure_tracer_provider() -> str:
+    """Install tracelens's TracerProvider + JSONL exporter DIRECTLY; return a status token.
+
+    This must never route through OTel's entry-point machinery: it needs only
+    ``opentelemetry-api`` + ``opentelemetry-sdk``, which tracelens requires anyway.
+    """
+    try:
+        from tracelens.otel.configurator import TracelensConfigurator
+
+        TracelensConfigurator().configure()
+        return "configured"
+    except BaseException as exc:  # noqa: BLE001 — never crash the target
+        _log.warning("tracelens: TracerProvider configuration failed: %s", exc)
+        return f"failed:{type(exc).__name__}"
+
+
+def bootstrap_autoinstrumentation(*, load_instrumentors: bool = True) -> dict[str, str]:
+    """Configure the span pipeline in-process; return per-instrumenter load status.
+
+    Step 1 — ALWAYS configure tracelens's own TracerProvider (JSONL exporter) by
+    calling ``TracelensConfigurator`` directly. This used to be routed through
+    OTel contrib's private entry-point loader
+    (``opentelemetry.instrumentation.auto_instrumentation._load``), which tied
+    core span export to the *contrib* package's importability: on Python 3.14
+    that module still imports the removed ``pkg_resources``, the resulting
+    ``ModuleNotFoundError`` was swallowed, no TracerProvider was ever installed,
+    every span went to the no-op ``ProxyTracerProvider`` — and the trace file was
+    silently never created (observed live on the fastapi demo repo).
+
+    Step 2 (only when ``load_instrumentors``) — best-effort contrib loading:
+        a. The official OTel ``_load_instrumentors`` (entry-point-based, what
            ``opentelemetry-instrument`` would do).
-        2. Tracelens's own ``_CONTRIB_MAP`` walk so we work even when the target's env
-           does not register entry-points (custom installs).
+        b. Tracelens's own ``_CONTRIB_MAP`` walk so we work even when the
+           target's env does not register entry-points (custom installs).
+    With ``--no-otel-autoinst`` no ``opentelemetry.instrumentation`` module is
+    imported at all, so a venv that lacks (or ships a broken) contrib package
+    still captures spans in minimal mode.
     Returns the merged status dict so the launcher can fold it into summary.json (T1.4).
     """
     status: dict[str, str] = {}
-    # 1) ALWAYS load configurators (this triggers our TracelensConfigurator → TracerProvider).
-    #    The ``load_instrumentors`` flag only gates the contrib library wrapping in step 2/3,
-    #    NOT the configurator that sets up the JSONL exporter — without it, no spans get
-    #    written to disk regardless of how the user invokes their app.
+    status["__tracelens_configurator__"] = configure_tracer_provider()
+    if not load_instrumentors:
+        status["__otel_entry_points__"] = "skipped:no_autoinst"
+        return status
     try:
         from opentelemetry.instrumentation.auto_instrumentation._load import (
-            _load_configurators,
             _load_distro,
             _load_instrumentors,
         )
 
         distro = _load_distro()
         distro.configure()
-        # Configures TracerProvider via our entry point; upstream keeps this private API untyped.
-        _load_configurators()  # type: ignore[no-untyped-call]
-        if load_instrumentors:
-            _load_instrumentors(distro)  # type: ignore[no-untyped-call]
-            status["__otel_entry_points__"] = "loaded"
-        else:
-            status["__otel_entry_points__"] = "configurator_only"
+        _load_instrumentors(distro)  # type: ignore[no-untyped-call]
+        status["__otel_entry_points__"] = "loaded"
     except BaseException as exc:  # noqa: BLE001
         status["__otel_entry_points__"] = f"failed:{type(exc).__name__}"
-        _log.info("tracelens: OTel entry-point loader produced no instrumenters (%s)", exc)
-    # 2) Tracelens's own probe — idempotent: instrumenters loaded twice are no-ops.
-    if load_instrumentors:
-        status.update(load_contrib_instrumenters())
+        _log.warning(
+            "tracelens: OTel auto-instrumentation unavailable (%s: %s) — span capture "
+            "continues, but contrib instrumenters were not loaded. Install/upgrade "
+            "'opentelemetry-instrumentation' in the target env or pass --no-otel-autoinst "
+            "to silence this.",
+            type(exc).__name__,
+            exc,
+        )
+    # Tracelens's own probe — idempotent: instrumenters loaded twice are no-ops.
+    status.update(load_contrib_instrumenters())
     return status

--- a/tracelens/src/tracelens/launcher/run.py
+++ b/tracelens/src/tracelens/launcher/run.py
@@ -445,6 +445,20 @@ def _extract_bundled_source(zip_path: Path) -> str | None:
             shutil.rmtree(tmp, ignore_errors=True)
 
 
+def _resolvable_executable(cmd0: str) -> bool:
+    """False only for a path-style argv[0] that points at nothing executable.
+
+    Bare names (``python``, ``uvicorn``) are left to PATH resolution at exec
+    time; only an explicit path (contains a separator) is checked here. That is
+    the mistyped-venv-interpreter case, which otherwise surfaces as a raw
+    ``FileNotFoundError`` traceback out of ``os.execvpe``.
+    """
+    if os.sep not in cmd0 and (os.altsep is None or os.altsep not in cmd0):
+        return True
+    p = Path(cmd0).expanduser()
+    return p.exists() and os.access(p, os.X_OK)
+
+
 def _maybe_handoff_to_target_python(argv: list[str], user: list[str]) -> None:
     """Re-exec the run inside the **target service's** Python interpreter.
 
@@ -462,6 +476,12 @@ def _maybe_handoff_to_target_python(argv: list[str], user: list[str]) -> None:
     Returns normally (no handoff) when the current interpreter can host the
     target itself. ``os.execvpe`` replaces this process on a successful handoff.
     """
+    if user and not _resolvable_executable(user[0]):
+        raise SystemExit(
+            f"tracelens run: target command not found: {user[0]!r} — the executable "
+            "after '--' does not exist (or is not executable). Check the path "
+            "(typo? venv not created yet?)."
+        )
     target_py = _external_target_python(user)
     if target_py is None:
         if _is_frozen() and not _is_python_command(user):
@@ -518,8 +538,15 @@ def _maybe_handoff_to_target_python(argv: list[str], user: list[str]) -> None:
                 f"tracelens run: failed to launch target interpreter {target_py!r}: {exc}"
             ) from None
         raise SystemExit(rc)
-    os.execvpe(target_py, [target_py, "-c", child, *argv], env)
-    # execvpe only returns on failure to launch the new image.
+    try:
+        os.execvpe(target_py, [target_py, "-c", child, *argv], env)
+    except OSError as exc:
+        # execvpe raises (rather than returns) on failure to launch the new image;
+        # without this the user sees a raw FileNotFoundError traceback.
+        raise SystemExit(
+            f"tracelens run: failed to exec target interpreter {target_py!r}: "
+            f"{exc.strerror or exc}"
+        ) from None
     raise SystemExit(f"tracelens run: failed to exec target interpreter {target_py!r}")
 
 
@@ -759,6 +786,18 @@ def run_main(argv: list[str] | None = None) -> None:
     # hand the whole run off to the target's own interpreter. On a successful
     # handoff os.execvpe replaces this process and never returns here.
     _maybe_handoff_to_target_python(argv, user)
+    # Preflight the core OTel SDK now — one clear line instead of a raw
+    # ModuleNotFoundError from deep inside the bootstrap (or, worse, from the
+    # injected `from tracelens.runtime import trace_fn` import inside the
+    # user's own rewritten modules). Only api+sdk are required; the contrib
+    # `opentelemetry-instrumentation` package is optional (see otel_setup).
+    _missing_dist = otel_setup.core_sdk_missing()
+    if _missing_dist is not None:
+        raise SystemExit(
+            f"tracelens run: this Python environment is missing '{_missing_dist}', "
+            "which tracelens needs to record spans. Install it into the target venv: "
+            "pip install opentelemetry-api opentelemetry-sdk"
+        )
     (
         output,
         targets,

--- a/tracelens/tests/test_run_bootstrap_resilience.py
+++ b/tracelens/tests/test_run_bootstrap_resilience.py
@@ -1,0 +1,286 @@
+"""Regression tests for the fastapi-demo silent-empty-trace defect and its papercuts.
+
+Root cause (found live on fastapi/full-stack-fastapi-template): the launcher routed
+TracerProvider setup through OTel contrib's private entry-point loader
+(``opentelemetry.instrumentation.auto_instrumentation._load``). On Python 3.14 that
+module imports the removed ``pkg_resources``; the ``ModuleNotFoundError`` was
+swallowed, no TracerProvider was ever installed, and every span went to the no-op
+``ProxyTracerProvider`` — the trace file was never created at all.
+
+The fixture below is uvicorn-shaped: a ``python -m fake_uvicorn pkg.mod:app`` target
+that resolves and imports the app module LAZILY (uvicorn's ``import_from_string``),
+i.e. after the launcher's hooks are installed, with a PYTHONPATH stub that shadows
+``opentelemetry.instrumentation.auto_instrumentation`` and raises the same
+``ModuleNotFoundError`` the demo venv produced. No network involved.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tracelens.launcher import otel_setup
+from tracelens.launcher import run as run_mod
+
+_ENTRY = "import sys; from tracelens.launcher.run import run_main; run_main(sys.argv[1:])"
+
+
+def _write_broken_contrib_stub(root: Path) -> Path:
+    """A PYTHONPATH dir whose ``opentelemetry.instrumentation.auto_instrumentation``
+    shadows the installed one and dies exactly like the demo venv did."""
+    stub = root / "stub"
+    pkg = stub / "opentelemetry" / "instrumentation" / "auto_instrumentation"
+    pkg.mkdir(parents=True)
+    # Parents stay namespace portions (no __init__.py) so the real
+    # opentelemetry / opentelemetry.instrumentation modules still resolve.
+    (pkg / "__init__.py").write_text(
+        "raise ModuleNotFoundError(\"No module named 'pkg_resources'\")\n",
+        encoding="utf-8",
+    )
+    return stub
+
+
+def _write_uvicorn_shaped_project(root: Path) -> Path:
+    proj = root / "proj"
+    app_pkg = proj / "demopkg"
+    app_pkg.mkdir(parents=True)
+    (app_pkg / "__init__.py").write_text("", encoding="utf-8")
+    (app_pkg / "main.py").write_text(
+        "class App:\n"
+        "    def handle(self, item):\n"
+        "        return self.transform(item)\n"
+        "\n"
+        "    def transform(self, item):\n"
+        "        return {'item': item}\n"
+        "\n"
+        "app = App()\n",
+        encoding="utf-8",
+    )
+    server = proj / "fake_uvicorn"
+    server.mkdir()
+    (server / "__init__.py").write_text("", encoding="utf-8")
+    # Lazy import-from-string, exactly like uvicorn.importer.import_from_string:
+    # the app package must not be imported until AFTER tracelens hooks are live.
+    (server / "__main__.py").write_text(
+        "import importlib\n"
+        "import sys\n"
+        "\n"
+        "spec = sys.argv[1]\n"
+        "modname, _, attr = spec.partition(':')\n"
+        "mod = importlib.import_module(modname)\n"
+        "app = getattr(mod, attr)\n"
+        "for i in range(3):\n"
+        "    app.handle(i)\n",
+        encoding="utf-8",
+    )
+    return proj
+
+
+def _run_tracelens(
+    args: list[str], *, cwd: Path, env: dict[str, str]
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-c", _ENTRY, *args],
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+
+
+@pytest.mark.skipif(os.name == "nt", reason="fork supervisor path is POSIX-only")
+def test_minimal_capture_survives_broken_otel_contrib(tmp_path: Path) -> None:
+    stub = _write_broken_contrib_stub(tmp_path)
+    proj = _write_uvicorn_shaped_project(tmp_path)
+    out = tmp_path / "trace.jsonl"
+    env = {**os.environ, "PYTHONPATH": str(stub)}
+    env.pop("TRACELENS_DIAG_LOG", None)
+
+    # Fixture sanity: with the stub, the contrib bootstrap import fails exactly
+    # like the demo venv (pkg_resources gone on Python 3.14).
+    probe = subprocess.run(
+        [sys.executable, "-c", "import opentelemetry.instrumentation.auto_instrumentation"],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert probe.returncode != 0
+    assert "pkg_resources" in probe.stderr
+
+    r = _run_tracelens(
+        [
+            "--minimal",
+            "--no-otel-autoinst",
+            "-t",
+            "demopkg",
+            "-o",
+            str(out),
+            "--",
+            sys.executable,
+            "-m",
+            "fake_uvicorn",
+            "demopkg.main:app",
+        ],
+        cwd=proj,
+        env=env,
+    )
+    assert r.returncode == 0, r.stderr
+    assert out.is_file(), "trace file was never created (root-cause regression)"
+    events = [json.loads(line) for line in out.read_text(encoding="utf-8").splitlines()]
+    components = {e["component"] for e in events}
+    assert "demopkg.main.App.handle" in components
+    assert "demopkg.main.App.transform" in components
+
+
+@pytest.mark.skipif(os.name == "nt", reason="fork supervisor path is POSIX-only")
+def test_autoinst_with_broken_contrib_warns_but_still_captures(tmp_path: Path) -> None:
+    """Without --no-otel-autoinst a broken contrib package must degrade loudly,
+    not silently disable span export."""
+    stub = _write_broken_contrib_stub(tmp_path)
+    proj = _write_uvicorn_shaped_project(tmp_path)
+    out = tmp_path / "trace.jsonl"
+    env = {**os.environ, "PYTHONPATH": str(stub)}
+    env.pop("TRACELENS_DIAG_LOG", None)
+
+    r = _run_tracelens(
+        [
+            "--minimal",
+            "-t",
+            "demopkg",
+            "-o",
+            str(out),
+            "--",
+            sys.executable,
+            "-m",
+            "fake_uvicorn",
+            "demopkg.main:app",
+        ],
+        cwd=proj,
+        env=env,
+    )
+    assert r.returncode == 0, r.stderr
+    assert out.is_file()
+    events = [json.loads(line) for line in out.read_text(encoding="utf-8").splitlines()]
+    assert any(e["component"].startswith("demopkg.") for e in events)
+    assert "auto-instrumentation unavailable" in r.stderr
+
+
+def test_bootstrap_no_autoinst_skips_contrib_and_configures(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("TRACELENS_OUTPUT", str(tmp_path / "trace.jsonl"))
+    # Poison the contrib loader import: if bootstrap touches it in minimal mode,
+    # this raises and the status would say "failed:" instead of "skipped:".
+    monkeypatch.setitem(
+        sys.modules, "opentelemetry.instrumentation.auto_instrumentation._load", None
+    )
+
+    status = otel_setup.bootstrap_autoinstrumentation(load_instrumentors=False)
+
+    assert status["__tracelens_configurator__"] == "configured"
+    assert status["__otel_entry_points__"] == "skipped:no_autoinst"
+
+
+def test_bootstrap_configures_provider_even_when_entry_loader_broken(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("TRACELENS_OUTPUT", str(tmp_path / "trace.jsonl"))
+    monkeypatch.setitem(
+        sys.modules, "opentelemetry.instrumentation.auto_instrumentation._load", None
+    )
+
+    status = otel_setup.bootstrap_autoinstrumentation(load_instrumentors=True)
+
+    assert status["__tracelens_configurator__"] == "configured"
+    assert status["__otel_entry_points__"].startswith("failed:")
+
+
+def test_core_sdk_missing_names_the_missing_distribution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert otel_setup.core_sdk_missing() is None  # dev env has api+sdk
+
+    real_find_spec = otel_setup.importlib.util.find_spec
+
+    def fake_find_spec(name: str, *args: object) -> object:
+        if name == "opentelemetry.sdk":
+            return None
+        return real_find_spec(name, *args)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(otel_setup.importlib.util, "find_spec", fake_find_spec)
+    assert otel_setup.core_sdk_missing() == "opentelemetry-sdk"
+
+
+def test_otel_less_interpreter_gets_friendly_one_liner(tmp_path: Path) -> None:
+    """Simulate a target venv without opentelemetry via ``python -S`` (site-packages
+    hidden); tracelens itself is supplied on PYTHONPATH. The run must exit with a
+    single actionable line, not a raw ModuleNotFoundError traceback."""
+    src = str(Path(run_mod.__file__).resolve().parents[2])
+    script = tmp_path / "app.py"
+    script.write_text("print('hi')\n", encoding="utf-8")
+    env = {**os.environ, "PYTHONPATH": src}
+    r = subprocess.run(
+        [
+            sys.executable,
+            "-S",
+            "-c",
+            _ENTRY,
+            "-o",
+            str(tmp_path / "t.jsonl"),
+            "--",
+            sys.executable,
+            str(script),
+        ],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    assert r.returncode != 0
+    assert "pip install opentelemetry-api opentelemetry-sdk" in r.stderr
+    assert "Traceback" not in r.stderr
+
+
+def test_missing_target_python_gets_friendly_one_liner(tmp_path: Path) -> None:
+    missing = "/definitely/not/a/venv/bin/python"
+    r = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _ENTRY,
+            "-o",
+            str(tmp_path / "t.jsonl"),
+            "--",
+            missing,
+            "-m",
+            "uvicorn",
+            "app.main:app",
+        ],
+        cwd=tmp_path,
+        env=dict(os.environ),
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    assert r.returncode != 0
+    assert "target command not found" in r.stderr
+    assert missing in r.stderr
+    assert "Traceback" not in r.stderr
+
+
+def test_missing_target_python_unit(monkeypatch: pytest.MonkeyPatch) -> None:
+    with pytest.raises(SystemExit, match="target command not found"):
+        run_mod._maybe_handoff_to_target_python(
+            ["--", "/nope/bin/python", "app.py"], ["/nope/bin/python", "app.py"]
+        )


### PR DESCRIPTION
…rib can't silence capture

Found live on the fastapi/full-stack-fastapi-template demo: `tracelens run --minimal --no-otel-autoinst -t app -o trace.jsonl -- <venv>/python -m uvicorn app.main:app` never created the trace file. The AST hook rewrote all 27 app modules fine — but the launcher routed TracerProvider setup exclusively through OTel contrib's private entry-point loader
(opentelemetry.instrumentation.auto_instrumentation._load), which on Python 3.14 still imports the removed pkg_resources. The ModuleNotFoundError was swallowed into a status string, no TracerProvider was ever installed, and every span went to the no-op ProxyTracerProvider, so the exporter (whose file is created on first configure) never ran.

- bootstrap now calls TracelensConfigurator directly (needs only opentelemetry-api/sdk); the contrib entry-point loader is used solely for instrumenters, only when autoinst is requested, and degrades with a loud actionable warning instead of silently.
- --no-otel-autoinst no longer imports opentelemetry.instrumentation at all; a venv missing the core api/sdk gets a one-line "pip install opentelemetry-api opentelemetry-sdk" preflight error instead of a raw ModuleNotFoundError from inside the bootstrap or a rewritten user module.
- a mistyped path-style target interpreter after `--` now produces a one-line "target command not found" error instead of a raw execvpe traceback (and exec launch failures are wrapped the same way).

Regression tests: a uvicorn-shaped fixture (lazy import_from_string child, PYTHONPATH stub that shadows the contrib bootstrap with the exact pkg_resources failure), bootstrap unit tests, an OTel-less interpreter e2e (python -S), and missing-interpreter e2e + unit. Suite: 164 passed, 2 skipped.