### PR TITLE
chore(pyproject): make the Python version policy consistent

### DIFF
--- a/bringup/pyproject.toml
+++ b/bringup/pyproject.toml
@@ -34,7 +34,7 @@ where = ["src"]
 "bringup" = ["prompts/*.txt"]
 
 [tool.ruff]
-target-version = "py313"
+target-version = "py312"
 line-length = 100
 src = ["src"]
 

--- a/contracts/pyproject.toml
+++ b/contracts/pyproject.toml
@@ -7,7 +7,7 @@ name = "lens-contracts"
 version = "0.1.0"
 description = "Canonical data contract for the lens system: SpanEvent, SampleEvent, ExternalCallEvent, ReplayCorpusRow, DeterminismBoundaryRecord."
 readme = "README.md"
-requires-python = ">=3.11,<3.14"
+requires-python = ">=3.11,<3.15"
 license = { text = "Apache-2.0" }
 dependencies = [
     "pydantic>=2.0.0,<3.0.0",

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -47,7 +47,7 @@ where = ["src"]
 litellm = { path = "vendor/litellm_stub", editable = true }
 
 [tool.ruff]
-target-version = "py313"
+target-version = "py312"
 line-length = 100
 src = ["src"]
 

--- a/exerciser/pyproject.toml
+++ b/exerciser/pyproject.toml
@@ -37,7 +37,7 @@ identification = { workspace = true }
 where = ["src"]
 
 [tool.ruff]
-target-version = "py313"
+target-version = "py312"
 line-length = 100
 src = ["src", "tests"]
 

--- a/goal/pyproject.toml
+++ b/goal/pyproject.toml
@@ -29,7 +29,7 @@ goal = "goal.cli:main"
 where = ["src"]
 
 [tool.ruff]
-target-version = "py313"
+target-version = "py312"
 line-length = 100
 src = ["src"]
 

--- a/handbook/pyproject.toml
+++ b/handbook/pyproject.toml
@@ -34,7 +34,7 @@ where = ["src"]
 "handbook" = ["prompts/*.txt"]
 
 [tool.ruff]
-target-version = "py313"
+target-version = "py312"
 line-length = 100
 src = ["src"]
 

--- a/identification/pyproject.toml
+++ b/identification/pyproject.toml
@@ -29,7 +29,7 @@ identification = "identification.cli:main"
 where = ["src"]
 
 [tool.ruff]
-target-version = "py313"
+target-version = "py312"
 line-length = 100
 src = ["src"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,11 @@ dev = [
     "ruff>=0.6.0,<0.9.0",
 ]
 
+# Python version policy (see issue #14). Ceiling is <3.15 for every member.
+# Floors are tiered by role, and each member's ruff `target-version` matches its
+# own floor: embedder >=3.10 (standalone embedding sidecar — widest reach),
+# contracts and tracelens >=3.11 (the data contract and the tracer, which run
+# against third-party targets), and every other engine >=3.12.
 [tool.uv.workspace]
 members = [
     "contracts",


### PR DESCRIPTION
Closes #14.

- Upper bound standardized to `<3.15` on every member (`contracts` was `<3.14`).
- Each package's ruff `target-version` now matches its own `requires-python` floor (the `>=3.12` engines were pinned to `py313`, so ruff wasn't actually enforcing 3.12 compatibility).
- The tiered-floor policy is documented in the root `pyproject.toml`.

Floors stay intentionally tiered by role (embedder `>=3.10` standalone sidecar; contracts/tracelens `>=3.11`; the rest `>=3.12`) rather than forced to a single value — lowering the 3.12 engines could hide real 3.12-only usage. Verified: floor == ruff target-version for all nine, ceiling uniform, root parses.