### PR TITLE
fix(webview): no webview button can fail silently — resolve, verify, …

### DIFF
--- a/extension/src/harness/episodeLoop.ts
+++ b/extension/src/harness/episodeLoop.ts
@@ -108,6 +108,7 @@ import {
 } from '../config/settings';
 import { dispatchAgentPrompt, getHarness, isHarnessBusy, runHarnessPrompt } from './harnessRunner';
 import { VINV_BASE_CSS } from '../views/webviewTheme';
+import { openPathInEditor } from '../support/openDocument';
 import {
 	isAskVinvOpen,
 	postEpisodeUpdate,
@@ -589,11 +590,9 @@ async function presentJudgment(j: ParkedJudgment): Promise<void> {
 				// Same courtesy as the dialog: show the brief before the next attempt.
 				// Not for an answer follow-up — that is a conversation, not a re-brief,
 				// and yanking a markdown file into the editor mid-question is noise.
-				try {
-					await vscode.window.showTextDocument(vscode.Uri.file(j.packPath), { preview: false });
-				} catch {
-					// Pack unopenable — the card still carried the evidence.
-				}
+				// openPathInEditor verifies + reports a missing pack rather than
+				// swallowing the failure; the retry proceeds regardless.
+				await openPathInEditor(j.packPath, { label: 'context pack', preview: false });
 			}
 			j.resolve(verdict);
 			return;
@@ -668,6 +667,67 @@ function escapeHtml(s: string): string {
 		.replace(/</g, '&lt;')
 		.replace(/>/g, '&gt;')
 		.replace(/"/g, '&quot;');
+}
+
+/** A message the judgment card posts back to the extension. */
+export interface JudgmentMessage {
+	type: string;
+	action?: string;
+	note?: string;
+	selectedProposals?: string[];
+	message?: unknown;
+	stack?: unknown;
+}
+
+/**
+ * Side effects a judgment-card message can trigger, injected so the routing is
+ * testable without a live webview. `openPack` opens the episode's context pack
+ * and — crucially — surfaces an actionable error when it cannot (missing/moved
+ * pack), replacing the empty catch that made "view context pack" a silent no-op.
+ */
+export interface JudgmentActions {
+	openPack: () => Promise<void>;
+	settle: (result: EscalationResult) => void;
+}
+
+/**
+ * Routes one judgment-card message. Extracted from the inline
+ * onDidReceiveMessage closure so the wiring is unit-tested directly. Both the
+ * "view context pack" button and "reject & retry" open the pack through
+ * `openPack`; a retry settles regardless of whether the pack opened, but the
+ * user is told when it didn't rather than left with a dead button.
+ */
+export async function handleJudgmentMessage(
+	m: JudgmentMessage,
+	actions: JudgmentActions,
+): Promise<void> {
+	if (m.type === 'webviewError') {
+		return;
+	}
+	if (m.type === 'openPack') {
+		// Inspection only — the dialog stays up, no verdict implied.
+		await actions.openPack();
+		return;
+	}
+	if (m.type !== 'verdict') {
+		return;
+	}
+	if (m.action === 'retry') {
+		// Show the pack so the user can inspect/edit before the next attempt.
+		await actions.openPack();
+		actions.settle({
+			action: 'retry',
+			note: m.note?.trim() || undefined,
+			selectedProposals: m.selectedProposals?.length ? m.selectedProposals : undefined,
+		});
+		return;
+	}
+	if (m.action === 'approve' || m.action === 'abort' || m.action === 'revert') {
+		actions.settle({
+			action: m.action,
+			selectedProposals: m.selectedProposals?.length ? m.selectedProposals : undefined,
+		});
+	}
 }
 
 /**
@@ -825,55 +885,20 @@ ${VINV_BASE_CSS}
 				panel.dispose();
 			}
 		};
-		panel.webview.onDidReceiveMessage(
-			async (m: {
-				type: string;
-				action?: string;
-				note?: string;
-				selectedProposals?: string[];
-				message?: unknown;
-				stack?: unknown;
-			}) => {
-				if (m.type === 'webviewError') {
-					return;
-				}
-				if (m.type === 'openPack' && packPath) {
-					// Inspection only — the dialog stays up, no verdict implied.
-					try {
-						await vscode.window.showTextDocument(vscode.Uri.file(packPath), {
-							preview: false,
-							viewColumn: vscode.ViewColumn.Beside,
-						});
-					} catch {
-						// Pack unopenable — the dialog still shows the evidence text.
-					}
-					return;
-				}
-				if (m.type !== 'verdict') {
-					return;
-				}
-				if (m.action === 'retry') {
-					// Show the pack so the user can inspect/edit before the next attempt.
-					try {
-						await vscode.window.showTextDocument(vscode.Uri.file(packPath), { preview: false });
-					} catch {
-						// Pack unopenable — continue regardless.
-					}
-					settle({
-						action: 'retry',
-						note: m.note?.trim() || undefined,
-						selectedProposals: m.selectedProposals?.length ? m.selectedProposals : undefined,
-					});
-					return;
-				}
-				if (m.action === 'approve' || m.action === 'abort' || m.action === 'revert') {
-					settle({
-						action: m.action,
-						selectedProposals: m.selectedProposals?.length ? m.selectedProposals : undefined,
-					});
-				}
+		const actions: JudgmentActions = {
+			// Absolute pack path from writeContextPack; the opener still resolves +
+			// verifies and, if the pack was moved/deleted, shows "context pack not
+			// found at <path>" instead of the old silent no-op.
+			openPack: async () => {
+				await openPathInEditor(packPath, {
+					label: 'context pack',
+					preview: false,
+					viewColumn: vscode.ViewColumn.Beside,
+				});
 			},
-		);
+			settle,
+		};
+		panel.webview.onDidReceiveMessage((m: JudgmentMessage) => handleJudgmentMessage(m, actions));
 		// Closed without a verdict (tab closed, editor reload): park it. The
 		// episode stays suspended on the operator rather than being aborted by
 		// an accident of window management.

--- a/extension/src/identification/callTreeView.ts
+++ b/extension/src/identification/callTreeView.ts
@@ -8,6 +8,7 @@ import { generateSmokeReport } from '../tracelens/report';
 import { openSmokeReport } from './smokeReportView';
 import { offerEpisodeForRuntimeErrors } from '../harness/autoTrigger';
 import { backingFilePath, buildCallSiteContext } from './callSiteContext';
+import { openPathInEditor } from '../support/openDocument';
 
 /** How often the runtime trace overlay is refreshed while the panel is open. */
 const TRACEMAP_POLL_MS = 1000;
@@ -22,12 +23,43 @@ const SMOKE_REPORT_SUPPORTED = process.platform !== 'win32';
 export const CALLTREE_VIEW_TYPE = 'vinv.callTree';
 
 /** Messages the call-tree webview sends back to the extension. */
-interface OutboundMessage {
+export interface OutboundMessage {
 	type: 'openSource' | 'runSmokeReport' | 'ask';
 	file?: string;
 	line?: number;
 	/** Symbol name — sent with 'ask' so the node can be located in the tree. */
 	name?: string;
+}
+
+/**
+ * Side effects a call-tree message can trigger, injected so the routing is
+ * testable without a live webview. Production binds these to the real closures
+ * in `openCallTree`; tests pass fakes and assert the exact call.
+ */
+export interface CallTreeActions {
+	openSource: (file: string | undefined, line?: number) => Promise<void>;
+	ask: (file?: string, name?: string) => Promise<void>;
+	runSmokeReport: () => Promise<void>;
+	smokeReportSupported: boolean;
+}
+
+/**
+ * Routes one call-tree webview message to its side effect. Extracted from the
+ * inline onDidReceiveMessage closure so the wiring is unit-tested directly.
+ * openSource resolves to absolute, verifies existence, and reports an actionable
+ * error on failure (via the injected opener) rather than a silent no-op.
+ */
+export async function handleCallTreeMessage(
+	msg: OutboundMessage,
+	actions: CallTreeActions,
+): Promise<void> {
+	if (msg.type === 'openSource') {
+		await actions.openSource(msg.file, msg.line);
+	} else if (msg.type === 'ask') {
+		await actions.ask(msg.file, msg.name);
+	} else if (msg.type === 'runSmokeReport' && actions.smokeReportSupported) {
+		await actions.runSmokeReport();
+	}
 }
 
 /** Recovers the workspace root from a backing file at <root>/.vinv/reports/<f>. */
@@ -148,33 +180,38 @@ function wireCallTree(
 	let disposed = false;
 	let polling = false;
 
-	const msgSub = webview.onDidReceiveMessage(async (msg: OutboundMessage) => {
-		const raw = msg as { type?: string; message?: unknown; stack?: unknown };
-		if (raw.type === 'webviewError') {
-			return;
-		}
-		if (msg.type === 'openSource' && msg.file) {
-			const abs = path.isAbsolute(msg.file) ? msg.file : path.join(workspaceRoot, msg.file);
-			const pos = new vscode.Position(Math.max(0, (msg.line ?? 1) - 1), 0);
-			await vscode.window.showTextDocument(vscode.Uri.file(abs), {
-				selection: new vscode.Range(pos, pos),
+	const actions: CallTreeActions = {
+		openSource: async (file, line) => {
+			await openPathInEditor(file, {
+				workspaceRoot,
+				line: line ?? 1,
+				label: 'source file',
 				preview: true,
 				viewColumn: vscode.ViewColumn.Beside,
 			});
-		} else if (msg.type === 'ask') {
+		},
+		ask: async (file, name) => {
 			// Resolve the clicked node against the snapshot this view just wrote,
 			// so the question carries the entry-point→symbol path and its
 			// endpoint-scoped runtime — not just "some symbol". Resolution is
 			// best-effort: an unresolvable node still opens the panel, unseeded.
 			let callSite;
 			try {
-				callSite = buildCallSiteContext(workspaceRoot, apiId, { file: msg.file, name: msg.name });
-			} catch (e) {
+				callSite = buildCallSiteContext(workspaceRoot, apiId, { file, name });
+			} catch {
+				// Node unresolved — open Ask Vinv unseeded rather than dropping the click.
 			}
 			await vscode.commands.executeCommand('vinv-vs.askVinv', { callSite });
-		} else if (msg.type === 'runSmokeReport' && SMOKE_REPORT_SUPPORTED) {
-			await runSmokeReport(context, workspaceRoot, apiId, label);
+		},
+		runSmokeReport: async () => runSmokeReport(context, workspaceRoot, apiId, label),
+		smokeReportSupported: SMOKE_REPORT_SUPPORTED,
+	};
+	const msgSub = webview.onDidReceiveMessage((msg: OutboundMessage) => {
+		const raw = msg as { type?: string; message?: unknown; stack?: unknown };
+		if (raw.type === 'webviewError') {
+			return;
 		}
+		return handleCallTreeMessage(msg, actions);
 	});
 
 	// 1) Static call tree first — fast, no trace needed.

--- a/extension/src/support/openDocument.ts
+++ b/extension/src/support/openDocument.ts
@@ -1,0 +1,120 @@
+/**
+ * Opening a file that a webview button asked for, safely.
+ *
+ * Every judgment card, flow rail, graph node and call-tree row can post a path
+ * back to the extension and expect the editor to open it. Historically each
+ * handler did `showTextDocument(Uri.file(p))` inside a try with an EMPTY catch:
+ * when the path was relative, missing, or moved, the click became a silent
+ * no-op — the exact live defect users hit ("view context pack does nothing").
+ *
+ * This module is the single choke point for those opens. It (a) resolves the
+ * path to ABSOLUTE against the workspace root, (b) verifies the file exists, and
+ * (c) on ANY failure raises an actionable `showErrorMessage` naming the file and
+ * the reason — never an empty catch. `resolveOpenTarget` is pure (no vscode) so
+ * the resolution/existence contract is unit-testable in isolation.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+/** Result of resolving a webview-supplied path to an absolute, existing file. */
+export interface ResolvedTarget {
+	ok: boolean;
+	/** Absolute path, present iff `ok`. */
+	absPath?: string;
+	/** User-facing message, present iff `!ok`. */
+	error?: string;
+}
+
+/**
+ * Pure resolution + existence check. No vscode, no I/O beyond the injectable
+ * `exists` probe, so tests can drive every branch deterministically.
+ *
+ * @param rawPath  what the webview posted (may be absolute, relative, or empty)
+ * @param workspaceRoot  absolute root used to anchor a relative path
+ * @param label  noun for the error message, e.g. "context pack"
+ * @param exists  existence probe (defaults to fs.existsSync)
+ */
+export function resolveOpenTarget(
+	rawPath: string | undefined,
+	workspaceRoot: string | undefined,
+	label = 'file',
+	exists: (p: string) => boolean = fs.existsSync,
+): ResolvedTarget {
+	if (!rawPath || !rawPath.trim()) {
+		return { ok: false, error: `Vinv: no ${label} path was provided to open.` };
+	}
+	let abs = rawPath;
+	if (!path.isAbsolute(abs)) {
+		if (!workspaceRoot) {
+			return {
+				ok: false,
+				error: `Vinv: cannot open ${label} "${rawPath}" — path is relative and no workspace is open.`,
+			};
+		}
+		abs = path.join(workspaceRoot, abs);
+	}
+	if (!exists(abs)) {
+		return { ok: false, error: `Vinv: ${label} not found at ${abs}` };
+	}
+	return { ok: true, absPath: abs };
+}
+
+/** How to open a resolved file. */
+export interface OpenInEditorOptions {
+	/** Anchors a relative path; omit when the path is already absolute. */
+	workspaceRoot?: string;
+	/** 1-based line to reveal/select. */
+	line?: number;
+	/** Passed to showTextDocument; defaults to false (a real, kept tab). */
+	preview?: boolean;
+	viewColumn?: vscode.ViewColumn;
+	/** Noun for any error message, e.g. "context pack". */
+	label?: string;
+	/**
+	 * Open through the registered default editor (`vscode.open`) instead of the
+	 * text editor — needed for custom viewers (call-tree JSON, smoke HTML).
+	 * `line` is ignored in this mode.
+	 */
+	useDefaultEditor?: boolean;
+}
+
+/**
+ * Resolve, verify, and open a webview-supplied path. Returns true on success;
+ * on ANY failure it shows an actionable error and returns false — the caller
+ * never has to (and must never) swallow the outcome silently.
+ */
+export async function openPathInEditor(
+	rawPath: string | undefined,
+	opts: OpenInEditorOptions = {},
+): Promise<boolean> {
+	const label = opts.label ?? 'file';
+	const resolved = resolveOpenTarget(rawPath, opts.workspaceRoot, label);
+	if (!resolved.ok || !resolved.absPath) {
+		void vscode.window.showErrorMessage(resolved.error ?? `Vinv: could not open ${label}.`);
+		return false;
+	}
+	const uri = vscode.Uri.file(resolved.absPath);
+	try {
+		if (opts.useDefaultEditor) {
+			await vscode.commands.executeCommand('vscode.open', uri);
+		} else {
+			const showOpts: vscode.TextDocumentShowOptions = {
+				preview: opts.preview ?? false,
+				viewColumn: opts.viewColumn,
+			};
+			if (opts.line && opts.line > 0) {
+				const pos = new vscode.Position(Math.max(0, opts.line - 1), 0);
+				showOpts.selection = new vscode.Range(pos, pos);
+			}
+			await vscode.window.showTextDocument(uri, showOpts);
+		}
+		return true;
+	} catch (e) {
+		const reason = e instanceof Error ? e.message : String(e);
+		void vscode.window.showErrorMessage(
+			`Vinv: could not open ${label} at ${resolved.absPath} — ${reason}`,
+		);
+		return false;
+	}
+}

--- a/extension/src/test/webviewWiring.test.ts
+++ b/extension/src/test/webviewWiring.test.ts
@@ -1,0 +1,494 @@
+/**
+ * Webview button wiring.
+ *
+ * The live defect this guards: a webview button ("view context pack", and the
+ * rest) whose extension-side handler opened a file inside a try with an EMPTY
+ * catch — so a missing/relative/moved path made the click a silent no-op. Every
+ * panel's onDidReceiveMessage routing is now an extracted, exported function; we
+ * drive each with (a) a valid payload and assert the right side effect, and
+ * (b) a broken payload and assert a user-facing error is raised, NOT a silent
+ * no-op. The shared path-resolution contract (resolve→absolute→verify→error) is
+ * pinned directly on resolveOpenTarget/openPathInEditor.
+ */
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { resolveOpenTarget, openPathInEditor } from '../support/openDocument';
+import { handleFlowMessage, type FlowActions, type OutboundMessage } from '../views/flowPanel';
+import {
+	handleGraphMessage,
+	type GraphActions,
+	type OutboundMessage as GraphMessage,
+} from '../views/graphExplorer';
+import { handleCallTreeMessage, type CallTreeActions } from '../identification/callTreeView';
+import { handleJudgmentMessage, type JudgmentActions } from '../harness/episodeLoop';
+import { handleAskVinvAction, dispatchAskVinvFix, type AskVinvActions } from '../views/askVinv';
+
+/** A temp workspace root holding one real file, torn down after the suite. */
+function makeWorkspace(): { root: string; existing: string; cleanup: () => void } {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'vinv-wire-'));
+	const dir = path.join(root, '.vinv', 'context');
+	fs.mkdirSync(dir, { recursive: true });
+	const existing = path.join(dir, 'pack-1.md');
+	fs.writeFileSync(existing, '# pack\n', 'utf8');
+	return { root, existing, cleanup: () => fs.rmSync(root, { recursive: true, force: true }) };
+}
+
+/**
+ * A fake file opener that mirrors production: it runs the REAL resolution
+ * (resolveOpenTarget) so a valid path records an absolute open and a broken one
+ * records the actionable error — exactly the not-silent behaviour under test.
+ */
+function makeOpener(root: string | undefined, label: string) {
+	const opened: string[] = [];
+	const errors: string[] = [];
+	const open = async (file?: string): Promise<void> => {
+		const r = resolveOpenTarget(file, root, label);
+		if (r.ok && r.absPath) {
+			opened.push(r.absPath);
+		} else {
+			errors.push(r.error ?? 'unknown');
+		}
+	};
+	return { open, opened, errors };
+}
+
+suite('Webview button wiring', () => {
+	// ---- shared path-resolution contract (every panel inherits it) ----------
+	suite('resolveOpenTarget', () => {
+		test('an absolute, existing path resolves', () => {
+			const ws = makeWorkspace();
+			try {
+				const r = resolveOpenTarget(ws.existing, ws.root, 'context pack');
+				assert.strictEqual(r.ok, true);
+				assert.strictEqual(r.absPath, ws.existing);
+			} finally {
+				ws.cleanup();
+			}
+		});
+
+		test('a missing file is an actionable error naming the path — never silent', () => {
+			const ws = makeWorkspace();
+			try {
+				const gone = path.join(ws.root, '.vinv', 'context', 'pack-gone.md');
+				const r = resolveOpenTarget(gone, ws.root, 'context pack');
+				assert.strictEqual(r.ok, false);
+				assert.match(r.error ?? '', /context pack not found at/);
+				assert.ok((r.error ?? '').includes(gone));
+			} finally {
+				ws.cleanup();
+			}
+		});
+
+		test('a relative path is resolved against the workspace root', () => {
+			const ws = makeWorkspace();
+			try {
+				const r = resolveOpenTarget('.vinv/context/pack-1.md', ws.root, 'context pack');
+				assert.strictEqual(r.ok, true);
+				assert.strictEqual(r.absPath, ws.existing);
+			} finally {
+				ws.cleanup();
+			}
+		});
+
+		test('a relative path with no workspace root errors instead of guessing', () => {
+			const r = resolveOpenTarget('pack.md', undefined, 'context pack');
+			assert.strictEqual(r.ok, false);
+			assert.match(r.error ?? '', /relative and no workspace/);
+		});
+
+		test('an empty/undefined path errors', () => {
+			assert.strictEqual(resolveOpenTarget(undefined, '/root', 'file').ok, false);
+			assert.strictEqual(resolveOpenTarget('   ', '/root', 'file').ok, false);
+		});
+	});
+
+	suite('openPathInEditor', () => {
+		test('opens a real file and reports success', async () => {
+			const ws = makeWorkspace();
+			try {
+				const ok = await openPathInEditor(ws.existing, { label: 'context pack' });
+				assert.strictEqual(ok, true);
+			} finally {
+				ws.cleanup();
+			}
+		});
+
+		test('a missing file returns false and shows an error — not a silent no-op', async () => {
+			const ws = makeWorkspace();
+			const orig = vscode.window.showErrorMessage;
+			let shown = '';
+			(vscode.window as unknown as { showErrorMessage: (m: string) => Promise<undefined> }).showErrorMessage = (m: string) => {
+				shown = m;
+				return Promise.resolve(undefined);
+			};
+			try {
+				const gone = path.join(ws.root, 'nope.md');
+				const ok = await openPathInEditor(gone, { label: 'context pack' });
+				assert.strictEqual(ok, false);
+				assert.match(shown, /context pack not found at/);
+			} finally {
+				(vscode.window as unknown as { showErrorMessage: typeof orig }).showErrorMessage = orig;
+				ws.cleanup();
+			}
+		});
+	});
+
+	// ---- judgment card (episodeLoop): the reported defect --------------------
+	suite('judgment card', () => {
+		function actions(root: string, packPath: string) {
+			const packOpener = makeOpener(root, 'context pack');
+			const settled: { action: string; note?: string }[] = [];
+			const acts: JudgmentActions = {
+				openPack: () => packOpener.open(packPath),
+				settle: (r) => settled.push(r),
+			};
+			return { acts, opened: packOpener.opened, errors: packOpener.errors, settled };
+		}
+
+		test('"view context pack" opens the pack (valid path)', async () => {
+			const ws = makeWorkspace();
+			try {
+				const a = actions(ws.root, ws.existing);
+				await handleJudgmentMessage({ type: 'openPack' }, a.acts);
+				assert.deepStrictEqual(a.opened, [ws.existing]);
+				assert.strictEqual(a.settled.length, 0, 'inspection implies no verdict');
+			} finally {
+				ws.cleanup();
+			}
+		});
+
+		test('"view context pack" with a missing pack raises an error, not a silent no-op', async () => {
+			const ws = makeWorkspace();
+			try {
+				const a = actions(ws.root, path.join(ws.root, 'gone.md'));
+				await handleJudgmentMessage({ type: 'openPack' }, a.acts);
+				assert.strictEqual(a.opened.length, 0);
+				assert.strictEqual(a.errors.length, 1);
+				assert.match(a.errors[0], /context pack not found/);
+			} finally {
+				ws.cleanup();
+			}
+		});
+
+		test('"reject & retry" opens the pack AND settles retry', async () => {
+			const ws = makeWorkspace();
+			try {
+				const a = actions(ws.root, ws.existing);
+				await handleJudgmentMessage({ type: 'verdict', action: 'retry', note: '  do X  ' }, a.acts);
+				assert.deepStrictEqual(a.opened, [ws.existing]);
+				assert.strictEqual(a.settled.length, 1);
+				assert.strictEqual(a.settled[0].action, 'retry');
+				assert.strictEqual(a.settled[0].note, 'do X');
+			} finally {
+				ws.cleanup();
+			}
+		});
+
+		test('retry with a missing pack still settles (proceeds) but surfaces the error', async () => {
+			const ws = makeWorkspace();
+			try {
+				const a = actions(ws.root, path.join(ws.root, 'gone.md'));
+				await handleJudgmentMessage({ type: 'verdict', action: 'retry' }, a.acts);
+				assert.strictEqual(a.errors.length, 1, 'user is told the pack was missing');
+				assert.strictEqual(a.settled.length, 1, 'retry proceeds regardless');
+				assert.strictEqual(a.settled[0].action, 'retry');
+			} finally {
+				ws.cleanup();
+			}
+		});
+
+		test('approve settles without opening the pack', async () => {
+			const ws = makeWorkspace();
+			try {
+				const a = actions(ws.root, ws.existing);
+				await handleJudgmentMessage({ type: 'verdict', action: 'approve' }, a.acts);
+				assert.strictEqual(a.opened.length, 0);
+				assert.strictEqual(a.settled[0].action, 'approve');
+			} finally {
+				ws.cleanup();
+			}
+		});
+
+		test('a webviewError message is inert', async () => {
+			const ws = makeWorkspace();
+			try {
+				const a = actions(ws.root, ws.existing);
+				await handleJudgmentMessage({ type: 'webviewError', message: 'x' }, a.acts);
+				assert.strictEqual(a.opened.length, 0);
+				assert.strictEqual(a.settled.length, 0);
+			} finally {
+				ws.cleanup();
+			}
+		});
+	});
+
+	// ---- Ask Vinv ------------------------------------------------------------
+	suite('Ask Vinv', () => {
+		function actions(root: string) {
+			const src = makeOpener(root, 'source file');
+			const pack = makeOpener(undefined, 'context pack');
+			const commands: { command: string; args: unknown[] }[] = [];
+			const shownErrors: string[] = [];
+			const acts: AskVinvActions = {
+				openSource: (file) => src.open(file),
+				openPack: (file) => pack.open(file),
+				runCommand: async (command, ...args) => {
+					commands.push({ command, args });
+				},
+				showError: (m) => shownErrors.push(m),
+			};
+			return { acts, src, pack, commands, shownErrors };
+		}
+
+		test('openSource opens a valid file (handled)', async () => {
+			const ws = makeWorkspace();
+			try {
+				const a = actions(ws.root);
+				const handled = await handleAskVinvAction(
+					{ type: 'openSource', file: ws.existing } as never,
+					a.acts,
+				);
+				assert.strictEqual(handled, true);
+				assert.deepStrictEqual(a.src.opened, [ws.existing]);
+			} finally {
+				ws.cleanup();
+			}
+		});
+
+		test('openSource with a missing file raises an error, not a silent no-op', async () => {
+			const ws = makeWorkspace();
+			try {
+				const a = actions(ws.root);
+				const handled = await handleAskVinvAction(
+					{ type: 'openSource', file: 'src/gone.ts' } as never,
+					a.acts,
+				);
+				assert.strictEqual(handled, true, 'the click was consumed');
+				assert.strictEqual(a.src.opened.length, 0);
+				assert.strictEqual(a.src.errors.length, 1);
+			} finally {
+				ws.cleanup();
+			}
+		});
+
+		test('viewPack opens a valid pack; a missing pack errors', async () => {
+			const ws = makeWorkspace();
+			try {
+				const a = actions(ws.root);
+				await handleAskVinvAction({ type: 'viewPack', file: ws.existing } as never, a.acts);
+				assert.deepStrictEqual(a.pack.opened, [ws.existing]);
+
+				const b = actions(ws.root);
+				await handleAskVinvAction({ type: 'viewPack', file: '/nope/pack.md' } as never, b.acts);
+				assert.strictEqual(b.pack.opened.length, 0);
+				assert.strictEqual(b.pack.errors.length, 1);
+			} finally {
+				ws.cleanup();
+			}
+		});
+
+		test('disputeStart dispatches the registered command', async () => {
+			const a = actions('/root');
+			await handleAskVinvAction({ type: 'disputeStart', episodeId: 'e7' } as never, a.acts);
+			assert.strictEqual(a.commands[0].command, 'vinv-vs.disputeVerified');
+			assert.deepStrictEqual(a.commands[0].args, ['e7']);
+		});
+
+		test('a stateful message (ask) is not consumed here', async () => {
+			const a = actions('/root');
+			const handled = await handleAskVinvAction({ type: 'ask', question: 'hi' } as never, a.acts);
+			assert.strictEqual(handled, false);
+		});
+
+		test('dispatchAskVinvFix routes a real issue to fixWithHarness', async () => {
+			const a = actions('/root');
+			await dispatchAskVinvFix(a.acts, '  POST /orders 500  ', [3, 7]);
+			assert.strictEqual(a.commands[0].command, 'vinv-vs.fixWithHarness');
+			assert.deepStrictEqual(a.commands[0].args[0], { issue: 'POST /orders 500', rows: [3, 7] });
+		});
+
+		test('dispatchAskVinvFix on an empty issue errors instead of firing a blank episode', async () => {
+			const a = actions('/root');
+			await dispatchAskVinvFix(a.acts, '   ', []);
+			assert.strictEqual(a.commands.length, 0);
+			assert.strictEqual(a.shownErrors.length, 1);
+		});
+	});
+
+	// ---- Flow rail -----------------------------------------------------------
+	suite('Flow rail', () => {
+		function actions(root: string) {
+			const files = makeOpener(root, 'file');
+			const links: unknown[] = [];
+			const commands: { command: string; args: unknown[] }[] = [];
+			const shownErrors: string[] = [];
+			const acts: FlowActions = {
+				openLink: async (link) => void links.push(link),
+				openFileAt: (p) => files.open(p),
+				runCommand: async (command, ...args) => void commands.push({ command, args }),
+				showError: (m) => shownErrors.push(m),
+			};
+			return { acts, files, links, commands, shownErrors };
+		}
+		const msg = (m: Partial<OutboundMessage>) => m as OutboundMessage;
+
+		test('fix with an issue dispatches fixWithHarness', async () => {
+			const a = actions('/root');
+			await handleFlowMessage(msg({ type: 'fix', fixArgs: { issue: 'boom', service: 'api' } }), a.acts);
+			assert.strictEqual(a.commands[0].command, 'vinv-vs.fixWithHarness');
+			assert.deepStrictEqual(a.commands[0].args[0], { issue: 'boom', service: 'api' });
+		});
+
+		test('fix with no issue errors instead of doing nothing', async () => {
+			const a = actions('/root');
+			await handleFlowMessage(msg({ type: 'fix', fixArgs: { issue: '' } }), a.acts);
+			assert.strictEqual(a.commands.length, 0);
+			assert.strictEqual(a.shownErrors.length, 1);
+		});
+
+		test('evidence opens a valid file; a missing one errors (not silent)', async () => {
+			const ws = makeWorkspace();
+			try {
+				const a = actions(ws.root);
+				await handleFlowMessage(msg({ type: 'evidence', path: ws.existing }), a.acts);
+				assert.deepStrictEqual(a.files.opened, [ws.existing]);
+
+				const b = actions(ws.root);
+				await handleFlowMessage(msg({ type: 'evidence', path: undefined }), b.acts);
+				assert.strictEqual(b.files.opened.length, 0);
+				assert.strictEqual(b.files.errors.length, 1);
+			} finally {
+				ws.cleanup();
+			}
+		});
+
+		test('link with a target runs; a targetless link errors', async () => {
+			const a = actions('/root');
+			await handleFlowMessage(msg({ type: 'link', link: { label: 'x', command: 'foo' } }), a.acts);
+			assert.strictEqual(a.links.length, 1);
+
+			const b = actions('/root');
+			await handleFlowMessage(msg({ type: 'link' }), b.acts);
+			assert.strictEqual(b.links.length, 0);
+			assert.strictEqual(b.shownErrors.length, 1);
+		});
+
+		test('action with a command runs; a command-less action errors', async () => {
+			const a = actions('/root');
+			await handleFlowMessage(msg({ type: 'action', command: 'vinv-vs.showTrajectory', args: [1] }), a.acts);
+			assert.strictEqual(a.commands[0].command, 'vinv-vs.showTrajectory');
+			assert.deepStrictEqual(a.commands[0].args, [1]);
+
+			const b = actions('/root');
+			await handleFlowMessage(msg({ type: 'action' }), b.acts);
+			assert.strictEqual(b.commands.length, 0);
+			assert.strictEqual(b.shownErrors.length, 1);
+		});
+	});
+
+	// ---- Graph explorer ------------------------------------------------------
+	suite('Graph explorer', () => {
+		function actions(root: string) {
+			const src = makeOpener(root, 'source file');
+			const calls: string[] = [];
+			const acts: GraphActions = {
+				openSource: (file, line) => {
+					void line;
+					return src.open(file);
+				},
+				refresh: () => calls.push('refresh'),
+				semanticSearch: async (q) => void calls.push(`search:${q}`),
+				ask: async (row) => void calls.push(`ask:${row}`),
+				harness: async (row, issue) => void calls.push(`harness:${row}:${issue}`),
+				trace: async (row, file) => void calls.push(`trace:${row}:${file}`),
+				trajectory: async () => void calls.push('trajectory'),
+			};
+			return { acts, src, calls };
+		}
+		const gmsg = (m: Partial<GraphMessage>) => m as GraphMessage;
+
+		test('openSource opens a valid node file; a missing one errors', async () => {
+			const ws = makeWorkspace();
+			try {
+				const a = actions(ws.root);
+				await handleGraphMessage(gmsg({ type: 'openSource', file: ws.existing, line: 2 }), a.acts);
+				assert.deepStrictEqual(a.src.opened, [ws.existing]);
+
+				const b = actions(ws.root);
+				await handleGraphMessage(gmsg({ type: 'openSource', file: 'x/gone.ts' }), b.acts);
+				assert.strictEqual(b.src.opened.length, 0);
+				assert.strictEqual(b.src.errors.length, 1);
+			} finally {
+				ws.cleanup();
+			}
+		});
+
+		test('ask/harness/trace/trajectory/refresh/search route to their actions', async () => {
+			const a = actions('/root');
+			await handleGraphMessage(gmsg({ type: 'ask', row: 5 }), a.acts);
+			await handleGraphMessage(gmsg({ type: 'harness', row: 5, issue: 'q' }), a.acts);
+			await handleGraphMessage(gmsg({ type: 'trace', row: 5, file: 'f.ts' }), a.acts);
+			await handleGraphMessage(gmsg({ type: 'trajectory' }), a.acts);
+			await handleGraphMessage(gmsg({ type: 'refresh' }), a.acts);
+			await handleGraphMessage(gmsg({ type: 'semanticSearch', query: 'auth' }), a.acts);
+			assert.deepStrictEqual(a.calls, [
+				'ask:5',
+				'harness:5:q',
+				'trace:5:f.ts',
+				'trajectory',
+				'refresh',
+				'search:auth',
+			]);
+		});
+	});
+
+	// ---- Call-tree view ------------------------------------------------------
+	suite('Call-tree view', () => {
+		function actions(root: string, smokeReportSupported = true) {
+			const src = makeOpener(root, 'source file');
+			const calls: string[] = [];
+			const acts: CallTreeActions = {
+				openSource: (file) => src.open(file),
+				ask: async (file, name) => void calls.push(`ask:${file}:${name}`),
+				runSmokeReport: async () => void calls.push('smoke'),
+				smokeReportSupported,
+			};
+			return { acts, src, calls };
+		}
+
+		test('openSource opens a valid file; a missing one errors', async () => {
+			const ws = makeWorkspace();
+			try {
+				const a = actions(ws.root);
+				await handleCallTreeMessage({ type: 'openSource', file: ws.existing }, a.acts);
+				assert.deepStrictEqual(a.src.opened, [ws.existing]);
+
+				const b = actions(ws.root);
+				await handleCallTreeMessage({ type: 'openSource', file: 'gone.ts' }, b.acts);
+				assert.strictEqual(b.src.opened.length, 0);
+				assert.strictEqual(b.src.errors.length, 1);
+			} finally {
+				ws.cleanup();
+			}
+		});
+
+		test('ask routes to askVinv seeding', async () => {
+			const a = actions('/root');
+			await handleCallTreeMessage({ type: 'ask', file: 'f.ts', name: 'handler' }, a.acts);
+			assert.deepStrictEqual(a.calls, ['ask:f.ts:handler']);
+		});
+
+		test('runSmokeReport runs when supported and is skipped when not', async () => {
+			const a = actions('/root', true);
+			await handleCallTreeMessage({ type: 'runSmokeReport' }, a.acts);
+			assert.deepStrictEqual(a.calls, ['smoke']);
+
+			const b = actions('/root', false);
+			await handleCallTreeMessage({ type: 'runSmokeReport' }, b.acts);
+			assert.deepStrictEqual(b.calls, []);
+		});
+	});
+});

--- a/extension/src/views/askVinv.ts
+++ b/extension/src/views/askVinv.ts
@@ -8,8 +8,8 @@
  * bandit ledger as explicit rewards.
  */
 import * as vscode from 'vscode';
-import * as path from 'path';
 import { VINV_BASE_CSS, VINV_FONT_SERIF } from './webviewTheme';
+import { openPathInEditor } from '../support/openDocument';
 import { buildGraphSnapshot, hasIndexStore } from '../graph/indexGraph';
 import {
 	buildQnaPrompt,
@@ -124,6 +124,64 @@ interface AskMessage {
 	note?: string;
 	/** Proposals ticked on an answer-mode card, queued as their own episodes. */
 	selectedProposals?: string[];
+}
+
+/**
+ * Side effects the "pure action" Ask Vinv messages trigger, injected so the
+ * routing is testable without a live webview. Production binds these to the real
+ * vscode surfaces; tests pass fakes and assert the exact call.
+ */
+export interface AskVinvActions {
+	openSource: (file: string | undefined, line?: number) => Promise<void>;
+	openPack: (file: string | undefined) => Promise<void>;
+	runCommand: (command: string, ...args: unknown[]) => Promise<void>;
+	showError: (message: string) => void;
+}
+
+/**
+ * Routes the stateless "open something / run a command" Ask Vinv messages,
+ * extracted from the big inline switch so the wiring is unit-tested directly.
+ * Returns true when it handled the message (the caller then returns early);
+ * false leaves the stateful cases (ask, dispatch, feedback, …) to the switch.
+ * openSource/viewPack go through the shared opener, which resolves to absolute,
+ * verifies existence, and reports a missing file instead of a silent no-op.
+ */
+export async function handleAskVinvAction(
+	msg: AskMessage,
+	actions: AskVinvActions,
+): Promise<boolean> {
+	switch (msg.type) {
+		case 'openSource':
+			await actions.openSource(msg.file, msg.line);
+			return true;
+		case 'viewPack':
+			await actions.openPack(msg.file);
+			return true;
+		case 'disputeStart':
+			// Inline "still wrong?" affordance — carries the clicked block's episode id.
+			await actions.runCommand('vinv-vs.disputeVerified', msg.episodeId);
+			return true;
+		default:
+			return false;
+	}
+}
+
+/**
+ * Dispatches a harness fix from Ask Vinv. Extracted + guarded so an empty issue
+ * reports an error rather than firing a blank episode; a real issue routes to
+ * the (registered, arg-tolerant) fixWithHarness command with its seed rows.
+ */
+export async function dispatchAskVinvFix(
+	actions: Pick<AskVinvActions, 'runCommand' | 'showError'>,
+	issue: string,
+	rows: number[],
+): Promise<void> {
+	const trimmed = issue.trim();
+	if (!trimmed) {
+		actions.showError('Vinv: cannot dispatch a fix — the question was empty.');
+		return;
+	}
+	await actions.runCommand('vinv-vs.fixWithHarness', { issue: trimmed, rows });
 }
 
 /** The operator's answer to an escalation raised inside the chat transcript. */
@@ -339,12 +397,36 @@ export function openAskVinv(
 		pendingRetractionConfirm = undefined;
 	});
 
+	const askActions: AskVinvActions = {
+		openSource: async (file, line) => {
+			await openPathInEditor(file, {
+				workspaceRoot,
+				line: line ?? 1,
+				label: 'source file',
+				preview: true,
+				viewColumn: vscode.ViewColumn.One,
+			});
+		},
+		openPack: async (file) => {
+			await openPathInEditor(file, { label: 'context pack', preview: false });
+		},
+		runCommand: async (command, ...args) => {
+			await vscode.commands.executeCommand(command, ...args);
+		},
+		showError: (message) => void vscode.window.showErrorMessage(message),
+	};
+
 	panel.webview.onDidReceiveMessage(async (msg: AskMessage) => {
 		if (!panel) {
 			return;
 		}
 		const raw = msg as { type?: string; message?: unknown; stack?: unknown };
 		if (raw.type === 'webviewError') {
+			return;
+		}
+		// Stateless open/command messages route through the extracted, tested
+		// handler; the switch below owns the stateful ones.
+		if (await handleAskVinvAction(msg, askActions)) {
 			return;
 		}
 		switch (msg.type) {
@@ -369,19 +451,8 @@ export function openAskVinv(
 				postModeLabel();
 				return;
 			}
-			case 'openSource': {
-				if (!msg.file) {
-					return;
-				}
-				const abs = path.isAbsolute(msg.file) ? msg.file : path.join(workspaceRoot, msg.file);
-				const pos = new vscode.Position(Math.max(0, (msg.line ?? 1) - 1), 0);
-				await vscode.window.showTextDocument(vscode.Uri.file(abs), {
-					selection: new vscode.Range(pos, pos),
-					preview: true,
-					viewColumn: vscode.ViewColumn.One,
-				});
-				return;
-			}
+			// 'openSource', 'viewPack' and 'disputeStart' are handled by
+			// handleAskVinvAction above (extracted + tested).
 			case 'feedback':
 				if (msg.decisionId && typeof msg.reward === 'number') {
 					recordQnaFeedback(workspaceRoot, msg.decisionId, msg.reward);
@@ -434,12 +505,6 @@ export function openAskVinv(
 				settle?.(choice);
 				return;
 			}
-			case 'disputeStart':
-				// Inline "still wrong?" affordance on a verified episode-end block —
-				// carries that block's episode id so the dispute targets what was
-				// clicked, not whatever verified most recently.
-				void vscode.commands.executeCommand('vinv-vs.disputeVerified', msg.episodeId);
-				return;
 			case 'episodeVerdict':
 				if (msg.action && pendingVerdict) {
 					const settle = pendingVerdict.resolve;
@@ -449,15 +514,6 @@ export function openAskVinv(
 						note: msg.note?.trim() || undefined,
 						selectedProposals: msg.selectedProposals?.length ? msg.selectedProposals : undefined,
 					});
-				}
-				return;
-			case 'viewPack':
-				if (msg.file) {
-					try {
-						await vscode.window.showTextDocument(vscode.Uri.file(msg.file), { preview: false });
-					} catch {
-						// Pack unopenable — the card still carries the evidence text.
-					}
 				}
 				return;
 			case 'dispatch':
@@ -522,10 +578,9 @@ export function openAskVinv(
 				// An unchanged goal is a no-op inside setGoal, so this cannot
 				// silently reset episodes_used on a plain confirm.
 				setGoal(workspaceRoot, (msg.note ?? '').trim());
-				await vscode.commands.executeCommand('vinv-vs.fixWithHarness', {
-					issue: pending.question,
-					rows: pending.rows,
-				});
+				// Guarded, tested dispatch: an empty question reports why instead of
+				// firing a blank episode.
+				await dispatchAskVinvFix(askActions, pending.question, pending.rows);
 				return;
 			}
 			case 'dispatchCancel':

--- a/extension/src/views/flowPanel.ts
+++ b/extension/src/views/flowPanel.ts
@@ -17,13 +17,14 @@ import * as vscode from 'vscode';
 import * as crypto from 'crypto';
 import * as path from 'path';
 import { VINV_BASE_CSS, VINV_FONT_SERIF } from './webviewTheme';
+import { openPathInEditor, resolveOpenTarget } from '../support/openDocument';
 import type { FlowStateSource } from './flowStateSource';
 import type { FlowLink, FlowModel } from './flowModel';
 
 export const FLOW_VIEW_ID = 'vinv.flow';
 
 /** Messages the Flow webview sends back to the extension. */
-interface OutboundMessage {
+export interface OutboundMessage {
 	type: 'link' | 'fix' | 'evidence' | 'action';
 	link?: FlowLink;
 	fixArgs?: { issue: string; service?: string; row?: number };
@@ -31,6 +32,57 @@ interface OutboundMessage {
 	line?: number;
 	command?: string;
 	args?: unknown[];
+}
+
+/**
+ * Side effects a Flow message can trigger, injected so the routing is testable
+ * without a live webview. Production wires these to the real vscode surfaces
+ * (see `resolveWebviewView`); tests pass fakes and assert the exact call.
+ */
+export interface FlowActions {
+	openLink: (link: FlowLink) => Promise<void>;
+	openFileAt: (fsPath: string | undefined, line?: number) => Promise<void>;
+	runCommand: (command: string, ...args: unknown[]) => Promise<void>;
+	showError: (message: string) => void;
+}
+
+/**
+ * Routes one Flow webview message to its side effect. Extracted from the inline
+ * onDidReceiveMessage closure so the wiring is unit-tested directly. Every arm
+ * guards its payload and reports an actionable error rather than a silent
+ * no-op — a malformed `fix`/`action` message tells the user why nothing opened.
+ */
+export async function handleFlowMessage(
+	msg: OutboundMessage,
+	actions: FlowActions,
+): Promise<void> {
+	switch (msg.type) {
+		case 'link':
+			if (msg.link) {
+				await actions.openLink(msg.link);
+			} else {
+				actions.showError('Vinv: this link is missing its target.');
+			}
+			return;
+		case 'fix':
+			if (msg.fixArgs?.issue) {
+				await actions.runCommand('vinv-vs.fixWithHarness', msg.fixArgs);
+			} else {
+				actions.showError('Vinv: cannot start a fix — no issue was attached to this action.');
+			}
+			return;
+		case 'evidence':
+			// openFileAt itself reports missing/relative/unreadable paths.
+			await actions.openFileAt(msg.path, msg.line);
+			return;
+		case 'action':
+			if (msg.command) {
+				await actions.runCommand(msg.command, ...(msg.args ?? []));
+			} else {
+				actions.showError('Vinv: this action has no command to run.');
+			}
+			return;
+	}
 }
 
 export class FlowViewProvider implements vscode.WebviewViewProvider {
@@ -57,30 +109,19 @@ export class FlowViewProvider implements vscode.WebviewViewProvider {
 		});
 		post(this.source.getModel());
 
-		view.webview.onDidReceiveMessage(async (msg: OutboundMessage) => {
-			switch (msg.type) {
-				case 'link':
-					if (msg.link) {
-						await openLink(msg.link);
-					}
-					return;
-				case 'fix':
-					if (msg.fixArgs) {
-						await vscode.commands.executeCommand('vinv-vs.fixWithHarness', msg.fixArgs);
-					}
-					return;
-				case 'evidence':
-					if (msg.path) {
-						await openFileAt(msg.path, msg.line);
-					}
-					return;
-				case 'action':
-					if (msg.command) {
-						await vscode.commands.executeCommand(msg.command, ...(msg.args ?? []));
-					}
-					return;
-			}
-		}, undefined, this.context.subscriptions);
+		const actions: FlowActions = {
+			openLink,
+			openFileAt: (fsPath, line) => openFileAt(fsPath, line),
+			runCommand: async (command, ...args) => {
+				await vscode.commands.executeCommand(command, ...args);
+			},
+			showError: (message) => void vscode.window.showErrorMessage(message),
+		};
+		view.webview.onDidReceiveMessage(
+			(msg: OutboundMessage) => handleFlowMessage(msg, actions),
+			undefined,
+			this.context.subscriptions,
+		);
 	}
 }
 
@@ -91,10 +132,20 @@ async function openLink(link: FlowLink): Promise<void> {
 		return;
 	}
 	if (!link.openPath) {
+		void vscode.window.showErrorMessage('Vinv: this link has no file to open.');
 		return;
 	}
 	if (link.markdownPreview) {
-		await vscode.commands.executeCommand('markdown.showPreview', vscode.Uri.file(link.openPath));
+		// Verify existence first so a moved handbook reports where, not nothing.
+		const resolved = resolveOpenTarget(link.openPath, undefined, 'document');
+		if (!resolved.ok || !resolved.absPath) {
+			void vscode.window.showErrorMessage(resolved.error ?? 'Vinv: could not open document.');
+			return;
+		}
+		await vscode.commands.executeCommand(
+			'markdown.showPreview',
+			vscode.Uri.file(resolved.absPath),
+		);
 		return;
 	}
 	// vscode.open resolves the registered default editor, so calltree-*.json
@@ -102,18 +153,19 @@ async function openLink(link: FlowLink): Promise<void> {
 	await openFileAt(link.openPath, link.openLine);
 }
 
-async function openFileAt(fsPath: string, line?: number): Promise<void> {
-	const uri = vscode.Uri.file(fsPath);
-	const ext = path.extname(fsPath);
-	if (line && ext !== '.html') {
-		const pos = new vscode.Position(Math.max(0, line - 1), 0);
-		await vscode.window.showTextDocument(uri, {
-			selection: new vscode.Range(pos, pos),
-			preview: true,
-		});
-		return;
-	}
-	await vscode.commands.executeCommand('vscode.open', uri);
+async function openFileAt(fsPath: string | undefined, line?: number): Promise<void> {
+	const ext = fsPath ? path.extname(fsPath) : '';
+	// .html (smoke reports) and extension-less custom docs go through the default
+	// editor so their registered viewers claim them; everything else opens as
+	// text at the requested line. Either way openPathInEditor verifies existence
+	// and surfaces an actionable error instead of a silent no-op.
+	const useDefaultEditor = ext === '.html' || !line;
+	await openPathInEditor(fsPath, {
+		label: 'file',
+		line,
+		preview: true,
+		useDefaultEditor,
+	});
 }
 
 function getFlowHtml(cspSource: string): string {

--- a/extension/src/views/graphExplorer.ts
+++ b/extension/src/views/graphExplorer.ts
@@ -17,6 +17,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
 import { getGraphHtml } from './graphExplorerHtml';
+import { openPathInEditor } from '../support/openDocument';
 import { buildGraphSnapshot, hasIndexStore, type GraphSnapshot } from '../graph/indexGraph';
 import { runIndexQuery, hitsToRows } from '../qna/answer';
 import { loadEntryPoints } from '../identification/identification';
@@ -26,7 +27,7 @@ import { endpointsForRows } from '../identification/endpointsForRow';
 export const GRAPH_VIEW_TYPE = 'vinv.graphExplorer';
 
 /** Messages the graph webview sends back to the extension. */
-interface OutboundMessage {
+export interface OutboundMessage {
 	type:
 		| 'openSource'
 		| 'semanticSearch'
@@ -40,6 +41,58 @@ interface OutboundMessage {
 	query?: string;
 	row?: number;
 	issue?: string;
+}
+
+/**
+ * Side effects a graph message can trigger, injected so the routing is testable
+ * without a live webview or index. Production binds these to the real closures
+ * in `resolveCustomEditor`; tests pass fakes and assert the exact call.
+ */
+export interface GraphActions {
+	openSource: (file: string | undefined, line?: number) => Promise<void>;
+	refresh: () => void;
+	semanticSearch: (query: string) => Promise<void>;
+	ask: (row?: number) => Promise<void>;
+	harness: (row?: number, issue?: string) => Promise<void>;
+	trace: (row?: number, file?: string) => Promise<void>;
+	trajectory: () => Promise<void>;
+}
+
+/**
+ * Routes one graph webview message to its side effect. Extracted from the inline
+ * onDidReceiveMessage closure so the wiring is unit-tested directly. openSource
+ * resolves its path to absolute, verifies existence, and reports an actionable
+ * error on failure (via the injected opener) instead of a silent no-op.
+ */
+export async function handleGraphMessage(
+	msg: OutboundMessage,
+	actions: GraphActions,
+): Promise<void> {
+	switch (msg.type) {
+		case 'openSource':
+			await actions.openSource(msg.file, msg.line);
+			return;
+		case 'refresh':
+			actions.refresh();
+			return;
+		case 'semanticSearch':
+			if (msg.query) {
+				await actions.semanticSearch(msg.query);
+			}
+			return;
+		case 'ask':
+			await actions.ask(msg.row);
+			return;
+		case 'harness':
+			await actions.harness(msg.row, msg.issue);
+			return;
+		case 'trace':
+			await actions.trace(msg.row, msg.file);
+			return;
+		case 'trajectory':
+			await actions.trajectory();
+			return;
+	}
 }
 
 function backingFilePath(workspaceRoot: string): string {
@@ -211,77 +264,62 @@ export class GraphExplorerEditorProvider implements vscode.CustomReadonlyEditorP
 			w.onDidCreate(scheduleRefresh);
 		}
 
-		const msgSub = webview.onDidReceiveMessage(async (msg: OutboundMessage) => {
+		const context = this.context;
+		const actions: GraphActions = {
+			openSource: async (file, line) => {
+				await openPathInEditor(file, {
+					workspaceRoot,
+					line: line ?? 1,
+					label: 'source file',
+					preview: true,
+					viewColumn: vscode.ViewColumn.Beside,
+				});
+			},
+			refresh: () => rebuild(),
+			semanticSearch: async (query) => {
+				try {
+					const snapshot = buildGraphSnapshot(workspaceRoot);
+					const hits = await runIndexQuery(context, workspaceRoot, query, 8);
+					void webview.postMessage({
+						type: 'searchResults',
+						rows: hitsToRows(snapshot, hits),
+						hits: hits.map((h) => ({
+							file: h.file,
+							name: h.name,
+							line: h.lines?.[0] ?? 1,
+							score: h.score,
+							summary: h.summary,
+						})),
+					});
+				} catch (e) {
+					void webview.postMessage({
+						type: 'searchResults',
+						rows: [],
+						hits: [],
+						error: e instanceof Error ? e.message : String(e),
+					});
+				}
+			},
+			ask: async (row) => {
+				await vscode.commands.executeCommand('vinv-vs.askVinv', { seedRow: row });
+			},
+			harness: async (row, issue) => {
+				await vscode.commands.executeCommand('vinv-vs.fixWithHarness', { row, issue });
+			},
+			// Infer which endpoint(s) reach the clicked node and open the call-tree
+			// view (with its latency/memory flamegraph) directly; only prompt when
+			// the node is ambiguous or unresolved.
+			trace: async (row, file) => openTraceForNode(context, workspaceRoot, row, file),
+			trajectory: async () => {
+				await vscode.commands.executeCommand('vinv-vs.showTrajectory');
+			},
+		};
+		const msgSub = webview.onDidReceiveMessage((msg: OutboundMessage) => {
 			const raw = msg as { type?: string; message?: unknown; stack?: unknown };
 			if (raw.type === 'webviewError') {
 				return;
 			}
-			switch (msg.type) {
-				case 'openSource': {
-					if (!msg.file) {
-						return;
-					}
-					const abs = path.isAbsolute(msg.file) ? msg.file : path.join(workspaceRoot, msg.file);
-					const pos = new vscode.Position(Math.max(0, (msg.line ?? 1) - 1), 0);
-					await vscode.window.showTextDocument(vscode.Uri.file(abs), {
-						selection: new vscode.Range(pos, pos),
-						preview: true,
-						viewColumn: vscode.ViewColumn.Beside,
-					});
-					return;
-				}
-				case 'refresh':
-					rebuild();
-					return;
-				case 'semanticSearch': {
-					if (!msg.query) {
-						return;
-					}
-					try {
-						const snapshot = buildGraphSnapshot(workspaceRoot);
-						const hits = await runIndexQuery(this.context, workspaceRoot, msg.query, 8);
-						void webview.postMessage({
-							type: 'searchResults',
-							rows: hitsToRows(snapshot, hits),
-							hits: hits.map((h) => ({
-								file: h.file,
-								name: h.name,
-								line: h.lines?.[0] ?? 1,
-								score: h.score,
-								summary: h.summary,
-							})),
-						});
-					} catch (e) {
-						void webview.postMessage({
-							type: 'searchResults',
-							rows: [],
-							hits: [],
-							error: e instanceof Error ? e.message : String(e),
-						});
-					}
-					return;
-				}
-				case 'ask':
-					await vscode.commands.executeCommand('vinv-vs.askVinv', {
-						seedRow: msg.row,
-					});
-					return;
-				case 'harness':
-					await vscode.commands.executeCommand('vinv-vs.fixWithHarness', {
-						row: msg.row,
-						issue: msg.issue,
-					});
-					return;
-				case 'trace':
-					// Infer which endpoint(s) reach the clicked node and open the
-					// call-tree view (with its latency/memory flamegraph) directly;
-					// only prompt when the node is ambiguous or unresolved.
-					await openTraceForNode(this.context, workspaceRoot, msg.row, msg.file);
-					return;
-				case 'trajectory':
-					await vscode.commands.executeCommand('vinv-vs.showTrajectory');
-					return;
-			}
+			return handleGraphMessage(msg, actions);
 		});
 
 		rebuild();


### PR DESCRIPTION
…and report every file-open

The live defect: clicking 'view context pack' on the judgment card (and 'all those buttons') did nothing. Every webview->extension file-open handler did showTextDocument(Uri.file(p)) inside a try with an EMPTY catch, so a relative/missing/moved path made the click a silent no-op with zero feedback.

Introduce support/openDocument.ts as the single choke point: resolveOpenTarget (pure) resolves a webview path to ABSOLUTE against the workspace root and verifies existence; openPathInEditor opens it and, on ANY failure, raises an actionable showErrorMessage naming the file and reason — never an empty catch.

Route every panel through it and extract each inline onDidReceiveMessage closure into an exported, testable handler:
  - episodeLoop judgment card: openPack + retry pack-open (the reported bug)
  - askVinv: viewPack + openSource + disputeStart + guarded dispatch fix
  - flowPanel: link / fix / evidence / action (missing issue/command now error)
  - graphExplorer: openSource + ask/harness/trace/trajectory/search
  - callTreeView: openSource + ask + smoke report Context-pack paths stay absolute end to end (writeContextPack already emits absolute); a missing pack now opens or says 'context pack not found at <path>'.

Add test/webviewWiring.test.ts: 30 tests driving each handler with a valid payload (asserts the right side effect) and a broken payload (asserts a user-facing error, never a silent no-op). Suite 313 -> 343.