### PR TITLE
fix(webviews): WCAG-grounded theme contrast for dark runtime overlay …

### DIFF
--- a/extension/src/identification/callTreeView.ts
+++ b/extension/src/identification/callTreeView.ts
@@ -368,10 +368,10 @@ function getHtml(label: string): string {
 		}
 		.cov .bar span { display: block; height: 100%; background: var(--ink); }
 		.note { margin-top: 8px; font-size: 11px; color: var(--muted); }
-		.live { color: var(--accent); }
+		.live { color: var(--accent-fg); }
 		#status { color: var(--muted); padding: 8px 0; font-size: 10.5px; letter-spacing: 0.18em; text-transform: uppercase; }
-		#status::before { content: '// '; color: var(--accent); }
-		.error, #status.error { color: var(--accent); white-space: pre-wrap; text-transform: none; letter-spacing: normal; font-size: 12px; }
+		#status::before { content: '// '; color: var(--accent-fg); }
+		.error, #status.error { color: var(--accent-fg); white-space: pre-wrap; text-transform: none; letter-spacing: normal; font-size: 12px; }
 		#status.error::before { content: none; }
 
 		ul.tree { list-style: none; margin: 0; padding: 0; }
@@ -382,7 +382,7 @@ function getHtml(label: string): string {
 			padding: 2px 6px; border-radius: 0; max-width: 100%;
 		}
 		.node.clickable { cursor: pointer; }
-		.node.clickable:hover { background: var(--bg-2); box-shadow: inset 2px 0 0 var(--accent); }
+		.node.clickable:hover { background: var(--bg-2); box-shadow: inset 2px 0 0 var(--accent-fg); }
 		.node.notrun { opacity: 0.45; }
 		.caret {
 			cursor: pointer; width: 14px; display: inline-block; text-align: center;
@@ -396,7 +396,7 @@ function getHtml(label: string): string {
 		.rt { font-size: 10.5px; flex: none; }
 		.rt.ok { color: var(--muted); }
 		.rt.no { color: var(--muted-2); }
-		.rt.err { color: var(--accent); }
+		.rt.err { color: var(--accent-fg); }
 		.badge {
 			font-size: 9px; padding: 1px 6px; border-radius: 0;
 			letter-spacing: 0.16em; text-transform: uppercase;
@@ -421,7 +421,7 @@ function getHtml(label: string): string {
 			color: var(--muted); margin: 0 0 10px; padding-top: 12px;
 			border-top: 1px solid var(--ink); display: inline-block;
 		}
-		.gap h2::before { content: '// '; color: var(--accent); }
+		.gap h2::before { content: '// '; color: var(--accent-fg); }
 		.gap ul { list-style: none; margin: 0; padding: 0; }
 		.gap li { padding: 2px 0; font-size: 11.5px; color: var(--muted); }
 		.collapsed > ul { display: none; }
@@ -472,7 +472,7 @@ function getHtml(label: string): string {
 			font-size: 10.5px; line-height: 20px; padding: 0 5px;
 			border: 1px solid var(--line-strong); border-radius: 0;
 		}
-		.flame-frame:hover { outline: 1px solid var(--accent); outline-offset: -1px; }
+		.flame-frame:hover { outline: 1px solid var(--accent-fg); outline-offset: -1px; }
 		.flame-hint { color: var(--muted); font-size: 11px; padding: 8px 0; }
 	</style>
 </head>
@@ -727,10 +727,16 @@ function getHtml(label: string): string {
 
 		// Neutral → brand red by share of the root's total (hotter = heavier on
 		// the metric), so the flamegraph reads in the site's white/black/red system.
-		// On dark themes the mix base (--bg-2) is near-black, so white text is
-		// legible from ~45% red; on light themes the mixed color stays pale much
-		// longer, and white-on-pink was unreadable — keep the dark ink until the
-		// frame is decisively red. Body theme classes are VS Code's own.
+		// Label color is fixed per theme, with the RED CAP chosen so the label
+		// clears 4.5:1 at the hottest frame (measured, not eyeballed):
+		// - dark: red over near-black darkens the frame, so white text works at
+		//   every mix (worst case 88% red = 6.3:1) — full 10–88% range.
+		// - light: red over near-white brightens the frame; white-on-pink fails
+		//   until ~88% and near-black ink fails ABOVE ~80%, so light keeps ink
+		//   text and caps the mix at 78% (ink = 4.85:1 there). Between 80–88%
+		//   NEITHER white nor ink reaches 4.5:1 — that band is unusable, which is
+		//   why the old 65% white-switch was still broken.
+		// Body theme classes are VS Code's own.
 		function isDarkTheme() {
 			const c = document.body.classList;
 			return c.contains('vscode-dark') ||
@@ -738,11 +744,11 @@ function getHtml(label: string): string {
 		}
 		function flameStyle(v, rootV) {
 			const frac = Math.max(0, Math.min(1, rootV > 0 ? v / rootV : 0));
-			const mix = Math.round(10 + 78 * frac);
-			const whiteFrom = isDarkTheme() ? 45 : 65;
+			const dark = isDarkTheme();
+			const mix = Math.round(10 + (dark ? 78 : 68) * frac);
 			return {
 				background: 'color-mix(in srgb, var(--accent) ' + mix + '%, var(--bg-2))',
-				color: mix > whiteFrom ? '#ffffff' : 'var(--ink)',
+				color: dark ? '#ffffff' : 'var(--ink)',
 			};
 		}
 

--- a/extension/src/views/flowPanel.ts
+++ b/extension/src/views/flowPanel.ts
@@ -196,10 +196,10 @@ function getFlowHtml(cspSource: string): string {
 
 		.next {
 			display: none; margin: 2px 0 12px; padding: 10px 12px;
-			border: 1px solid var(--accent);
+			border: 1px solid var(--accent-fg);
 		}
 		.next.on { display: block; }
-		.next .k { font-size: 9px; letter-spacing: 0.22em; text-transform: uppercase; color: var(--accent); margin-bottom: 4px; }
+		.next .k { font-size: 9px; letter-spacing: 0.22em; text-transform: uppercase; color: var(--accent-fg); margin-bottom: 4px; }
 		.next .why { color: var(--muted); margin: 6px 0 10px; line-height: 1.5; }
 		.next button {
 			display: inline-flex; align-items: center; gap: 6px;
@@ -226,9 +226,9 @@ function getFlowHtml(cspSource: string): string {
 			border: 1.5px solid var(--muted-2); background: var(--bg);
 		}
 		.stage.done .dot { border-color: var(--ink); background: var(--ink); }
-		.stage.error .dot { border-color: var(--accent); background: var(--accent); }
+		.stage.error .dot { border-color: var(--accent-fg); background: var(--accent-fg); }
 		.stage.running .dot {
-			border-color: var(--accent); background: var(--accent);
+			border-color: var(--accent-fg); background: var(--accent-fg);
 			box-shadow: 0 0 0 4px rgba(215, 25, 33, 0.18);
 			animation: v-pulse 2.4s ease-in-out infinite;
 		}
@@ -242,11 +242,11 @@ function getFlowHtml(cspSource: string): string {
 			font-size: 8.5px; letter-spacing: 0.2em; text-transform: uppercase;
 			color: var(--muted-2);
 		}
-		.stage.error h2 .st, .stage.running h2 .st { color: var(--accent); }
+		.stage.error h2 .st, .stage.running h2 .st { color: var(--accent-fg); }
 		.stage.done h2 .st { color: var(--muted); }
 		.summary { color: var(--muted); margin: 3px 0 0; line-height: 1.5; }
-		.stage.error .summary { color: var(--accent); }
-		.activity { color: var(--accent); margin: 3px 0 0; line-height: 1.5; }
+		.stage.error .summary { color: var(--accent-fg); }
+		.activity { color: var(--accent-fg); margin: 3px 0 0; line-height: 1.5; }
 		.links { margin: 6px 0 0; }
 		.lnk {
 			display: flex; align-items: baseline; gap: 7px;
@@ -256,7 +256,7 @@ function getFlowHtml(cspSource: string): string {
 			border-radius: 0; color: var(--ink); font-family: inherit; font-size: 11px;
 			cursor: pointer; line-height: 1.45;
 		}
-		.lnk:hover { background: var(--bg-2); border-left-color: var(--accent); }
+		.lnk:hover { background: var(--bg-2); border-left-color: var(--accent-fg); }
 		.lnk:disabled { cursor: default; }
 		.lnk:disabled:hover { background: transparent; border-left-color: transparent; }
 		.lnk .b {
@@ -264,9 +264,9 @@ function getFlowHtml(cspSource: string): string {
 			align-self: center; background: var(--muted-2);
 		}
 		.lnk.s-ok .b { background: var(--ink); }
-		.lnk.s-error .b { background: var(--accent); }
+		.lnk.s-error .b { background: var(--accent-fg); }
 		.lnk.s-running .b {
-			background: var(--accent);
+			background: var(--accent-fg);
 			box-shadow: 0 0 0 3px rgba(215, 25, 33, 0.18);
 			animation: v-pulse 2.4s ease-in-out infinite;
 		}
@@ -275,7 +275,7 @@ function getFlowHtml(cspSource: string): string {
 		.lnk .det { color: var(--muted-2); font-size: 10px; min-width: 0; }
 
 		/* ---- issues ---- */
-		.issues { display: none; margin-top: 6px; border: 1px solid var(--accent); }
+		.issues { display: none; margin-top: 6px; border: 1px solid var(--accent-fg); }
 		.issues.on { display: block; }
 		.issues .hd {
 			padding: 7px 10px; background: var(--accent); color: #ffffff;
@@ -296,7 +296,7 @@ function getFlowHtml(cspSource: string): string {
 			transition: background 0.2s, color 0.2s, border-color 0.2s;
 		}
 		.issue .fix { background: var(--accent); border: 1px solid var(--accent); color: #ffffff; }
-		.issue .fix:hover { background: var(--accent-soft); border-color: var(--accent-soft); }
+		.issue .fix:hover { background: var(--accent-hover); border-color: var(--accent-hover); }
 		.issue .ev { background: transparent; border: 1px solid var(--line-strong); color: var(--ink); }
 		.issue .ev:hover { border-color: var(--ink); }
 		.issue .sent { align-self: center; font-size: 11px; letter-spacing: 0.04em; color: var(--muted); border: 1px dashed var(--line-strong); padding: 3px 8px; }

--- a/extension/src/views/graphExplorerHtml.ts
+++ b/extension/src/views/graphExplorerHtml.ts
@@ -30,14 +30,16 @@ export function getGraphHtml(): string {
 		   an explicit choice beats whatever the editor stamped on <body>. */
 		body.vinv-light {
 			--bg: #ffffff; --bg-2: #f4f4f4; --ink: #0a0a0a; --ink-soft: #1a1a1a;
-			--muted: #6b6b6b; --muted-2: #9a9a9a;
+			--muted: #616161; --muted-2: #7a7a7a;
+			--accent: #d71921; --accent-fg: #d71921; --accent-hover: #b3151c;
 			--line: rgba(10, 10, 10, 0.14); --line-strong: rgba(10, 10, 10, 0.32);
 			--grid: rgba(10, 10, 10, 0.05); --grain: rgba(10, 10, 10, 0.05);
 			--grain-blend: multiply;
 		}
 		body.vinv-dark {
 			--bg: #000000; --bg-2: #0b0b0b; --ink: #ffffff; --ink-soft: #ededed;
-			--muted: #8f8f8f; --muted-2: #5c5c5c;
+			--muted: #8f8f8f; --muted-2: #6e6e6e;
+			--accent: #d71921; --accent-fg: #ff4048; --accent-hover: #e2262f;
 			--line: rgba(255, 255, 255, 0.14); --line-strong: rgba(255, 255, 255, 0.32);
 			--grid: rgba(255, 255, 255, 0.05); --grain: rgba(255, 255, 255, 0.05);
 			--grain-blend: screen;
@@ -58,7 +60,7 @@ export function getGraphHtml(): string {
 			width: 250px; padding: 6px 10px; border: 1px solid var(--line-strong); border-radius: 0;
 			background: var(--bg); color: var(--ink); font-family: inherit; font-size: 11.5px;
 		}
-		#search:focus { outline: none; border-color: var(--accent); }
+		#search:focus { outline: none; border-color: var(--accent-fg); }
 		.mode-switch { display: inline-flex; border: 1px solid var(--line-strong); }
 		.mode-switch button {
 			background: transparent; color: var(--muted); border: none; padding: 5px 11px; cursor: pointer;
@@ -69,7 +71,7 @@ export function getGraphHtml(): string {
 		/* Dead Code is a standing accent call-to-action, not one mode among many —
 		   it reads as red-on-white at a glance whether or not it is engaged. */
 		.v-btn.dead { background: var(--accent); border-color: var(--accent); color: #ffffff; }
-		.v-btn.dead:hover { background: var(--accent-soft); border-color: var(--accent-soft); color: #ffffff; }
+		.v-btn.dead:hover { background: var(--accent-hover); border-color: var(--accent-hover); color: #ffffff; }
 		.v-btn.dead.active { box-shadow: inset 0 0 0 2px var(--bg); }
 		main { flex: 1; display: flex; min-height: 0; }
 		#canvas-wrap { flex: 1; position: relative; min-width: 0; }
@@ -131,10 +133,10 @@ export function getGraphHtml(): string {
 			padding: 5px 7px; cursor: pointer; border-left: 2px solid transparent;
 			display: flex; justify-content: space-between; gap: 6px; align-items: baseline;
 		}
-		.sym:hover, .link-row:hover { background: var(--bg-2); border-left-color: var(--accent); }
+		.sym:hover, .link-row:hover { background: var(--bg-2); border-left-color: var(--accent-fg); }
 		.sym .nm, .link-row .nm { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 		.sym .rt, .link-row .dir { flex: none; font-size: 9.5px; color: var(--muted-2); text-transform: uppercase; letter-spacing: 0.1em; }
-		.sym .rt.err { color: var(--accent); }
+		.sym .rt.err { color: var(--accent-fg); }
 		#status {
 			position: absolute; top: 12px; right: 12px; padding: 6px 10px;
 			font-size: 10px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--muted);
@@ -205,10 +207,15 @@ export function getGraphHtml(): string {
 		config: '#a67c52',   // umber
 		scripts: '#3f9aa6',  // teal — direct complement of the brand red
 		tests: '#7e8a4f',    // olive
-		docs: '#8f8f8f',     // neutral gray (matches --muted)
-		other: '#5c5c5c',    // neutral dark (matches --muted-2)
+		docs: '#8f8f8f',     // neutral gray (matches dark --muted)
+		other: '#6e6e6e',    // neutral dark (matches dark --muted-2; was #5c5c5c,
+		                     // which sat at exactly the 3:1 floor on black)
 	};
-	const ACCENT = '#d71921';
+	// State red (errors, selection, changed-this-epoch) is read from the theme
+	// each time it is used: --accent-fg keeps the brand hue but shifts lightness
+	// per theme (#d71921 on white, #ff4048 on black), because the print red at
+	// 4.05:1 on black made the whole Runtime overlay unreadable in dark themes.
+	function accentFg() { return cssVar('--accent-fg'); }
 	// Layers that start hidden on big graphs — one legend click brings them back.
 	const NOISY_LAYERS = ['tests', 'docs'];
 	const BIG_GRAPH_FILES = 120;
@@ -855,6 +862,7 @@ export function getGraphHtml(): string {
 		ctx.clearRect(0, 0, canvas.width / dpr, canvas.height / dpr);
 		if (!snapshot) { return; }
 		const ink = cssVar('--ink'), line = cssVar('--line-strong'), muted = cssVar('--muted');
+		const accent = accentFg();
 
 		// Edges: when a node is selected only ITS edges render at full strength.
 		ctx.lineWidth = 0.6;
@@ -865,7 +873,7 @@ export function getGraphHtml(): string {
 			if (mode === 'dead' && (!isDead(a) || !isDead(b))) { continue; }
 			const [ax, ay] = worldToScreen(a.x, a.y);
 			const [bx, by] = worldToScreen(b.x, b.y);
-			ctx.strokeStyle = touchesSelection ? ACCENT : line;
+			ctx.strokeStyle = touchesSelection ? accent : line;
 			ctx.globalAlpha = touchesSelection ? 0.8 : Math.min(0.4, 0.08 + e.w * 0.03);
 			ctx.lineWidth = touchesSelection ? 1.2 : 0.6;
 			ctx.beginPath(); ctx.moveTo(ax, ay); ctx.lineTo(bx, by); ctx.stroke();
@@ -891,7 +899,7 @@ export function getGraphHtml(): string {
 				// Red only for a call path that failed in its LATEST run — a
 				// fixed path returns to ink instead of staying red on history.
 				const flowLive = (f.current_errors ?? f.errors) > 0;
-				ctx.strokeStyle = flowLive ? ACCENT : ink;
+				ctx.strokeStyle = flowLive ? accent : ink;
 				ctx.globalAlpha = touchesSelection ? 0.9 : Math.min(0.75, 0.35 + Math.log1p(f.calls) * 0.12);
 				ctx.lineWidth = touchesSelection ? 1.6 : 1.1;
 				if (f.only) { ctx.setLineDash([5, 3]); }
@@ -923,29 +931,41 @@ export function getGraphHtml(): string {
 			if (x < -40 || y < -40 || x > canvas.width / dpr + 40 || y > canvas.height / dpr + 40) { continue; }
 			const alpha = nodeAlpha(n);
 			if (alpha <= 0.001) { continue; }
-			ctx.globalAlpha = alpha;
+			// Never-ran nodes in Runtime mode render as full-strength OUTLINES,
+			// not alpha-faded fills: an 18% fill composites to ~1.2:1 against
+			// either background (invisible on black), while a hollow disc at the
+			// layer color keeps every layer ≥3:1 on both themes and still reads
+			// as "did not run" next to the filled + ringed executed nodes.
+			// Selection isolation and search dimming still apply through alpha.
+			const hollow = mode === 'runtime' && !n.rt;
+			ctx.globalAlpha = hollow && !selected && !highlightFiles.size ? 1 : alpha;
 			ctx.fillStyle = LAYER_COLORS[n.layer] || LAYER_COLORS.other;
-			ctx.beginPath(); ctx.arc(x, y, r, 0, Math.PI * 2); ctx.fill();
+			ctx.beginPath(); ctx.arc(x, y, r, 0, Math.PI * 2);
+			if (hollow) {
+				ctx.strokeStyle = ctx.fillStyle; ctx.lineWidth = 1.2; ctx.stroke();
+			} else {
+				ctx.fill();
+			}
 			if (n.kind === 'symbol') {
 				ctx.strokeStyle = ink; ctx.lineWidth = 0.8;
 				ctx.beginPath(); ctx.arc(x, y, r, 0, Math.PI * 2); ctx.stroke();
 			}
 			if (mode === 'runtime' && n.rt && alpha > 0.5) {
 				const live = (n.rt.current_errors ?? n.rt.errors) > 0;
-				ctx.strokeStyle = live ? ACCENT : ink;
+				ctx.strokeStyle = live ? accent : ink;
 				ctx.lineWidth = live ? 2.2 : 1.2;
 				ctx.beginPath(); ctx.arc(x, y, r + 3, 0, Math.PI * 2); ctx.stroke();
 			}
 			if (mode === 'diff' && changedFiles.has(n.file) && alpha > 0.5) {
-				ctx.strokeStyle = ACCENT; ctx.lineWidth = 2;
+				ctx.strokeStyle = accent; ctx.lineWidth = 2;
 				ctx.beginPath(); ctx.arc(x, y, r + 3, 0, Math.PI * 2); ctx.stroke();
 			} else if (mode === 'diff' && impactedFiles.has(n.file) && alpha > 0.5) {
-				ctx.strokeStyle = ACCENT; ctx.lineWidth = 1; ctx.setLineDash([3, 3]);
+				ctx.strokeStyle = accent; ctx.lineWidth = 1; ctx.setLineDash([3, 3]);
 				ctx.beginPath(); ctx.arc(x, y, r + 3, 0, Math.PI * 2); ctx.stroke();
 				ctx.setLineDash([]);
 			}
 			if (n.id === selected) {
-				ctx.strokeStyle = ACCENT; ctx.lineWidth = 2;
+				ctx.strokeStyle = accent; ctx.lineWidth = 2;
 				ctx.beginPath(); ctx.arc(x, y, r + 5, 0, Math.PI * 2); ctx.stroke();
 			}
 			if (n.id === hoverId && n.id !== selected) {
@@ -1160,13 +1180,13 @@ export function getGraphHtml(): string {
 			html += '<div class="aside-head"><span class="v-label">file · ' + esc(n.layer) + '</span>' + closeBtn + '</div>';
 			html += '<h2>' + esc(n.file) + '</h2>';
 			html += '<div class="sub">' + g.symbols + ' symbols · rank ' + g.rank.toFixed(3) +
-				(g.changed ? ' · <span style="color:' + ACCENT + '">changed this epoch</span>' : '') + '</div>';
+				(g.changed ? ' · <span style="color:var(--accent-fg)">changed this epoch</span>' : '') + '</div>';
 			if (n.rt) {
 				// Live error badge reflects the latest run; lifetime history is
 				// noted separately so a fixed file is not flagged red.
 				const liveErr = n.rt.current_errors ?? n.rt.errors;
 				const errBadge = liveErr
-					? ' · <span style="color:' + ACCENT + '">⚠' + liveErr + ' errors (latest run)</span>'
+					? ' · <span style="color:var(--accent-fg)">⚠' + liveErr + ' errors (latest run)</span>'
 					: (n.rt.errors ? ' · <span style="color:' + cssVar('--muted') + '">' + n.rt.errors + ' errors in history, none in latest run</span>' : '');
 				html += '<div class="sub">runtime: ' + n.rt.executed + ' symbols executed · ×' + n.rt.calls +
 					' · ' + Math.round(n.rt.ms) + 'ms' + errBadge + '</div>';
@@ -1183,7 +1203,7 @@ export function getGraphHtml(): string {
 				return (r.current_errors ?? r.errors) === 0 && (r.errors || 0) > 0;
 			});
 			if (errRows.length) {
-				html += '<div class="sub" style="color:' + ACCENT + '">failing: ' +
+				html += '<div class="sub" style="color:var(--accent-fg)">failing: ' +
 					errRows.map((row) => {
 						const s = snapshot.nodes[row];
 						const rt = snapshot.runtime[row];
@@ -1221,7 +1241,7 @@ export function getGraphHtml(): string {
 				const rt = snapshot.runtime[row];
 				const isNew = snapshot.store_epoch > 0 && s.epoch === snapshot.store_epoch;
 				html += '<div class="sym" data-act="open" data-file="' + esc(s.file) + '" data-line="' + s.start_line + '" title="jump to ' + esc(s.file) + ':' + s.start_line + '">' +
-					'<span class="nm">' + esc(s.name) + (isNew ? ' <span style="color:' + ACCENT + '">●</span>' : '') + '</span>' +
+					'<span class="nm">' + esc(s.name) + (isNew ? ' <span style="color:var(--accent-fg)">●</span>' : '') + '</span>' +
 					'<span class="rt' + (rt && rt.errors > 0 ? ' err' : '') + '">' + (rt ? rtLabel(rt) : '') + '</span></div>';
 			}
 			html += '</div></div>';

--- a/extension/src/views/webviewTheme.ts
+++ b/extension/src/views/webviewTheme.ts
@@ -19,15 +19,29 @@ export const VINV_FONT_SERIF =
 	"'Instrument Serif', 'Iowan Old Style', Georgia, 'Times New Roman', serif";
 
 export const VINV_BASE_CSS = `
-	/* ===== Vinv palette (light default, mirrors vinv.ai styles.css) ===== */
+	/* ===== Vinv palette (light default, mirrors vinv.ai styles.css) =====
+	 *
+	 * Contrast contract (WCAG, against --bg):
+	 *   --muted     body-size secondary text   ≥ 4.5:1
+	 *   --muted-2   small detail text          ≥ 3:1 (kept ≥ 4:1 for comfort)
+	 *   --accent-fg accent used AS FOREGROUND (text, rings, strokes) ≥ 4.5:1
+	 *   --accent    accent used AS FILL — always paired with #ffffff text
+	 *               (white on #d71921 is 5.18:1 in both themes, so the fill
+	 *               stays the brand red everywhere)
+	 *   --accent-hover hover FILL — the same hue with lightness shifted per
+	 *               theme so white text stays ≥ 4.5:1 (darker in light,
+	 *               brighter in dark; #ff5a5f-style tints fail at 3.05:1)
+	 */
 	body {
 		--bg: #ffffff;
 		--bg-2: #f4f4f4;
 		--ink: #0a0a0a;
 		--ink-soft: #1a1a1a;
-		--muted: #6b6b6b;
-		--muted-2: #9a9a9a;
+		--muted: #616161;
+		--muted-2: #7a7a7a;
 		--accent: #d71921;
+		--accent-fg: #d71921;
+		--accent-hover: #b3151c;
 		--accent-soft: #ff5a5f;
 		--line: rgba(10, 10, 10, 0.14);
 		--line-strong: rgba(10, 10, 10, 0.32);
@@ -42,8 +56,10 @@ export const VINV_BASE_CSS = `
 		--ink: #ffffff;
 		--ink-soft: #ededed;
 		--muted: #8f8f8f;
-		--muted-2: #5c5c5c;
+		--muted-2: #6e6e6e;
 		--accent: #d71921;
+		--accent-fg: #ff4048;
+		--accent-hover: #e2262f;
 		--accent-soft: #ff5a5f;
 		--line: rgba(255, 255, 255, 0.14);
 		--line-strong: rgba(255, 255, 255, 0.32);
@@ -96,7 +112,7 @@ export const VINV_BASE_CSS = `
 		text-transform: uppercase;
 		color: var(--muted);
 	}
-	.v-label::before { content: '// '; color: var(--accent); }
+	.v-label::before { content: '// '; color: var(--accent-fg); }
 
 	/* serif-italic display heading */
 	.v-display {
@@ -147,7 +163,7 @@ export const VINV_BASE_CSS = `
 		width: 7px;
 		height: 7px;
 		border-radius: 50%;
-		background: var(--accent);
+		background: var(--accent-fg);
 		box-shadow: 0 0 0 4px rgba(215, 25, 33, 0.18);
 		animation: v-pulse 2.4s ease-in-out infinite;
 	}


### PR DESCRIPTION
…and light muted text

Palette (webviewTheme.ts + graph manual-theme overrides), measured against the actual backgrounds (ratios in the PR body):

- --muted-2: light #9a9a9a (2.81:1) -> #7a7a7a (4.29:1); dark #5c5c5c (3.14:1) -> #6e6e6e (4.12:1). Fixes barely-visible service/detail rows in the Flow panel on light themes.
- --muted: light #6b6b6b (5.33:1) -> #616161 (6.19:1); dark unchanged.
- New --accent-fg: the brand red used AS FOREGROUND (text, rings, arrows, dots) with per-theme lightness: light keeps #d71921 (5.18:1), dark uses #ff4048 (6.08:1) instead of the print red that sat at 4.05:1 on black and made the Runtime overlay unreadable. Same hue, lightness only.
- New --accent-hover: hover fill that keeps white text >= 4.5:1 per theme (#b3151c light / #e2262f dark); replaces --accent-soft hover fills whose white text measured 3.05:1.
- --accent stays #d71921 in both themes for solid fills paired with white text (5.18:1 either way).

Graph explorer:
- The hardcoded ACCENT JS constant is gone; canvas + detail panel read --accent-fg live, so overlays follow the theme toggle.
- Runtime mode: never-ran nodes render as full-strength layer-colored OUTLINES instead of 18%-alpha fills (which composited to ~1.2:1 and vanished on black); every layer outline now measures >= 3:1 on both themes while staying visually distinct from filled executed nodes.
- LAYER_COLORS.other #5c5c5c -> #6e6e6e (was exactly at the 3:1 floor).

Call tree flamegraph: per-theme label rule replaces the broken white-from threshold — dark always white (>= 6.3:1 at max red), light always ink with the red mix capped at 78% (ink 4.85:1 there; between 80-88% mix neither white nor ink reaches 4.5:1, which is why the old 65% switch still failed).