### PR TITLE
fix(harness): classify auth/quota/network CLI failures as terminal in…

### DIFF
--- a/extension/src/harness/autoPilot.ts
+++ b/extension/src/harness/autoPilot.ts
@@ -27,6 +27,7 @@ import {
 	failureSignature,
 	initialPipelineLedger,
 	initialServiceState,
+	markBlockedOnHarness,
 	markGaveUp,
 	markGreen,
 	markNotAService,
@@ -58,10 +59,13 @@ import {
 import { isServiceRunning, startService } from '../bringup/serviceRunner';
 import {
 	getHarness,
+	getHarnessBlock,
 	isHarnessAutonomous,
 	isHarnessBusy,
+	preflightHarnessAuth,
 	quickScanHarnesses,
 	runBringupStartViaHarness,
+	type HarnessBlock,
 } from './harnessRunner';
 import {
 	isEpisodeRunning,
@@ -110,6 +114,15 @@ export function showAutoPilotLog(): void {
 
 function delay(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** One-line "why blocked" for the ledger/summary when the harness cannot run. */
+function blockedDetail(block: HarnessBlock | undefined): string {
+	const label = getHarness(getHarnessId()).label;
+	if (!block) {
+		return `${label} cannot run (precondition failure) — fix the agent CLI, then re-run Auto-Pilot`;
+	}
+	return `${label} ${block.kind === 'auth' ? 'needs login' : block.kind === 'quota' ? 'is out of quota/credits' : 'cannot reach its service'} — ${block.remediation}`;
 }
 
 /**
@@ -404,6 +417,15 @@ async function drive(
 				if (!(await waitForHarnessIdle(token))) {
 					continue;
 				}
+				// Infra preflight BEFORE the attempt is counted: a signed-out CLI
+				// cannot set anything up, and burning setup attempts discovering
+				// that would also swallow the budget the human needs after login.
+				if ((await preflightHarnessAuth(getHarnessId())) !== 'ok') {
+					const block = getHarnessBlock(getHarnessId());
+					replace(markBlockedOnHarness(svc, blockedDetail(block)));
+					report(`${svc.name} blocked — ${blockedDetail(block)}`);
+					continue;
+				}
 				replace(noteSetupAttempt(svc));
 				const entry = readServices(workspaceRoot).find((s) => s.name === svc.name);
 				if (!entry) {
@@ -466,6 +488,17 @@ async function drive(
 		// ---- failure path: budget check → fix episode → retry ------------------
 		const step: PilotStep = action.kind === 'setup' ? 'setup' : 'start';
 		const current = services.find((s) => s.name === svc.name) ?? svc;
+		// Harness precondition failure (needs login / quota / network — the
+		// runner classified it and set the session block): terminal for this
+		// run WITHOUT consuming any fix budget, and no fix episode is
+		// dispatched — an unauthenticated CLI cannot fix anything. The next
+		// run, after the human acts, starts with the budgets intact.
+		const preBlock = getHarnessBlock(getHarnessId());
+		if (preBlock) {
+			replace(markBlockedOnHarness(current, blockedDetail(preBlock)));
+			report(`${svc.name} blocked — ${blockedDetail(preBlock)}`);
+			continue;
+		}
 		const signature = failureSignature(step, failureDetail ?? '');
 		const { state: budgeted, decision } = decideOnFailure(current, step, signature, budgets);
 		if (decision.next === 'give-up') {
@@ -496,6 +529,16 @@ async function drive(
 				workspaceRoot,
 				fixTask(svc.name, step, failureDetail ?? ''),
 			);
+			// The episode itself may have been the first to discover the harness
+			// precondition failure — then retrying the step is pointless: mark
+			// the service blocked-on-you and move on (budgets stay as they are).
+			const postBlock = getHarnessBlock(getHarnessId());
+			if (postBlock) {
+				const blocked = services.find((s) => s.name === svc.name) ?? budgeted;
+				replace(markBlockedOnHarness(blocked, blockedDetail(postBlock)));
+				report(`${svc.name} blocked — ${blockedDetail(postBlock)}`);
+				continue;
+			}
 			report(
 				verified
 					? `Fix episode for ${svc.name} verified — retrying ${step}`

--- a/extension/src/harness/autoPilotMachine.ts
+++ b/extension/src/harness/autoPilotMachine.ts
@@ -188,6 +188,17 @@ export function markGaveUp(svc: ServiceState, reason: string): ServiceState {
 }
 
 /**
+ * Marks a service blocked on a harness PRECONDITION failure (CLI needs login,
+ * quota exhausted, vendor unreachable). Terminal for THIS run — the human must
+ * act — but crucially it consumes NOTHING: no setup attempt, no fix episode,
+ * no per-signature spend. The next Auto-Pilot run (after `cursor-agent login`
+ * or the like) starts the service with its budgets intact.
+ */
+export function markBlockedOnHarness(svc: ServiceState, detail: string): ServiceState {
+	return { ...svc, phase: 'gave-up', reason: `blocked on you: ${detail}` };
+}
+
+/**
  * Marks a service as not-a-service: the replay ran to completion cleanly, so
  * this is a CLI/script misclassified as a service. Terminal like 'library' —
  * it must never re-enter setup or consume fix budgets (the historical

--- a/extension/src/harness/autoTrigger.ts
+++ b/extension/src/harness/autoTrigger.ts
@@ -21,7 +21,14 @@ import { onServiceExit, type ServiceExitEvent } from '../bringup/serviceRunner';
 import { readBringupOutcome } from '../bringup/bringup';
 import { runEpisode, isEpisodeRunning, type EpisodeTask } from './episodeLoop';
 import { classifyIntent, criteriaFor } from './taskIntent';
-import { getHarness, isHarnessAutonomous, isHarnessBusy, quickScanHarnesses } from './harnessRunner';
+import {
+	getHarness,
+	getHarnessBlock,
+	isHarnessAutonomous,
+	isHarnessBusy,
+	preflightHarnessAuth,
+	quickScanHarnesses,
+} from './harnessRunner';
 import { pickHarness } from './harnessPicker';
 import { loadRuntimeOverlay, loadNodes, indexStoreDir } from '../graph/indexGraph';
 import { readAndClearRequests, restoreEpisodeRequests } from './requestQueue';
@@ -75,6 +82,12 @@ async function offerOrDispatch(
 	const harnessReady =
 		quickScanHarnesses()[harnessId] === true && isHarnessAutonomous(getHarness(harnessId));
 	if (isAutoEpisodesEnabled() && harnessReady) {
+		// Infra preflight: an unauthenticated CLI must not consume the dispatch
+		// (markHarnessBlocked already surfaced the remediation once) — the issue
+		// stays blocked-on-you and re-dispatches fresh after login.
+		if ((await preflightHarnessAuth(harnessId)) !== 'ok') {
+			return;
+		}
 		void vscode.window.showInformationMessage(`Vinv: ${summary} — dispatching a fix episode…`);
 		await runEpisode(context, workspaceRoot, task);
 		return;
@@ -131,12 +144,25 @@ export async function dispatchIssueEpisode(
 	const harnessReady =
 		quickScanHarnesses()[harnessId] === true && isHarnessAutonomous(getHarness(harnessId));
 	if (isAutoEpisodesEnabled() && harnessReady) {
+		// Infra preflight: a blocked CLI (needs login / quota / network) must
+		// not consume the dispatch. Returning false keeps every issue eligible,
+		// so the same signatures re-dispatch fresh once the human has logged in
+		// — blocked is never recorded as dispatched.
+		if ((await preflightHarnessAuth(harnessId)) !== 'ok') {
+			return false;
+		}
 		void vscode.window.showInformationMessage(
 			`Vinv: ${issues.length} issue(s) identified from the live trace — dispatching a fix episode…`,
 		);
 		// Fire-and-observe: runEpisode owns the busy-lock (it refuses to start
 		// while a harness run or episode is in flight, which we checked above).
 		await runEpisode(context, workspaceRoot, task);
+		// The dispatch itself may have discovered the precondition failure —
+		// then nothing was actually attempted-to-completion: report "not handed
+		// off" so the caller leaves the signatures eligible for re-dispatch.
+		if (getHarnessBlock(harnessId)) {
+			return false;
+		}
 		return true;
 	}
 	const choice = await vscode.window.showWarningMessage(
@@ -152,7 +178,9 @@ export async function dispatchIssueEpisode(
 		return false;
 	}
 	await runEpisode(context, workspaceRoot, task, picked);
-	return true;
+	// Same rule as the auto path: a dispatch that ended infra-blocked was not
+	// handed off — the issues stay eligible for a fresh dispatch after login.
+	return !getHarnessBlock(picked);
 }
 
 /**
@@ -419,6 +447,13 @@ export function registerRuntimeErrorTrigger(context: vscode.ExtensionContext): v
 			runtimeErrorTask(clusters),
 			`the live trace shows ${clusters.length} function(s) raising errors`,
 		);
+		// Blocked ≠ dispatched: if the dispatch ran into a harness precondition
+		// failure (needs login / quota / network), un-record the signature so
+		// the SAME failure picture re-arms and dispatches fresh after login —
+		// otherwise the dedup would bury it forever.
+		if (getHarnessBlock(getHarnessId())) {
+			await context.workspaceState.update(RUNTIME_ERROR_SIG_KEY, undefined);
+		}
 	};
 	const schedule = (): void => {
 		if (timer) {

--- a/extension/src/harness/episodeLoop.ts
+++ b/extension/src/harness/episodeLoop.ts
@@ -106,7 +106,19 @@ import {
 	isAcceptanceTestsEnabled,
 	isAutoEpisodesEnabled,
 } from '../config/settings';
-import { dispatchAgentPrompt, getHarness, isHarnessBusy, runHarnessPrompt } from './harnessRunner';
+import {
+	dispatchAgentPrompt,
+	getHarness,
+	getHarnessBlock,
+	harnessBlockRemediation,
+	INFRA_BLOCK_LABELS,
+	isHarnessBusy,
+	preflightHarnessAuth,
+	runHarnessPrompt,
+	type HarnessDef,
+	type HarnessInfraKind,
+	type HarnessRunResult,
+} from './harnessRunner';
 import { VINV_BASE_CSS } from '../views/webviewTheme';
 import {
 	isAskVinvOpen,
@@ -443,6 +455,37 @@ export async function verifyServiceReplay(
 		killProcessTree(child, 'SIGTERM');
 		setTimeout(() => killProcessTree(child, 'SIGKILL'), 4000);
 	}
+}
+
+/** How an episode ends when its harness hits a precondition failure. */
+export interface InfraStop {
+	kind: HarnessInfraKind;
+	/** Issue/Flow state label, e.g. 'blocked: agent CLI needs login'. */
+	endLabel: string;
+	/** The one actionable remediation sentence for the notification. */
+	remediation: string;
+}
+
+/**
+ * Pure gate between a harness run and ALL verification machinery: an infra
+ * precondition failure (CLI signed out, key invalid, quota exhausted, vendor
+ * unreachable) can never be fixed by retrying, so it ends the episode on the
+ * FIRST occurrence — one attempt, no re-dispatch, no stall judge, no dispute
+ * negotiation, objective:false (never composition-failure evidence for the
+ * bandit). Returns null for every other outcome (normal verification runs).
+ */
+export function gateAttemptRun(
+	run: Pick<HarnessRunResult, 'ok' | 'infra' | 'detail'>,
+	harness: HarnessDef,
+): InfraStop | null {
+	if (!run.infra) {
+		return null;
+	}
+	return {
+		kind: run.infra,
+		endLabel: INFRA_BLOCK_LABELS[run.infra],
+		remediation: run.detail ?? harnessBlockRemediation(harness, run.infra),
+	};
 }
 
 /** Escalation verdict from the user when evidence alone cannot decide. */
@@ -940,6 +983,24 @@ export async function runEpisode(
 		);
 		return false;
 	}
+	// Infra preflight: a signed-out (or quota-dead, or unreachable) CLI can
+	// never complete an episode — refuse to dispatch, and to spend acceptance
+	// tests or judge work, BEFORE any budget is touched. markHarnessBlocked
+	// already surfaced the remediation once this session; the chat note keeps
+	// the issue visibly blocked-on-you rather than "agent working". A later
+	// dispatch of the same issue re-probes and proceeds fresh after login.
+	const preflight = await preflightHarnessAuth(chosenHarness);
+	if (preflight !== 'ok') {
+		const block = getHarnessBlock(chosenHarness);
+		postEpisodeUpdate({
+			kind: 'note',
+			text:
+				`⛔ episode "${task.title}" not dispatched — ${INFRA_BLOCK_LABELS[preflight]}. ` +
+				(block?.remediation ?? harnessBlockRemediation(harness, preflight)),
+			sessionId,
+		});
+		return false;
+	}
 
 	const policy = loadEpisodePolicy();
 	const decision = selectEpisodeArm(policy);
@@ -965,6 +1026,10 @@ export async function runEpisode(
 	let attempts = 0;
 	let verified = false;
 	let aborted = false;
+	// Set when the harness hit a precondition failure (auth/quota/network):
+	// the episode ended as infra-blocked — terminal after ONE attempt, shown
+	// as blocked-on-you, and never trained into the bandit.
+	let infraBlocked: InfraStop | undefined;
 	// True only when the terminal verdict came from the OBJECTIVE oracle (service
 	// replay pass, or a definitive oracle failure the human did not override) —
 	// not from a human "approve as done", an abort, or a no-oracle general task.
@@ -1448,6 +1513,35 @@ export async function runEpisode(
 						},
 					);
 					const dispatchSeconds = (Date.now() - started) / 1000;
+
+					// Precondition failure (CLI signed out, quota exhausted, vendor
+					// unreachable): terminal on the FIRST occurrence. No retry can
+					// succeed, so none of the machinery below — directives, dispute,
+					// verify, stall judge, escalation — may engage; the episode ends
+					// blocked-on-you with the exact remediation, objective:false.
+					const infraStop = gateAttemptRun(run, harness);
+					if (infraStop) {
+						appendEpisodeEvent({
+							type: 'infra_blocked',
+							ts: new Date().toISOString(),
+							episode_id: episodeId,
+							attempt: attempts,
+							kind: infraStop.kind,
+							detail: infraStop.remediation.slice(0, 300),
+						});
+						postEpisodeUpdate({
+							kind: 'note',
+							text: `⛔ ${harness.label} could not run — ${infraStop.endLabel}. ${infraStop.remediation}`,
+							sessionId: owningSessionId,
+						});
+						lastEvidence = `${infraStop.endLabel} — ${infraStop.remediation}`;
+						infraBlocked = infraStop;
+						// Terminal (also suppresses the trajectory continuation): this
+						// is not negative evidence about the fix or the arm, so
+						// lastObjectiveFail stays false and the bandit learns nothing.
+						aborted = true;
+						return;
+					}
 
 					// Tri-directional channel: the USER can steer Vinv from the
 					// harness chat; the agent relays it as VINV: directives on stdout.
@@ -2114,7 +2208,16 @@ export async function runEpisode(
 		}
 		postEpisodeUpdate({
 			kind: 'end',
-			text: verified ? 'verified' : aborted ? 'stopped' : 'not verified',
+			// An infra block is neither "stopped" (the user did nothing) nor "not
+			// verified" (the fix was never judged) — it is blocked ON THE USER,
+			// and the label says exactly what unblocks it.
+			text: infraBlocked
+				? infraBlocked.endLabel
+				: verified
+					? 'verified'
+					: aborted
+						? 'stopped'
+						: 'not verified',
 			ok: verified,
 			sessionId: owningSessionId,
 			episodeId,
@@ -2126,6 +2229,9 @@ export async function runEpisode(
 			episode_id: episodeId,
 			verified,
 			aborted,
+			// Non-null when the episode ended on a harness precondition failure
+			// (auth/quota/network) — infra, never composition evidence.
+			infra: infraBlocked?.kind ?? null,
 			// Whether this outcome trains the composition bandit (oracle verdict)
 			// or is excluded (human discretion / abort / no-oracle general task).
 			objective: objectiveOutcome,
@@ -2176,7 +2282,13 @@ export async function runEpisode(
 					ts: new Date().toISOString(),
 					text:
 						`episode "${task.title}" ` +
-						(verified ? 'verified' : aborted ? 'stopped' : 'not verified') +
+						(infraBlocked
+							? infraBlocked.endLabel
+							: verified
+								? 'verified'
+								: aborted
+									? 'stopped'
+									: 'not verified') +
 						` after ${attempts} attempt(s)`,
 				},
 				owningSessionId,

--- a/extension/src/harness/episodeTelemetry.ts
+++ b/extension/src/harness/episodeTelemetry.ts
@@ -629,7 +629,7 @@ export function selectEpisodeArm(policy: EpisodePolicy, rng: () => number = Math
 }
 
 export interface EpisodeEvent {
-	type: 'episode_start' | 'attempt' | 'acceptance' | 'candidate_defect' | 'mutation_smoke' | 'stall' | 'dispute' | 'revert' | 'episode_end' | 'reconciliation' | 'policy_invalidated' | 'policy_updated';
+	type: 'episode_start' | 'attempt' | 'acceptance' | 'candidate_defect' | 'mutation_smoke' | 'stall' | 'dispute' | 'revert' | 'infra_blocked' | 'episode_end' | 'reconciliation' | 'policy_invalidated' | 'policy_updated';
 	ts: string;
 	episode_id?: string;
 	[key: string]: unknown;

--- a/extension/src/harness/harnessRunner.ts
+++ b/extension/src/harness/harnessRunner.ts
@@ -51,6 +51,19 @@ export interface HarnessDef {
 	installCommand: string | null;
 	/** The step after installing (sign-in etc.), shown in the install guide. */
 	postInstall: string;
+	/**
+	 * The exact remediation shown when a run fails on authentication (CLI not
+	 * signed in / key invalid). One actionable sentence — it is the whole
+	 * notification body, so it must name the command to run.
+	 */
+	authRemediation?: string;
+	/**
+	 * Cheap auth-preflight probe: args (appended to the resolved executable)
+	 * whose non-zero exit with auth-classified output proves the CLI cannot
+	 * serve a dispatch. Only set where the vendor ships such a probe — a
+	 * `--version` that succeeds while logged out is NOT one.
+	 */
+	authProbeArgs?: string[];
 	/** ide-chat only: how the hand-off prompt reaches the panel. */
 	chat?: {
 		mechanism: 'chat-command' | 'deeplink' | 'clipboard';
@@ -101,6 +114,10 @@ export const HARNESSES: ReadonlyArray<HarnessDef> = [
 			? 'irm https://claude.ai/install.ps1 | iex'
 			: 'curl -fsSL https://claude.ai/install.sh | bash',
 		postInstall: 'Then run `claude` once in a terminal to sign in. Note: the Claude desktop app or IDE extension does not include this CLI.',
+		authRemediation:
+			'Run `claude` in a terminal and sign in with `/login` (or fix ANTHROPIC_API_KEY), then retry the episode.',
+		// No probe: `claude --version` succeeds while logged out, and there is no
+		// documented cheap status subcommand — the run itself classifies instead.
 	},
 	{
 		id: 'codex',
@@ -113,6 +130,10 @@ export const HARNESSES: ReadonlyArray<HarnessDef> = [
 		installHint: 'Install with `npm install -g @openai/codex` and run `codex` once to sign in.',
 		installCommand: 'npm install -g @openai/codex',
 		postInstall: 'Then run `codex` once in a terminal to sign in.',
+		authRemediation:
+			'Run `codex login` in a terminal (or fix OPENAI_API_KEY), then retry the episode.',
+		// `codex login status` exits non-zero with "Not logged in" when signed out.
+		authProbeArgs: ['login', 'status'],
 	},
 	{
 		id: 'cursor',
@@ -130,6 +151,11 @@ export const HARNESSES: ReadonlyArray<HarnessDef> = [
 			? "irm 'https://cursor.com/install?win32=true' | iex"
 			: 'curl https://cursor.com/install -fsS | bash',
 		postInstall: 'Then sign in with `agent login` (older installs: `cursor-agent login`).',
+		authRemediation:
+			'Run `cursor-agent login` (newer installs: `agent login`) in a terminal, then retry the episode.',
+		// `cursor-agent status` exits non-zero and prints the same
+		// "Authentication required" text as a dispatch when signed out.
+		authProbeArgs: ['status'],
 	},
 	{
 		id: 'gemini',
@@ -141,6 +167,9 @@ export const HARNESSES: ReadonlyArray<HarnessDef> = [
 		installHint: 'Install with `npm install -g @google/gemini-cli` and run `gemini` once to sign in.',
 		installCommand: 'npm install -g @google/gemini-cli',
 		postInstall: 'Then run `gemini` once in a terminal to sign in.',
+		authRemediation:
+			'Run `gemini` in a terminal and complete the Google sign-in (or fix GEMINI_API_KEY), then retry the episode.',
+		// No probe: the CLI has no documented cheap logged-out status command.
 	},
 	// IDE-chat hand-offs: the task goes to the editor's agent panel via the
 	// .vinv/handoff file protocol (see ideChat.ts). Copilot Chat's documented
@@ -203,6 +232,270 @@ export function isHarnessAutonomous(h: HarnessDef): boolean {
 
 export function getHarness(id: string): HarnessDef {
 	return HARNESSES.find((h) => h.id === id) ?? HARNESSES[0];
+}
+
+// ---- infrastructure-failure classification ---------------------------------
+//
+// A precondition failure (CLI not signed in, key invalid/expired, quota
+// exhausted, vendor unreachable) can never be fixed by retrying, mutating the
+// pack, or judging a stall — every consumer of a harness run must recognize it
+// on the FIRST occurrence and stop, surfacing the one remediation the human
+// actually needs ("run `cursor-agent login`"). The patterns are data, kept
+// here next to the HARNESSES catalog they describe.
+
+/** Classification of a failed harness run. Only 'other' is retryable. */
+export type HarnessFailureKind = 'auth' | 'quota' | 'network' | 'other';
+
+/** A HarnessFailureKind that terminates work (everything except 'other'). */
+export type HarnessInfraKind = Exclude<HarnessFailureKind, 'other'>;
+
+interface InfraPattern {
+	kind: HarnessInfraKind;
+	re: RegExp;
+	/**
+	 * Strong patterns are unambiguous error sentences and match regardless of
+	 * exit code. Weak patterns (bare env-var names, generic connectivity words)
+	 * only count on a non-zero exit — an agent legitimately answering "set
+	 * ANTHROPIC_API_KEY" must never classify its own success as an auth failure.
+	 */
+	strong: boolean;
+}
+
+/** Per-CLI (plus a few vendor-neutral) precondition-failure fingerprints. */
+const INFRA_PATTERNS: ReadonlyArray<InfraPattern> = [
+	// -- auth: cursor ----------------------------------------------------------
+	{ kind: 'auth', re: /authentication required/i, strong: true },
+	{ kind: 'auth', re: /cursor-agent login/i, strong: true },
+	{ kind: 'auth', re: /CURSOR_API_KEY/, strong: false },
+	// -- auth: claude ----------------------------------------------------------
+	{ kind: 'auth', re: /please run \/login/i, strong: true },
+	{ kind: 'auth', re: /OAuth token has expired/i, strong: true },
+	{ kind: 'auth', re: /invalid api key/i, strong: true },
+	{ kind: 'auth', re: /ANTHROPIC_API_KEY/, strong: false },
+	// -- auth: codex -----------------------------------------------------------
+	{ kind: 'auth', re: /not (?:currently )?logged in/i, strong: true },
+	{ kind: 'auth', re: /\bcodex login\b/i, strong: true },
+	{ kind: 'auth', re: /OPENAI_API_KEY/, strong: false },
+	// -- auth: gemini ----------------------------------------------------------
+	{ kind: 'auth', re: /api key not valid/i, strong: true },
+	{ kind: 'auth', re: /GEMINI_API_KEY|GOOGLE_API_KEY/, strong: false },
+	// -- auth: vendor-neutral --------------------------------------------------
+	{ kind: 'auth', re: /api key.{0,40}\b(?:expired|revoked|disabled)\b/i, strong: true },
+	{ kind: 'auth', re: /\bnot authenticated\b/i, strong: true },
+	{ kind: 'auth', re: /\b(?:401|403)\b.{0,40}\bunauthorized\b|\bunauthorized\b.{0,40}\b(?:401|403)\b/i, strong: true },
+	// -- quota -----------------------------------------------------------------
+	{ kind: 'quota', re: /credit balance is too low/i, strong: true }, // anthropic
+	{ kind: 'quota', re: /exceeded your current quota/i, strong: true }, // openai
+	{ kind: 'quota', re: /insufficient_quota/i, strong: true }, // openai error code
+	{ kind: 'quota', re: /RESOURCE_EXHAUSTED/, strong: true }, // google
+	{ kind: 'quota', re: /quota (?:has been )?(?:exhausted|exceeded)/i, strong: true },
+	{ kind: 'quota', re: /usage limit (?:reached|exceeded)/i, strong: true },
+	{ kind: 'quota', re: /out of (?:free )?credits/i, strong: true },
+	// -- network (vendor unreachable) ------------------------------------------
+	{ kind: 'network', re: /\b(?:ENOTFOUND|ECONNREFUSED|ECONNRESET|ETIMEDOUT|EAI_AGAIN|EHOSTUNREACH|ENETUNREACH)\b/, strong: true },
+	{ kind: 'network', re: /getaddrinfo/i, strong: true },
+	{ kind: 'network', re: /network is unreachable/i, strong: true },
+	{ kind: 'network', re: /\bfetch failed\b/i, strong: false },
+	{ kind: 'network', re: /(?:unable|could not|failed) to connect/i, strong: false },
+];
+
+/** Precedence when several kinds match at once: sign-in beats billing beats pipes. */
+const INFRA_PRECEDENCE: ReadonlyArray<HarnessInfraKind> = ['auth', 'quota', 'network'];
+
+/**
+ * Classifies one harness run's output as an infrastructure/precondition
+ * failure — 'auth' | 'quota' | 'network' — or 'other' (a normal, retryable
+ * failure). Pure; safe on any consumer of run output.
+ *
+ * Guards against false positives:
+ *  - a ZERO exit with substantial output is a real agent answer, never infra
+ *    (an agent explaining "set CURSOR_API_KEY" must not classify itself);
+ *  - weak patterns (bare env-var names, generic connect words) require a
+ *    non-zero exit; strong ones (exact vendor error sentences) do not, because
+ *    some CLIs print the auth refusal and still exit 0.
+ */
+export function classifyHarnessFailure(
+	output: string,
+	exitCode: number | null,
+): HarnessFailureKind {
+	const tail = output.slice(-4000);
+	if (!tail.trim()) {
+		return 'other';
+	}
+	// A clean exit that produced a real answer (not just an error line).
+	if (exitCode === 0 && output.length > 2000) {
+		return 'other';
+	}
+	const failed = exitCode !== 0; // null (killed / never ran) counts as failed
+	const matched = new Set<HarnessInfraKind>();
+	for (const p of INFRA_PATTERNS) {
+		if ((p.strong || failed) && p.re.test(tail)) {
+			matched.add(p.kind);
+		}
+	}
+	for (const kind of INFRA_PRECEDENCE) {
+		if (matched.has(kind)) {
+			return kind;
+		}
+	}
+	return 'other';
+}
+
+/** Short state label per kind — used for issue/Flow surfaces and end labels. */
+export const INFRA_BLOCK_LABELS: Readonly<Record<HarnessInfraKind, string>> = {
+	auth: 'blocked: agent CLI needs login',
+	quota: 'blocked: agent CLI quota exhausted',
+	network: 'blocked: agent CLI cannot reach its service',
+};
+
+/** The one actionable remediation sentence for a blocked harness. */
+export function harnessBlockRemediation(h: HarnessDef, kind: HarnessInfraKind): string {
+	if (kind === 'auth') {
+		return h.authRemediation ?? `Sign in to ${h.label} in a terminal, then retry the episode. ${h.postInstall}`;
+	}
+	if (kind === 'quota') {
+		return `${h.label} reports its usage quota or credits are exhausted — resolve billing or wait for the quota to reset, then retry the episode.`;
+	}
+	return `${h.label} could not reach its service — check your network/VPN/proxy, then retry the episode.`;
+}
+
+/** A harness currently known to be unable to run (precondition failure). */
+export interface HarnessBlock {
+	kind: HarnessInfraKind;
+	/** The remediation sentence shown to the user. */
+	remediation: string;
+}
+
+// Session-scoped blocked registry. A block means "do not burn attempts, tests,
+// or judges on this harness until the human acts" — it is NOT a permanent
+// verdict: a later dispatch re-probes (or simply re-runs) and a success clears
+// it, so re-dispatching the same issue after login proceeds fresh.
+const harnessBlocks = new Map<string, HarnessBlock>();
+// One notification per harness+kind per session — the remediation is the same
+// whichever issue tripped it; repeating it per issue is noise, not signal.
+const notifiedBlocks = new Set<string>();
+
+/** The current block for a harness, if any. */
+export function getHarnessBlock(harnessId: string): HarnessBlock | undefined {
+	return harnessBlocks.get(harnessId);
+}
+
+/** Clears a harness's block (a successful run or probe proves it works). */
+export function clearHarnessBlock(harnessId: string): void {
+	harnessBlocks.delete(harnessId);
+	preflightPassed.delete(harnessId); // a fresh dispatch re-establishes it
+}
+
+/**
+ * Records a precondition failure for a harness and surfaces the remediation —
+ * once per session per harness+kind, never per issue. Returns the block.
+ */
+export function markHarnessBlocked(
+	harnessId: string,
+	kind: HarnessInfraKind,
+	options?: { notify?: boolean },
+): HarnessBlock {
+	const harness = getHarness(harnessId);
+	const block: HarnessBlock = { kind, remediation: harnessBlockRemediation(harness, kind) };
+	harnessBlocks.set(harnessId, block);
+	preflightPassed.delete(harnessId);
+	const noteKey = `${harnessId}:${kind}`;
+	if ((options?.notify ?? true) && !notifiedBlocks.has(noteKey)) {
+		notifiedBlocks.add(noteKey);
+		void vscode.window.showErrorMessage(
+			`Vinv: ${harness.label} cannot run — ${INFRA_BLOCK_LABELS[kind].replace('blocked: ', '')}. ${block.remediation}`,
+		);
+	}
+	return block;
+}
+
+/** Test hook: wipes the session block/notification/preflight state. */
+export function resetHarnessBlockStateForTests(): void {
+	harnessBlocks.clear();
+	notifiedBlocks.clear();
+	preflightPassed.clear();
+}
+
+// Harness ids whose auth preflight passed this session — a passed probe is
+// cached (auth state rarely regresses mid-session); a FAILED probe is never
+// cached, so the first dispatch after the human logs in re-probes and proceeds.
+const preflightPassed = new Set<string>();
+
+/** Wall-clock cap for one auth probe — it must stay cheap. */
+const AUTH_PROBE_TIMEOUT_MS = 10_000;
+
+/**
+ * Cheap auth preflight for a harness: where the vendor ships a status probe
+ * (see authProbeArgs), run it BEFORE spending any dispatch/test/judge work.
+ * Resolves 'ok' when the harness can be dispatched (probe passed, no probe
+ * exists, CLI missing — the missing-CLI path has its own message) and the
+ * infra kind when the probe proves the precondition failure. A failed probe
+ * marks the session block (notifying once); a passed probe clears it.
+ */
+export async function preflightHarnessAuth(harnessId: string): Promise<'ok' | HarnessInfraKind> {
+	const harness = getHarness(harnessId);
+	if (harness.kind !== 'cli' || !harness.bin || !harness.authProbeArgs?.length) {
+		// No probe exists: never keep a stale block standing in the way of a
+		// fresh dispatch — the run itself re-classifies in one cheap failure.
+		harnessBlocks.delete(harnessId);
+		return 'ok';
+	}
+	if (preflightPassed.has(harnessId)) {
+		return 'ok';
+	}
+	const exe = resolveHarnessCli(harness);
+	if (!exe) {
+		return 'ok'; // missing CLI is handled by the existing install-hint paths
+	}
+	const probe = await new Promise<{ code: number | null; output: string }>((resolve) => {
+		let out = '';
+		let settled = false;
+		const settle = (code: number | null) => {
+			if (!settled) {
+				settled = true;
+				resolve({ code, output: out });
+			}
+		};
+		try {
+			const child = spawn(
+				`"${exe}" ${harness.authProbeArgs!.join(' ')}`,
+				hiddenBackgroundOptions({ shell: true, env: process.env }),
+			);
+			const timer = setTimeout(() => {
+				killProcessTree(child, 'SIGKILL');
+				settle(null);
+			}, AUTH_PROBE_TIMEOUT_MS);
+			const absorb = (c: string) => (out = (out + c).slice(-8000));
+			child.stdout?.setEncoding('utf8');
+			child.stdout?.on('data', absorb);
+			child.stderr?.setEncoding('utf8');
+			child.stderr?.on('data', absorb);
+			child.on('error', () => {
+				clearTimeout(timer);
+				settle(null);
+			});
+			child.on('close', (code) => {
+				clearTimeout(timer);
+				settle(code);
+			});
+		} catch {
+			settle(null);
+		}
+	});
+	if (probe.code !== 0) {
+		const kind = classifyHarnessFailure(probe.output, probe.code);
+		if (kind !== 'other') {
+			markHarnessBlocked(harnessId, kind);
+			return kind;
+		}
+		// Probe failed for an unrelated reason (unknown subcommand on an older
+		// CLI, timeout): inconclusive — let the dispatch itself decide.
+		harnessBlocks.delete(harnessId);
+		return 'ok';
+	}
+	preflightPassed.add(harnessId);
+	harnessBlocks.delete(harnessId);
+	return 'ok';
 }
 
 /**
@@ -511,6 +804,14 @@ export interface HarnessRunResult {
 	stdout: string;
 	/** Human-readable failure reason when ok is false. */
 	detail?: string;
+	/**
+	 * Set when the failure is an infrastructure PRECONDITION (CLI not signed
+	 * in, quota exhausted, vendor unreachable) that no retry, stall judge, or
+	 * pack mutation can fix. Consumers must treat it as terminal on the first
+	 * occurrence: end the work as infra-blocked (objective:false — never
+	 * composition-failure evidence) and surface `detail` (the remediation).
+	 */
+	infra?: HarnessInfraKind;
 }
 
 /**
@@ -546,6 +847,13 @@ export function dispatchAgentPrompt(
 ): Promise<string | null> {
 	const harness = getHarness(harnessId);
 	if (harness.kind !== 'cli' || !harness.bin) {
+		return Promise.resolve(null);
+	}
+	// A blocked harness (needs login / quota / network) cannot answer — resolve
+	// null immediately so verification agents degrade to their safe paths
+	// instead of fanning out N doomed spawns. The block is cleared by a later
+	// successful run or preflight, so this never outlives the precondition.
+	if (getHarnessBlock(harnessId)) {
 		return Promise.resolve(null);
 	}
 	const exe = resolveHarnessCli(harness);
@@ -633,10 +941,18 @@ export function dispatchAgentPrompt(
 			clearTimeout(timer);
 			settle(null);
 		});
-		child.on('exit', () => {
+		child.on('exit', (code) => {
 			clearTimeout(timer);
 			if (pending) {
 				decode(pending);
+			}
+			// One doomed spawn is enough: classify precondition failures here so
+			// the session block short-circuits every sibling agent immediately.
+			const infra = classifyHarnessFailure(out, code);
+			if (infra !== 'other') {
+				markHarnessBlocked(harnessId, infra);
+				settle(null);
+				return;
 			}
 			const answer =
 				harness.stream === 'claude-stream-json'
@@ -695,6 +1011,23 @@ export async function runHarnessPrompt(
 			stdout: '',
 			detail: `The ${harness.label} CLI ('${harness.bin}') was not found. ${harness.installHint}`,
 		};
+	}
+	// Known-blocked harness (auth/quota/network precondition): re-probe cheaply
+	// instead of burning a dispatch. Failed probes are never cached, so the
+	// first dispatch after the human logs in re-probes, passes, and proceeds
+	// fresh — blocked is a state, not a dedup.
+	if (getHarnessBlock(harnessId)) {
+		await preflightHarnessAuth(harnessId);
+		const block = getHarnessBlock(harnessId);
+		if (block) {
+			return {
+				ok: false,
+				exitCode: null,
+				stdout: '',
+				detail: block.remediation,
+				infra: block.kind,
+			};
+		}
 	}
 	const commandLine = `"${exe}" ${harness.args}`;
 	const childEnv: NodeJS.ProcessEnv = {
@@ -926,6 +1259,22 @@ export async function runHarnessPrompt(
 			flush();
 			if (options?.token?.isCancellationRequested) {
 				settle({ ok: false, exitCode: code, stdout: answerText(), detail: 'cancelled' });
+				return;
+			}
+			// Precondition failures (not signed in, quota, vendor unreachable)
+			// classify from the RAW channel output — some CLIs print the refusal
+			// and still exit 0, and a stream-json refusal is a bare error line.
+			// Terminal for every consumer; the detail is the remediation.
+			const infra = classifyHarnessFailure(out, code);
+			if (infra !== 'other') {
+				const block = markHarnessBlocked(harnessId, infra);
+				settle({
+					ok: false,
+					exitCode: code,
+					stdout: answerText(),
+					detail: block.remediation,
+					infra,
+				});
 			} else if (code !== 0) {
 				settle({
 					ok: false,
@@ -934,6 +1283,10 @@ export async function runHarnessPrompt(
 					detail: lastLine || `exited with code ${code ?? 'null'}`,
 				});
 			} else {
+				// A genuine success proves the precondition holds again.
+				if (getHarnessBlock(harnessId)) {
+					clearHarnessBlock(harnessId);
+				}
 				settle({ ok: true, exitCode: 0, stdout: answerText() });
 			}
 		});
@@ -983,6 +1336,12 @@ async function runHarnessTask(
 			void vscode.window.showErrorMessage(
 				`Vinv: The ${harness.label} CLI ('${harness.bin}') was not found on this machine. ${harness.installHint}`,
 			);
+			return false;
+		}
+		// Auth preflight: a signed-out CLI can never produce the deliverable —
+		// skip the dispatch entirely (markHarnessBlocked already surfaced the
+		// remediation once this session).
+		if ((await preflightHarnessAuth(harnessId)) !== 'ok') {
 			return false;
 		}
 	}
@@ -1084,9 +1443,13 @@ async function runHarnessTask(
 
 					let chunks = 0;
 					let lastLine = '';
+					// Classification ring: the last 4000 chars of raw output, so a
+					// precondition refusal (auth/quota/network) is recognized on close.
+					let tailRing = '';
 					const onData = (chunk: string) => {
 						log?.write(chunk);
 						chunks += 1;
+						tailRing = (tailRing + chunk).slice(-4000);
 						const line = chunk.trim().split('\n').pop() ?? '';
 						if (line) {
 							// Status label only — marked when clipped, never silently.
@@ -1122,7 +1485,17 @@ async function runHarnessTask(
 					child.on('close', (code) => {
 						if (token.isCancellationRequested || extToken?.isCancellationRequested) {
 							settle(false);
-						} else if (code !== 0) {
+							return;
+						}
+						// Precondition refusal: terminal, with the remediation as the
+						// failure detail (markHarnessBlocked notifies once per session).
+						const infra = classifyHarnessFailure(tailRing, code);
+						if (infra !== 'other') {
+							const block = markHarnessBlocked(harnessId, infra);
+							settle(false, block.remediation);
+							return;
+						}
+						if (code !== 0) {
 							settle(
 								false,
 								lastLine ||

--- a/extension/src/test/harnessInfra.test.ts
+++ b/extension/src/test/harnessInfra.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Infrastructure/precondition failure handling for harness runs — the "CLI is
+ * not logged in" class of defect that must terminate work on the FIRST
+ * occurrence instead of burning attempts, stall judges, and fix budgets.
+ *
+ * Covers:
+ *   - classifyHarnessFailure: per-CLI auth/quota/network fingerprints, the
+ *     weak-vs-strong pattern rule, and the false-positive guards;
+ *   - the session block registry (mark/get/clear) and preflightHarnessAuth
+ *     semantics (failed probes never cached → re-dispatch after login
+ *     proceeds fresh);
+ *   - gateAttemptRun, the episode loop's seam: an infra-classified run is
+ *     terminal after ONE attempt — no verification, stall-judge, dispute, or
+ *     escalation machinery may engage, and the outcome is objective:false;
+ *   - runHarnessPrompt end-to-end against a fake signed-out CLI (real spawn,
+ *     real classification, block set) and after "login" (block cleared);
+ *   - markBlockedOnHarness: an Auto-Pilot blocked dispatch consumes NO setup
+ *     attempts and NO fix-episode budget.
+ */
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+	classifyHarnessFailure,
+	clearHarnessBlock,
+	dispatchAgentPrompt,
+	getHarness,
+	getHarnessBlock,
+	harnessBlockRemediation,
+	INFRA_BLOCK_LABELS,
+	markHarnessBlocked,
+	preflightHarnessAuth,
+	resetHarnessBlockStateForTests,
+	runHarnessPrompt,
+} from '../harness/harnessRunner';
+import { gateAttemptRun } from '../harness/episodeLoop';
+import {
+	decideOnFailure,
+	DEFAULT_BUDGETS,
+	markBlockedOnHarness,
+	summarize,
+	type ServiceState,
+} from '../harness/autoPilotMachine';
+
+const CURSOR_AUTH_ERROR =
+	'Error: Authentication required. Please run cursor-agent login first, or set CURSOR_API_KEY environment variable';
+
+suite('classifyHarnessFailure: auth patterns per CLI', () => {
+	test('cursor: the live-defect output classifies as auth on exit 1', () => {
+		assert.strictEqual(classifyHarnessFailure(CURSOR_AUTH_ERROR, 1), 'auth');
+	});
+
+	test('cursor: the same refusal on exit 0 (short output) is still auth', () => {
+		// Some CLIs print the refusal and exit 0 — a strong pattern must not
+		// depend on the exit code.
+		assert.strictEqual(classifyHarnessFailure(CURSOR_AUTH_ERROR, 0), 'auth');
+	});
+
+	test('claude: /login, expired OAuth, and invalid key all classify as auth', () => {
+		assert.strictEqual(classifyHarnessFailure('Please run /login', 1), 'auth');
+		assert.strictEqual(
+			classifyHarnessFailure('OAuth token has expired. Please obtain a new token.', 1),
+			'auth',
+		);
+		assert.strictEqual(classifyHarnessFailure('API Error: Invalid API key', 1), 'auth');
+	});
+
+	test('claude: a bare ANTHROPIC_API_KEY mention is weak — needs a failing exit', () => {
+		assert.strictEqual(classifyHarnessFailure('set the ANTHROPIC_API_KEY env var', 1), 'auth');
+		// The same words in a SUCCESSFUL run are an agent's answer, not a failure.
+		assert.strictEqual(classifyHarnessFailure('set the ANTHROPIC_API_KEY env var', 0), 'other');
+	});
+
+	test('codex: not-logged-in and codex login classify as auth', () => {
+		assert.strictEqual(
+			classifyHarnessFailure('Not logged in. Run codex login to authenticate.', 1),
+			'auth',
+		);
+	});
+
+	test('gemini: invalid API key classifies as auth', () => {
+		assert.strictEqual(
+			classifyHarnessFailure('[400] API key not valid. Please pass a valid API key.', 1),
+			'auth',
+		);
+	});
+});
+
+suite('classifyHarnessFailure: quota and network', () => {
+	test('vendor quota messages classify as quota', () => {
+		assert.strictEqual(
+			classifyHarnessFailure('Your credit balance is too low to access the API.', 1),
+			'quota',
+		); // anthropic
+		assert.strictEqual(
+			classifyHarnessFailure('You exceeded your current quota, please check your plan.', 1),
+			'quota',
+		); // openai
+		assert.strictEqual(classifyHarnessFailure('error code: insufficient_quota', 1), 'quota');
+		assert.strictEqual(classifyHarnessFailure('429 RESOURCE_EXHAUSTED', 1), 'quota'); // google
+		assert.strictEqual(classifyHarnessFailure('usage limit reached — upgrade to continue', 1), 'quota');
+	});
+
+	test('unreachable-vendor errors classify as network', () => {
+		assert.strictEqual(
+			classifyHarnessFailure('getaddrinfo ENOTFOUND api.anthropic.com', 1),
+			'network',
+		);
+		assert.strictEqual(classifyHarnessFailure('connect ECONNREFUSED 104.18.0.1:443', 1), 'network');
+		assert.strictEqual(classifyHarnessFailure('TypeError: fetch failed', 1), 'network');
+		// Weak network words on a clean exit are not a failure at all.
+		assert.strictEqual(classifyHarnessFailure('the app logged: fetch failed once', 0), 'other');
+	});
+
+	test('auth outranks network when both appear', () => {
+		assert.strictEqual(
+			classifyHarnessFailure('fetch failed after: Authentication required', 1),
+			'auth',
+		);
+	});
+});
+
+suite('classifyHarnessFailure: false-positive guards', () => {
+	test('an ordinary failing run stays other', () => {
+		assert.strictEqual(classifyHarnessFailure('Error: 3 tests failed\nexit 1', 1), 'other');
+		assert.strictEqual(classifyHarnessFailure('', 1), 'other');
+		assert.strictEqual(classifyHarnessFailure('build succeeded', 0), 'other');
+	});
+
+	test('a long successful answer that MENTIONS a login command is not infra', () => {
+		// An agent explaining harness auth to the user must never classify its
+		// own success as an auth failure.
+		const answer = `${'The auth flow works like this. '.repeat(100)}\nIf signed out, run cursor-agent login.`;
+		assert.ok(answer.length > 2000);
+		assert.strictEqual(classifyHarnessFailure(answer, 0), 'other');
+	});
+});
+
+suite('harness block registry + preflight', () => {
+	setup(() => resetHarnessBlockStateForTests());
+	teardown(() => resetHarnessBlockStateForTests());
+
+	test('mark → get → clear round-trips, with the remediation attached', () => {
+		assert.strictEqual(getHarnessBlock('cursor'), undefined);
+		const block = markHarnessBlocked('cursor', 'auth', { notify: false });
+		assert.strictEqual(block.kind, 'auth');
+		assert.ok(block.remediation.includes('cursor-agent login'));
+		assert.deepStrictEqual(getHarnessBlock('cursor'), block);
+		clearHarnessBlock('cursor');
+		assert.strictEqual(getHarnessBlock('cursor'), undefined);
+	});
+
+	test('remediation names the exact command per harness', () => {
+		assert.ok(harnessBlockRemediation(getHarness('cursor'), 'auth').includes('cursor-agent login'));
+		assert.ok(harnessBlockRemediation(getHarness('claude-code'), 'auth').includes('/login'));
+		assert.ok(harnessBlockRemediation(getHarness('codex'), 'auth').includes('codex login'));
+		assert.ok(/quota|credits/i.test(harnessBlockRemediation(getHarness('cursor'), 'quota')));
+		assert.ok(/network|reach/i.test(harnessBlockRemediation(getHarness('cursor'), 'network')));
+	});
+
+	test('a probe-less harness never keeps a stale block standing (re-dispatch proceeds)', async () => {
+		markHarnessBlocked('claude-code', 'auth', { notify: false });
+		// claude-code has no cheap auth probe: preflight must not permanently
+		// bury the harness — it clears the block and lets the dispatch itself
+		// re-classify in one cheap failure.
+		assert.strictEqual(await preflightHarnessAuth('claude-code'), 'ok');
+		assert.strictEqual(getHarnessBlock('claude-code'), undefined);
+	});
+
+	test('a blocked harness makes dispatchAgentPrompt degrade to null without spawning', async () => {
+		markHarnessBlocked('cursor', 'auth', { notify: false });
+		const t0 = Date.now();
+		const reply = await dispatchAgentPrompt('cursor', os.tmpdir(), 'infra-test', 'hello');
+		assert.strictEqual(reply, null);
+		assert.ok(Date.now() - t0 < 1000, 'must short-circuit, not spawn a doomed CLI');
+	});
+});
+
+suite('gateAttemptRun: the episode terminal seam', () => {
+	const cursor = getHarness('cursor');
+
+	test('an auth-failing run is terminal after ONE attempt — no verify/stall/judge', () => {
+		const stop = gateAttemptRun(
+			{ ok: false, infra: 'auth', detail: 'Run `cursor-agent login` …' },
+			cursor,
+		);
+		assert.ok(stop, 'infra runs must stop the episode');
+		assert.strictEqual(stop.kind, 'auth');
+		// The Flow/issue surface shows blocked-on-you, not "agent working".
+		assert.strictEqual(stop.endLabel, 'blocked: agent CLI needs login');
+		assert.ok(stop.remediation.includes('cursor-agent login'));
+	});
+
+	test('quota and network map to their own blocked labels', () => {
+		assert.strictEqual(
+			gateAttemptRun({ ok: false, infra: 'quota' }, cursor)?.endLabel,
+			'blocked: agent CLI quota exhausted',
+		);
+		assert.strictEqual(
+			gateAttemptRun({ ok: false, infra: 'network' }, cursor)?.endLabel,
+			'blocked: agent CLI cannot reach its service',
+		);
+		assert.deepStrictEqual(Object.keys(INFRA_BLOCK_LABELS).sort(), ['auth', 'network', 'quota']);
+	});
+
+	test('ordinary outcomes pass through to the normal verification machinery', () => {
+		assert.strictEqual(gateAttemptRun({ ok: true }, cursor), null);
+		assert.strictEqual(
+			gateAttemptRun({ ok: false, detail: 'exited with code 2' }, cursor),
+			null,
+		);
+	});
+
+	test('missing detail falls back to the catalog remediation', () => {
+		const stop = gateAttemptRun({ ok: false, infra: 'auth' }, cursor);
+		assert.ok(stop?.remediation.includes('cursor-agent login'));
+	});
+});
+
+suite('runHarnessPrompt: fake signed-out CLI (integration)', function () {
+	// Real spawns through the real dispatch path — allow generous time.
+	this.timeout(20_000);
+
+	let binDir = '';
+	let workspace = '';
+	let savedPath: string | undefined;
+	const fake = () => path.join(binDir, 'cursor-agent');
+
+	/** Installs a fake `cursor-agent` shell script first on PATH. */
+	function installFake(script: string): void {
+		fs.writeFileSync(fake(), `#!/bin/sh\n${script}\n`, { mode: 0o755 });
+	}
+
+	suiteSetup(function () {
+		if (process.platform === 'win32') {
+			this.skip();
+		}
+		binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vinv-fake-cli-'));
+		workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'vinv-infra-ws-'));
+		savedPath = process.env.PATH;
+		process.env.PATH = `${binDir}${path.delimiter}${process.env.PATH ?? ''}`;
+	});
+
+	suiteTeardown(() => {
+		if (savedPath !== undefined) {
+			process.env.PATH = savedPath;
+		}
+		resetHarnessBlockStateForTests();
+		fs.rmSync(binDir, { recursive: true, force: true });
+		fs.rmSync(workspace, { recursive: true, force: true });
+	});
+
+	setup(() => resetHarnessBlockStateForTests());
+
+	test('a signed-out dispatch classifies auth, carries the remediation, and blocks the session', async () => {
+		installFake(`cat >/dev/null\necho "${CURSOR_AUTH_ERROR}" >&2\nexit 1`);
+		const run = await runHarnessPrompt('cursor', workspace, 'infra-auth', 'fix the bug');
+		assert.strictEqual(run.ok, false);
+		assert.strictEqual(run.infra, 'auth');
+		assert.ok(run.detail?.includes('cursor-agent login'), `detail was: ${run.detail}`);
+		assert.strictEqual(getHarnessBlock('cursor')?.kind, 'auth');
+		// The episode loop's gate turns exactly this result into a terminal
+		// infra stop BEFORE any verification/stall machinery — one attempt.
+		const stop = gateAttemptRun(run, getHarness('cursor'));
+		assert.strictEqual(stop?.endLabel, 'blocked: agent CLI needs login');
+	});
+
+	test('preflight probe (`cursor-agent status`) fails closed, then passes after login', async () => {
+		installFake(`echo "${CURSOR_AUTH_ERROR}" >&2\nexit 1`);
+		assert.strictEqual(await preflightHarnessAuth('cursor'), 'auth');
+		assert.strictEqual(getHarnessBlock('cursor')?.kind, 'auth');
+		// Failed probes are never cached: the next dispatch attempt re-probes.
+		assert.strictEqual(await preflightHarnessAuth('cursor'), 'auth');
+		// "Login": the same probe now succeeds — the block clears and the same
+		// signature can dispatch fresh (blocked ≠ dispatched).
+		installFake('echo "Logged in as tester"\nexit 0');
+		assert.strictEqual(await preflightHarnessAuth('cursor'), 'ok');
+		assert.strictEqual(getHarnessBlock('cursor'), undefined);
+	});
+
+	test('re-dispatch after login proceeds fresh and a success clears the block', async () => {
+		// First: signed out — dispatch fails and blocks.
+		installFake(`cat >/dev/null\necho "${CURSOR_AUTH_ERROR}" >&2\nexit 1`);
+		const blocked = await runHarnessPrompt('cursor', workspace, 'infra-relogin', 'fix it');
+		assert.strictEqual(blocked.infra, 'auth');
+		assert.ok(getHarnessBlock('cursor'));
+		// Then: the human logs in (fake now handles both `status` and a run).
+		installFake('if [ "$1" = "status" ]; then echo ok; exit 0; fi\ncat >/dev/null\necho "done: applied the fix"\nexit 0');
+		const rerun = await runHarnessPrompt('cursor', workspace, 'infra-relogin', 'fix it');
+		assert.strictEqual(rerun.ok, true, `detail: ${rerun.detail}`);
+		assert.strictEqual(rerun.infra, undefined);
+		assert.ok(rerun.stdout.includes('applied the fix'));
+		assert.strictEqual(getHarnessBlock('cursor'), undefined);
+	});
+});
+
+suite('autoPilotMachine: blocked dispatch consumes no budgets', () => {
+	const svc = (): ServiceState => ({
+		name: 'api',
+		phase: 'needs-setup',
+		setupAttempts: 2,
+		fixEpisodes: { 'setup:something': 1 },
+	});
+
+	test('markBlockedOnHarness is terminal but spends nothing', () => {
+		const before = svc();
+		const blocked = markBlockedOnHarness(before, 'Cursor CLI needs login — run `cursor-agent login`');
+		assert.strictEqual(blocked.phase, 'gave-up');
+		assert.ok(blocked.reason?.startsWith('blocked on you:'));
+		assert.ok(blocked.reason?.includes('cursor-agent login'));
+		// The whole point: no setup attempt and no fix episode was consumed —
+		// the next run (after login) starts with the budgets intact.
+		assert.strictEqual(blocked.setupAttempts, before.setupAttempts);
+		assert.deepStrictEqual(blocked.fixEpisodes, before.fixEpisodes);
+	});
+
+	test('contrast: the normal failure path DOES spend a fix episode', () => {
+		const { state } = decideOnFailure(svc(), 'setup', 'setup:new-sig', DEFAULT_BUDGETS);
+		assert.strictEqual(state.fixEpisodes['setup:new-sig'], 1);
+	});
+
+	test('a blocked service surfaces in the gave-up summary bucket (blocked-on-you)', () => {
+		const { gaveUp } = summarize([markBlockedOnHarness(svc(), 'needs login')]);
+		assert.strictEqual(gaveUp.length, 1);
+		assert.ok(gaveUp[0].reason?.includes('blocked on you'));
+	});
+});


### PR DESCRIPTION
…fra — end after one attempt with the exact remediation

A signed-out coding-agent CLI (the live defect: Cursor printing "Authentication required. Please run cursor-agent login first") used to be treated like a fix that failed verification: the episode re-composed and re-dispatched, the stall judge negotiated over two identical refusals, and the run escalated to a judgment card — burning the attempt budget on a precondition no retry can satisfy, while the UI said "agent working".

Now every consumer of harness run output recognizes precondition failures on the FIRST occurrence and stops:

- classifyHarnessFailure(output, exitCode) in harnessRunner: pure, data-driven per-CLI fingerprints (cursor/claude/codex/gemini + vendor-neutral) kept next to the HARNESSES catalog, → 'auth' | 'quota' | 'network' | 'other'. Strong patterns (exact vendor refusal sentences) match regardless of exit code; weak ones (bare env-var names, generic connect words) require a failing exit, and a clean exit with a substantial answer is never infra — an agent explaining "set CURSOR_API_KEY" must not classify its own success.
- Session block registry: an infra failure marks the harness blocked with the one actionable remediation ("Run `cursor-agent login` in a terminal, then retry the episode."), notified once per session per harness — not per issue. Blocked is a state, not a dedup: failed preflights are never cached, a successful run or probe clears the block, so re-dispatching the same issue after login proceeds fresh.
- Cheap auth preflight (authProbeArgs: `cursor-agent status`, `codex login status`) runs before the first dispatch of a session per harness — in runEpisode (before acceptance tests and judges spend anything), runHarnessTask (handbook/bring-up/Auto-Pilot setup), and the auto-trigger auto-dispatch paths — skipping the dispatch entirely when it fails closed.
- Episode loop: gateAttemptRun sits between the harness run and ALL verification machinery — an infra run ends the episode after ONE attempt with no verify/stall-judge/dispute/escalation, surfaces "blocked: agent CLI needs login" (per-kind labels) in the chat/session transcript, and logs episode_end with objective:false plus a new infra field, so the composition bandit never trains on infrastructure.
- Auto-Pilot: blocked dispatches consume NO setup attempts and NO fix-episode budgets (markBlockedOnHarness), the service is reported blocked-on-you, and no fix episode is dispatched to an unauthenticated CLI.
- Auto-triggers/insights: a blocked dispatch is never recorded as dispatched (dispatchIssueEpisode reports not-handed-off; the red-ring signature is un-recorded), so the same failure picture re-arms after login.
- Verification agents (dispatchAgentPrompt) short-circuit to their safe null paths while blocked, and the first doomed spawn marks the block for its siblings; one-shot QnA/chat runs fail once with the remediation as detail.

25 new tests (313 passing): per-CLI classification incl. false-positive guards, block registry + preflight cache semantics, the episode terminal seam, an end-to-end fake signed-out CLI through runHarnessPrompt with re-dispatch-after-login, and the Auto-Pilot budget-preservation contract.