### PR TITLE
chore(pyproject): add [project.urls] to the Python engine packages

### DIFF
--- a/bringup/pyproject.toml
+++ b/bringup/pyproject.toml
@@ -22,6 +22,11 @@ dev = [
 [project.scripts]
 bringup = "bringup.cli:main"
 
+[project.urls]
+Homepage = "https://vinv.ai"
+Repository = "https://github.com/VinvAI/VinvAI"
+Issues = "https://github.com/VinvAI/VinvAI/issues"
+
 [tool.setuptools.package-dir]
 "" = "src"
 

--- a/contracts/pyproject.toml
+++ b/contracts/pyproject.toml
@@ -22,6 +22,11 @@ dev = [
     "hypothesis>=6.100.0,<7.0.0",
 ]
 
+[project.urls]
+Homepage = "https://vinv.ai"
+Repository = "https://github.com/VinvAI/VinvAI"
+Issues = "https://github.com/VinvAI/VinvAI/issues"
+
 [tool.setuptools.package-dir]
 "" = "src"
 

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -32,6 +32,11 @@ dev = [
     "ruff>=0.6.0,<0.9.0",
 ]
 
+[project.urls]
+Homepage = "https://vinv.ai"
+Repository = "https://github.com/VinvAI/VinvAI"
+Issues = "https://github.com/VinvAI/VinvAI/issues"
+
 [tool.setuptools.package-dir]
 "" = "src"
 

--- a/embedder/pyproject.toml
+++ b/embedder/pyproject.toml
@@ -26,6 +26,11 @@ dev = [
 [project.scripts]
 vinv-embedder = "vinv_embedder.cli:main"
 
+[project.urls]
+Homepage = "https://vinv.ai"
+Repository = "https://github.com/VinvAI/VinvAI"
+Issues = "https://github.com/VinvAI/VinvAI/issues"
+
 [tool.setuptools.package-dir]
 "" = "src"
 

--- a/exerciser/pyproject.toml
+++ b/exerciser/pyproject.toml
@@ -30,6 +30,11 @@ exerciser = "exerciser.cli:main"
 [tool.uv.sources]
 identification = { workspace = true }
 
+[project.urls]
+Homepage = "https://vinv.ai"
+Repository = "https://github.com/VinvAI/VinvAI"
+Issues = "https://github.com/VinvAI/VinvAI/issues"
+
 [tool.setuptools.package-dir]
 "" = "src"
 

--- a/goal/pyproject.toml
+++ b/goal/pyproject.toml
@@ -22,6 +22,11 @@ dev = [
 [project.scripts]
 goal = "goal.cli:main"
 
+[project.urls]
+Homepage = "https://vinv.ai"
+Repository = "https://github.com/VinvAI/VinvAI"
+Issues = "https://github.com/VinvAI/VinvAI/issues"
+
 [tool.setuptools.package-dir]
 "" = "src"
 

--- a/handbook/pyproject.toml
+++ b/handbook/pyproject.toml
@@ -22,6 +22,11 @@ dev = [
 [project.scripts]
 handbook = "handbook.cli:main"
 
+[project.urls]
+Homepage = "https://vinv.ai"
+Repository = "https://github.com/VinvAI/VinvAI"
+Issues = "https://github.com/VinvAI/VinvAI/issues"
+
 [tool.setuptools.package-dir]
 "" = "src"
 

--- a/identification/pyproject.toml
+++ b/identification/pyproject.toml
@@ -22,6 +22,11 @@ dev = [
 [project.scripts]
 identification = "identification.cli:main"
 
+[project.urls]
+Homepage = "https://vinv.ai"
+Repository = "https://github.com/VinvAI/VinvAI"
+Issues = "https://github.com/VinvAI/VinvAI/issues"
+
 [tool.setuptools.package-dir]
 "" = "src"
 

--- a/tracelens/pyproject.toml
+++ b/tracelens/pyproject.toml
@@ -67,6 +67,11 @@ tracelens = "tracelens.otel.configurator:TracelensConfigurator"
 [tool.uv.sources]
 lens-contracts = { workspace = true }
 
+[project.urls]
+Homepage = "https://vinv.ai"
+Repository = "https://github.com/VinvAI/VinvAI"
+Issues = "https://github.com/VinvAI/VinvAI/issues"
+
 [tool.setuptools.package-dir]
 "" = "src"
 


### PR DESCRIPTION
Closes #11.

Adds a `[project.urls]` table (Homepage / Repository / Issues) to all nine Python workspace members: contracts, core, tracelens, identification, handbook, bringup, goal, embedder, exerciser. This mirrors the `repository` link the Rust crate already sets in `index/Cargo.toml`.

- Purely additive package metadata; no code or dependency changes.
- `uv sync` still resolves (all tables validated as TOML).
