### PR TITLE
fix(tracelens): foreign target venv needs ZERO installs to be traced

### DIFF
--- a/tracelens/src/tracelens/launcher/run.py
+++ b/tracelens/src/tracelens/launcher/run.py
@@ -7,6 +7,7 @@ path is ``$TRACELENS_HOME/baselines/<service>/trace.jsonl``.
 
 from __future__ import annotations
 
+import importlib.util
 import logging
 import math
 import os
@@ -47,6 +48,41 @@ _PRESETS: dict[str, dict[str, object]] = {
 _DEFAULT_PRESET = "standard"
 _MAX_BUNDLED_SOURCE_FILES = 10_000
 _MAX_BUNDLED_SOURCE_BYTES = 256 * 1024 * 1024
+
+# Top-level distribution packages the in-process capture path imports and that a
+# *target* service venv should NOT have to install just to be traced. When we hand
+# off into a foreign target interpreter (see ``_maybe_handoff_to_target_python``)
+# we locate the directories that hold these packages in tracelens's OWN
+# environment and hand them to the child, which APPENDS them to ``sys.path`` (see
+# ``_install_capture_dep_fallback``). This is the whole design point of the
+# foreign-venv zero-install path: tracing a service in its own venv installs
+# nothing — not tracelens, not opentelemetry, not PyYAML — into that venv.
+#
+# The set is the transitive closure of the capture path's third-party imports:
+#   * span pipeline — ``opentelemetry`` (api + sdk + semconv share one namespace
+#     dir) and its runtime deps ``deprecated`` → ``wrapt`` and, on interpreters
+#     without the stdlib backport, ``importlib_metadata`` → ``zipp``;
+#   * ``typing_extensions`` (version-dependent OTel typing dep);
+#   * per-call enrichment — ``yaml`` (PyYAML), imported eagerly by
+#     ``tracelens.enrich.external_invariants`` which ``trace_fn`` pulls in.
+# All are pure-Python (or have a pure-Python fallback), so injecting tracelens's
+# 3.13 copies onto a 3.14 target works. We append (never prepend) the dirs so the
+# target's own copy of any package always wins — the injected copies only fill a
+# gap the target does not provide at all — and, crucially, appending to
+# ``sys.path`` (rather than a code-only ``meta_path`` finder) also exposes the
+# dependencies' ``.dist-info`` metadata, which ``opentelemetry`` needs for its
+# entry-point-based runtime-context lookup. tracelens itself is supplied
+# separately via the source root on ``PYTHONPATH`` (``_tracelens_source_root``).
+_CAPTURE_DEP_TOPLEVEL: tuple[str, ...] = (
+    "opentelemetry",
+    "deprecated",
+    "wrapt",
+    "importlib_metadata",
+    "zipp",
+    "typing_extensions",
+    "yaml",
+)
+_CAPTURE_DEP_ROOTS_ENV = "TRACELENS_CAPTURE_DEP_ROOTS"
 
 
 def _safe_service_name(value: str) -> str:
@@ -446,6 +482,76 @@ def _extract_bundled_source(zip_path: Path) -> str | None:
             shutil.rmtree(tmp, ignore_errors=True)
 
 
+def _capture_dependency_roots() -> list[str]:
+    """Directories in *tracelens's own* interpreter that hold the capture path's
+    third-party dependencies (``_CAPTURE_DEP_TOPLEVEL``).
+
+    Resolved via ``find_spec`` on the CURRENTLY running interpreter — i.e. the
+    tracelens process about to hand off — so it names the exact dirs where
+    tracelens itself imports OTel / PyYAML / their deps. These are handed to the
+    foreign target interpreter (via ``TRACELENS_CAPTURE_DEP_ROOTS``) so the child
+    can import the capture stack without those packages being installed into the
+    target venv. Best-effort: a dependency that does not resolve to a real
+    directory (e.g. a built-in, or bundled inside a frozen binary) is skipped, and
+    the target's own copy — if any — always wins regardless (the child installs
+    these as a last-resort finder, never a shadow).
+    """
+    roots: list[str] = []
+    seen: set[str] = set()
+    for name in _CAPTURE_DEP_TOPLEVEL:
+        try:
+            spec = importlib.util.find_spec(name)
+        except (ImportError, AttributeError, ValueError):
+            continue
+        if spec is None:
+            continue
+        dirs: list[str] = []
+        locations = list(spec.submodule_search_locations or [])
+        if locations:  # a package — its parent dir is the sys.path entry
+            dirs = [str(Path(p).resolve().parent) for p in locations]
+        elif spec.origin and spec.origin not in ("built-in", "frozen"):
+            dirs = [str(Path(spec.origin).resolve().parent)]
+        for d in dirs:
+            if d and d not in seen and Path(d).is_dir():
+                seen.add(d)
+                roots.append(d)
+    return roots
+
+
+def _install_capture_dep_fallback() -> list[str]:
+    """Child-side: expose tracelens's capture dependencies as a last-resort import
+    fallback so a foreign target venv needs ZERO tracing installs.
+
+    Reads ``TRACELENS_CAPTURE_DEP_ROOTS`` (set by the parent in
+    ``_maybe_handoff_to_target_python``) and APPENDS each dir to ``sys.path``.
+    Appending — not prepending — is what makes the precedence correct: Python's
+    import machinery and ``importlib.metadata`` both walk ``sys.path`` front-to-
+    back, so the target venv's own site-packages (already earlier on the path)
+    shadow these injected dirs for every package the target actually ships; the
+    injected copies only satisfy imports (and ``.dist-info`` / entry-point lookups,
+    which ``opentelemetry`` relies on) the target cannot satisfy at all. Must run
+    BEFORE any ``opentelemetry`` / ``yaml`` import in ``run_main`` — including the
+    ``core_sdk_missing`` preflight and the span pipeline. No-op — and byte-identical
+    to the historical behaviour — when the env var is unset (in-process / same-venv
+    runs, where the deps are already importable). Idempotent. Returns the roots
+    added, for diagnostics and tests.
+    """
+    raw = os.environ.get(_CAPTURE_DEP_ROOTS_ENV)
+    if not raw:
+        return []
+    added: list[str] = []
+    for root in raw.split(os.pathsep):
+        if root and root not in sys.path:
+            sys.path.append(root)
+            added.append(root)
+    if added:
+        # Invalidate importlib's caches so the newly-appended dirs are visible to
+        # both module imports and metadata/entry-point discovery immediately.
+        importlib.invalidate_caches()
+        _log.info("tracelens: capture-dependency fallback active (sys.path+=%s)", added)
+    return added
+
+
 def _resolvable_executable(cmd0: str) -> bool:
     """False only for a path-style argv[0] that points at nothing executable.
 
@@ -509,6 +615,16 @@ def _maybe_handoff_to_target_python(argv: list[str], user: list[str]) -> None:
     env = dict(os.environ)
     prev = env.get("PYTHONPATH", "")
     env["PYTHONPATH"] = src_root + (os.pathsep + prev if prev else "")
+    # Foreign-venv zero-install: also tell the child where tracelens's own capture
+    # dependencies (OTel api/sdk, PyYAML, transitive deps) live, so it can import
+    # the capture stack even when the target venv has none of them installed. The
+    # child APPENDS these to ``sys.path`` (not PYTHONPATH, which would prepend and
+    # shadow), so a target that already ships a compatible opentelemetry keeps
+    # using its own — the injected copies only fill genuine gaps. See
+    # ``_install_capture_dep_fallback``.
+    dep_roots = _capture_dependency_roots()
+    if dep_roots:
+        env[_CAPTURE_DEP_ROOTS_ENV] = os.pathsep.join(dep_roots)
     _log_diag_dispatch("handoff")
     _log.info(
         "tracelens: handing off to target interpreter %s (PYTHONPATH+=%s)",
@@ -954,6 +1070,14 @@ def _install_hooks() -> None:
 def run_main(argv: list[str] | None = None) -> None:
     if argv is None:
         argv = sys.argv[1:]
+    # Foreign-venv zero-install: when a parent tracelens handed off into this
+    # target interpreter, expose tracelens's own capture dependencies (OTel
+    # api/sdk, PyYAML, …) as a last-resort import fallback. MUST precede any
+    # opentelemetry/yaml import below — including the ``core_sdk_missing``
+    # preflight and the span pipeline. No-op on same-venv / in-process runs
+    # (the env var is only set on handoff), keeping healthy-path behaviour and
+    # the trace JSONL byte-identical.
+    _install_capture_dep_fallback()
     _configure_diag()
     pre, user = _parse_user_command(argv)
     # Before doing any in-process instrumentation, decide whether THIS

--- a/tracelens/tests/test_foreign_venv_zero_install.py
+++ b/tracelens/tests/test_foreign_venv_zero_install.py
@@ -1,0 +1,183 @@
+"""Foreign-venv zero-install capture (spec §5.2, launcher handoff).
+
+Tracing a service that lives in ITS OWN venv must require ZERO installs into that
+venv — not tracelens, not opentelemetry, not PyYAML. The launcher achieves this by
+handing off into the target interpreter and, alongside the tracelens *source root*
+on ``PYTHONPATH``, telling the child where tracelens's own capture dependencies
+live (``TRACELENS_CAPTURE_DEP_ROOTS``); the child appends those dirs to
+``sys.path`` as a last-resort fallback (``_install_capture_dep_fallback``).
+
+These tests exercise both the unit seam (the roots-computation + the fallback
+installer) and, end to end, a subprocess that stands in for a *clean* target venv:
+``python -S`` hides site-packages so opentelemetry/PyYAML are unimportable through
+the normal path, exactly like a target venv that never installed them. Without the
+fallback the run must fail with the friendly missing-OTel line (the historical
+behaviour, still covered in ``test_run_bootstrap_resilience``); WITH the fallback
+roots injected the same clean interpreter captures a non-empty trace of the app's
+own components.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from tracelens.launcher import run as run_mod
+
+_ENTRY = "import sys; from tracelens.launcher.run import run_main; run_main(sys.argv[1:])"
+
+
+def _src_root() -> str:
+    return str(Path(run_mod.__file__).resolve().parents[2])
+
+
+def _write_app(tmp_path: Path) -> Path:
+    """A component module (imported → AST-rewritten) plus a bounded entry that
+    imports and drives it, then exits cleanly (no signal needed)."""
+    (tmp_path / "svc.py").write_text(
+        "def compute(n):\n"
+        "    return sum(i * i for i in range(n))\n\n\n"
+        "def summarize(counter):\n"
+        "    return {'counter': counter, 'sq': compute(counter % 7 + 1)}\n\n\n"
+        "def tick(counter):\n"
+        "    return summarize(counter)\n",
+        encoding="utf-8",
+    )
+    main = tmp_path / "main.py"
+    main.write_text(
+        "import svc\n\n"
+        "for c in range(5):\n"
+        "    svc.tick(c)\n",
+        encoding="utf-8",
+    )
+    return main
+
+
+# --------------------------------------------------------------------------- unit
+
+
+def test_capture_dependency_roots_covers_otel_and_yaml() -> None:
+    """The computed roots must contain the dirs where the dev env resolves the
+    capture path's hard deps (opentelemetry + PyYAML), so a foreign child can find
+    them."""
+    roots = {os.path.realpath(r) for r in run_mod._capture_dependency_roots()}
+    assert roots, "expected at least one capture-dependency root in a healthy env"
+    import importlib.util
+
+    for mod in ("opentelemetry", "yaml"):
+        spec = importlib.util.find_spec(mod)
+        assert spec is not None
+        locs = list(spec.submodule_search_locations or [])
+        parent = os.path.realpath(str(Path(locs[0]).parent))
+        assert parent in roots, f"{mod} dir {parent} not among capture roots {roots}"
+
+
+def test_install_capture_dep_fallback_appends_and_is_idempotent(
+    tmp_path: Path, monkeypatch: object
+) -> None:
+    """The fallback APPENDS the roots (target-wins precedence) and never double-adds."""
+    import importlib
+
+    dep = tmp_path / "dep_root"
+    dep.mkdir()
+    (dep / "zz_fake_capture_dep.py").write_text("VALUE = 42\n", encoding="utf-8")
+    monkeypatch.setenv(run_mod._CAPTURE_DEP_ROOTS_ENV, str(dep))  # type: ignore[attr-defined]
+
+    before = list(sys.path)
+    try:
+        added = run_mod._install_capture_dep_fallback()
+        assert added == [str(dep)]
+        # Appended to the END so the target's own copies (earlier on sys.path) win.
+        assert sys.path[-1] == str(dep)
+        assert str(dep) not in before
+        importlib.invalidate_caches()
+        mod = importlib.import_module("zz_fake_capture_dep")
+        assert mod.VALUE == 42
+        # Idempotent: a second call adds nothing.
+        assert run_mod._install_capture_dep_fallback() == []
+        assert sys.path.count(str(dep)) == 1
+    finally:
+        sys.modules.pop("zz_fake_capture_dep", None)
+        while str(dep) in sys.path:
+            sys.path.remove(str(dep))
+
+
+def test_install_capture_dep_fallback_noop_without_env(monkeypatch: object) -> None:
+    monkeypatch.delenv(run_mod._CAPTURE_DEP_ROOTS_ENV, raising=False)  # type: ignore[attr-defined]
+    before = list(sys.path)
+    assert run_mod._install_capture_dep_fallback() == []
+    assert sys.path == before
+
+
+# --------------------------------------------------------------------- end to end
+
+
+def _run_clean_target(
+    tmp_path: Path, *, inject_dep_roots: bool
+) -> subprocess.CompletedProcess[str]:
+    """Run a trace where the interpreter hosting instrumentation has site-packages
+    hidden (``-S``) — a stand-in for a target venv with no otel/yaml installed."""
+    main = _write_app(tmp_path)
+    out = tmp_path / "trace.jsonl"
+    dep_env = run_mod._CAPTURE_DEP_ROOTS_ENV  # type: ignore[attr-defined]
+    env = {k: v for k, v in os.environ.items() if k not in ("PYTHONPATH", dep_env)}
+    env["PYTHONPATH"] = _src_root()
+    env["TRACELENS_NO_SELFCHECK"] = "1"
+    if inject_dep_roots:
+        env[dep_env] = os.pathsep.join(run_mod._capture_dependency_roots())
+    return subprocess.run(
+        [
+            sys.executable,
+            "-S",
+            "-c",
+            _ENTRY,
+            "--minimal",
+            "--no-otel-autoinst",
+            "-t",
+            "svc",
+            "-o",
+            str(out),
+            "--",
+            sys.executable,
+            str(main),
+        ],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=90,
+        check=False,
+    )
+
+
+def test_clean_target_without_fallback_fails_friendly(tmp_path: Path) -> None:
+    """Sanity anchor: with site hidden and NO injected roots, the run fails with the
+    actionable missing-OTel line (never a raw traceback)."""
+    r = _run_clean_target(tmp_path, inject_dep_roots=False)
+    assert r.returncode != 0
+    assert "opentelemetry" in r.stderr
+    assert "Traceback" not in r.stderr
+
+
+def test_clean_target_with_injected_roots_captures_nonempty_trace(tmp_path: Path) -> None:
+    """The whole point: the SAME clean interpreter, given tracelens's capture-dep
+    roots, records a non-empty parseable trace of the app's own components without
+    those deps ever being installed into it."""
+    r = _run_clean_target(tmp_path, inject_dep_roots=True)
+    assert r.returncode == 0, f"run failed: {r.stderr}"
+    out = tmp_path / "trace.jsonl"
+    assert out.is_file() and out.stat().st_size > 0, "expected a non-empty trace"
+    components: set[str] = set()
+    n = 0
+    for line in out.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        event = json.loads(line)  # parseable JSONL or this raises
+        components.add(event["component"])
+        n += 1
+    assert n > 0
+    # The app's own instrumented functions appear as components.
+    assert {"svc.compute", "svc.summarize", "svc.tick"} <= components


### PR DESCRIPTION
Tracing a service in its own venv must not require installing tracelens's runtime dependencies (opentelemetry-api/sdk, PyYAML) into that venv. The launcher handoff prepended only tracelens's SOURCE ROOT to the child's PYTHONPATH, so a target venv lacking opentelemetry died with a ModuleNotFoundError (observed on a 3.14 fastapi target).

Compute, from tracelens's OWN environment, the directories that hold the capture path's third-party deps (opentelemetry api+sdk+semconv, deprecated, wrapt, importlib_metadata, zipp, typing_extensions, yaml) and pass them to the handoff child via TRACELENS_CAPTURE_DEP_ROOTS. The child APPENDS them to sys.path before any opentelemetry/yaml import.

Precedence by construction: import machinery and importlib.metadata both walk sys.path front-to-back, and the target venv's own site-packages sit earlier, so a target that already ships a compatible opentelemetry keeps using its own — the injected copies only fill genuine gaps. Appending to sys.path (not a code-only meta_path finder, and not PYTHONPATH which would prepend and shadow) is deliberate: it also exposes the deps' .dist-info metadata, which opentelemetry needs for its entry-point-based runtime-context lookup.

No-op on same-venv / in-process runs (env var only set on handoff), so the healthy-path trace JSONL stays byte-identical and the 3.14 TracerProvider fix plus capture_health work are preserved.

Adds regression tests: a clean interpreter (python -S, site hidden) fails friendly without the roots and captures a non-empty trace of the app's own components with them injected, plus unit coverage of the roots computation and the append/idempotency of the fallback installer.