### PR TITLE
docs(e2e): note the Windows interpreter path in the planted-bug README

### DIFF
--- a/tests/e2e/planted_bug_golden/README.md
+++ b/tests/e2e/planted_bug_golden/README.md
@@ -39,7 +39,8 @@ Prefer the Tracelens project venv (has `click` and other deps):
 ./tracelens/.venv/bin/python tests/e2e/planted_bug_golden/run.py --real-tracelens
 ```
 
-The runner auto-selects `tracelens/.venv/bin/python` when present. The fixture
+The runner auto-selects `tracelens/.venv/bin/python` (or
+`tracelens\.venv\Scripts\python` on Windows) when present. The fixture
 supplies a local test-only licensing shim for this E2E process. It does not
 alter or bypass production module code.
 


### PR DESCRIPTION
Closes #15.

Adds the Windows `tracelens\.venv\Scripts\python` equivalent to the one remaining POSIX-only venv path (the `handbook` and `tracelens` READMEs already got this note in an earlier pass). After this, `git grep .venv/bin -- '*/README.md'` has a Windows note next to every occurrence.