### PR TITLE
fix(optimize): honest verdict markers — dismissed status, watcher diff-gate, auto-measure on accept

### DIFF
--- a/extension/src/harness/autoTrigger.ts
+++ b/extension/src/harness/autoTrigger.ts
@@ -997,6 +997,7 @@ export async function runVerifiedHotspotEpisode(
 		deps,
 	);
 	announceVerdict(result, plan.label);
+	await autoMeasureAfterUnproven(result);
 }
 
 /** Cache sweep through the same verdict engine (see runVerifiedHotspotEpisode). */
@@ -1022,6 +1023,28 @@ export async function runVerifiedCacheSweep(
 		deps,
 	);
 	announceVerdict(result, plan.label);
+	await autoMeasureAfterUnproven(result);
+}
+
+/**
+ * Auto-measure after an accepted-but-unmeasured optimization. When the verdict
+ * engine could NOT self-measure the after-run (mode 'fallback' — the exercised
+ * flow has no auto-replayable probe, e.g. an auth'd POST endpoint), the
+ * operator's accept keeps the fix but leaves no before/after. Rather than making
+ * them click "Measure Optimization" by hand, kick off the re-trace automatically
+ * so the predicted→proven comparison runs on accept. A bridge-measured verdict
+ * ('verdict') already carries its CI; a declined episode ('declined') changed
+ * nothing — neither needs this.
+ */
+async function autoMeasureAfterUnproven(result: OptimizeRunResult): Promise<void> {
+	if (result.mode !== 'fallback') {
+		return;
+	}
+	try {
+		await vscode.commands.executeCommand('vinv-vs.measureOptimization');
+	} catch {
+		// Best-effort: the manual "Measure Optimization" command remains available.
+	}
 }
 
 /** One closing notification per engine-judged episode. */

--- a/extension/src/harness/episodeLoop.ts
+++ b/extension/src/harness/episodeLoop.ts
@@ -23,6 +23,30 @@ import { buildGraphSnapshot, hasIndexStore, type GraphSnapshot } from '../graph/
 import { enrichTagsFromFeedback } from '../graph/graphEnhancer';
 import { deriveSeedRows, packBudgets, writeContextPack, type PackTask } from './contextPack';
 import type { IndexHit } from '../qna/answer';
+import { optimizationSourceInstance } from '../views/optimizationSource';
+
+/**
+ * When the operator accepts an agent's dispute on an OPTIMIZE episode ("agree
+ * there is no issue"), the ranked opportunity is not real. Mark its row(s)
+ * DISMISSED so the Optimize panel shows a terminal "not a real opportunity"
+ * badge carrying the dispute, instead of leaving the row stuck at 'dispatched'
+ * (a non-measurable symbol never gets a session-timing verdict, so nothing else
+ * would ever resolve it). Guarded by task.optimization so only optimize
+ * episodes touch the board — a no-op for service-fix / error-cluster episodes.
+ */
+function dismissDisputedOptimization(root: string, task: EpisodeTask, dispute: string): void {
+	try {
+		const source = optimizationSourceInstance();
+		if (!source || !task.optimization) {
+			return;
+		}
+		for (const row of task.seedRows ?? []) {
+			source.dismissRow(root, row, dispute);
+		}
+	} catch {
+		// Panel bookkeeping must never break the episode's own completion.
+	}
+}
 
 /**
  * Renders the winning pack's cited symbols as retrieval hits so a verified
@@ -1660,6 +1684,11 @@ export async function runEpisode(
 							);
 							if (call === 'approve') {
 								verified = true;
+								// The operator agreed the disputed premise is not real — for an
+								// optimize episode that means the ranked row is not a genuine
+								// opportunity, so record it dismissed (a terminal panel badge)
+								// rather than leaving it stuck 'dispatched'.
+								dismissDisputedOptimization(workspaceRoot, task, directives.dispute);
 								queueProposalEpisodes(selectedProposals);
 								return;
 							}

--- a/extension/src/harness/optimizationAnalysis.ts
+++ b/extension/src/harness/optimizationAnalysis.ts
@@ -97,7 +97,8 @@ export type OptimizationStatus =
 	| 'dispatched' // an episode is running / awaiting a fresh after-run
 	| 'proven' // after-run measured a drop beyond the noise band
 	| 'inconclusive' // after-run landed inside the noise band — no honest claim
-	| 'regressed'; // after-run measured a rise beyond the noise band
+	| 'regressed' // after-run measured a rise beyond the noise band
+	| 'dismissed'; // agent disputed the premise and the operator agreed — not a real opportunity
 
 /** The measured result of a dispatched optimization, filled by the after-run. */
 export interface OptimizationOutcome {
@@ -137,6 +138,19 @@ export interface OptimizationOutcome {
 	};
 	/** True when the change was actually rolled back (revertToSnapshot ran). */
 	reverted?: boolean;
+	/**
+	 * When status is 'dismissed': the agent's dispute the operator agreed with
+	 * (verbatim, truncated) — the reason this ranked row is not a real
+	 * optimization opportunity. No measurement was taken.
+	 */
+	dismiss_note?: string;
+	/**
+	 * Working-tree diff signature captured at dispatch. The watcher compares it to
+	 * the current signature to tell a REAL fix (signature changed since dispatch —
+	 * anywhere, including callee files the symbol depends on) from a no-op dispute
+	 * (signature unchanged), instead of only checking the symbol's own file.
+	 */
+	dispatch_diff_sig?: string;
 }
 
 /** One ranked optimization opportunity. */
@@ -948,6 +962,7 @@ export function reconcileOutcome(
 	candidate: OptimizationCandidate,
 	timings: SymbolSessionTiming[] | undefined,
 	behaviorOk: boolean,
+	codeChanged = true,
 ): OptimizationCandidate {
 	if (candidate.status !== 'dispatched' || !candidate.outcome) {
 		return candidate;
@@ -960,6 +975,30 @@ export function reconcileOutcome(
 	const after = l.total_ms;
 	const delta = after - candidate.outcome.measured_before;
 	const band = candidate.outcome.noise_band_ms;
+	// Integrity gate: the watcher judges by session timing ALONE, so a symbol
+	// whose file was never changed must not be credited with a "proven" win (nor
+	// blamed for a "regressed"). Cold→warm variance on a network-I/O symbol (e.g.
+	// an MCP/TLS handshake ~17s cold at boot and ~3s warm) can dwarf the noise
+	// band and fake a huge speedup for a fix that never happened. With no code
+	// diff, the honest verdict is DISMISSED — nothing was optimized. (Signal is
+	// "uncommitted change to the file"; committing mid-verdict could hide a real
+	// change, but erring toward "not a win" never fabricates one.)
+	if (!codeChanged) {
+		return {
+			...candidate,
+			status: 'dismissed',
+			total_ms: after,
+			outcome: {
+				...candidate.outcome,
+				measured_after: after,
+				delta_ms: delta,
+				behavior_ok: behaviorOk,
+				dismiss_note:
+					`No code change was made for this symbol, so the measured ${Math.round(Math.abs(delta))}${candidate.unit === 'bytes' ? ' bytes' : 'ms'} ` +
+					'difference is run-to-run variance (e.g. a cold vs warm run), not a verified optimization.',
+			},
+		};
+	}
 	let status: OptimizationStatus;
 	if (!behaviorOk) {
 		// A behavior change disqualifies any timing claim — the fix broke

--- a/extension/src/test/optimizationAnalysis.test.ts
+++ b/extension/src/test/optimizationAnalysis.test.ts
@@ -445,6 +445,25 @@ suite('optimizationAnalysis: predicted → proven loop', () => {
 		assert.strictEqual(done.outcome!.measured_after, 40);
 	});
 
+	test('a big drop with NO code change is DISMISSED, not proven (watcher integrity)', () => {
+		const d = markDispatched(candidate, [timing('s1', 200, 100)], 't');
+		// The same 160ms drop that reads PROVEN above — but with no file diff the
+		// move is cold→warm variance, not a fix, so it must never be credited.
+		const done = reconcileOutcome(d, [timing('s1', 200, 100), timing('s2', 40, 100)], true, false);
+		assert.strictEqual(done.status, 'dismissed');
+		assert.ok(
+			done.outcome!.dismiss_note && done.outcome!.dismiss_note.includes('No code change'),
+			'dismiss note explains why',
+		);
+		assert.strictEqual(done.outcome!.measured_after, 40);
+	});
+
+	test('the same drop WITH a code change is still PROVEN (gate open by default)', () => {
+		const d = markDispatched(candidate, [timing('s1', 200, 100)], 't');
+		const done = reconcileOutcome(d, [timing('s1', 200, 100), timing('s2', 40, 100)], true, true);
+		assert.strictEqual(done.status, 'proven');
+	});
+
 	test('a drop inside the band is INCONCLUSIVE (no false proof)', () => {
 		const d = markDispatched(candidate, [timing('s1', 200, 100)], 't');
 		const done = reconcileOutcome(d, [timing('s1', 200, 100), timing('s2', 190, 100)], true);

--- a/extension/src/test/viewHtml.test.ts
+++ b/extension/src/test/viewHtml.test.ts
@@ -222,6 +222,21 @@ suite('optimization report: verdict copy, direction, glossary, optional fields',
 		assert.ok(html.includes('title="Noise band:'));
 	});
 
+	test('a dismissed opportunity renders a terminal badge carrying the dispute', () => {
+		const html = api().verdict({
+			status: 'dismissed',
+			outcome: { dismiss_note: 'one-time import cost, not amortizable across processes' },
+		});
+		assert.ok(html.includes('Dismissed — not a real opportunity'), `dismissed badge: ${html}`);
+		assert.ok(html.includes('no change was made'), 'states nothing was changed');
+		assert.ok(html.includes('one-time import cost'), 'carries the verbatim dispute note');
+	});
+
+	test('a dismissed card gets the dismissed row class', () => {
+		const html = api().card({ ...base, status: 'dismissed', outcome: { dismiss_note: 'n/a' } }, 100);
+		assert.ok(html.includes('row dismissed'), `card class: ${html}`);
+	});
+
 	test('the measured axis label carries the direction on both sides', () => {
 		const slower = api().axis({ ...base, status: 'regressed', outcome: { delta_ms: 12 } }, 100);
 		assert.ok(slower.includes('measured 12ms slower'), slower);

--- a/extension/src/views/optimizationReportView.ts
+++ b/extension/src/views/optimizationReportView.ts
@@ -220,6 +220,7 @@ function getReportHtml(): string {
 		.row.working { border-color: var(--accent-fg); }
 		.row.proven { border-left: 3px solid var(--ink); }
 		.row.regressed { border-left: 3px solid var(--accent-fg); }
+		.row.dismissed { border-left: 3px solid var(--muted-2); opacity: 0.9; }
 		.rhd { display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; }
 		.rhd .nm { font-weight: 600; font-size: 14px; }
 		.rhd .loc { color: var(--muted-2); font-size: 10.5px; }
@@ -239,6 +240,7 @@ function getReportHtml(): string {
 		.verdict { padding: 8px 10px; border: 1px solid var(--line); margin: 2px 0 10px; line-height: 1.55; }
 		.verdict.proven { border-color: var(--ink); }
 		.verdict.regressed { border-color: var(--accent-fg); color: var(--accent-fg); }
+		.verdict.dismissed { border-color: var(--muted-2); color: var(--muted); }
 		.verdict b { letter-spacing: 0.02em; }
 		.acts { display: flex; gap: 8px; flex-wrap: wrap; }
 		.acts button { padding: 6px 13px; cursor: pointer; border-radius: 0; font-family: inherit; font-size: 9px; font-weight: 500; letter-spacing: 0.18em; text-transform: uppercase; transition: background 0.2s, color 0.2s, border-color 0.2s; }
@@ -309,6 +311,7 @@ function getReportHtml(): string {
 			const open = cands.filter((c) => c.status === 'candidate');
 			const proven = cands.filter((c) => c.status === 'proven');
 			const working = cands.filter((c) => c.status === 'dispatched');
+			const dismissed = cands.filter((c) => c.status === 'dismissed');
 			const recTime = open.filter((c) => (c.unit || 'ms') === 'ms').reduce((s, c) => s + c.predicted_ms, 0);
 			const recMem = open.filter((c) => c.unit === 'bytes').reduce((s, c) => s + c.predicted_ms, 0);
 			const t = [
@@ -317,6 +320,7 @@ function getReportHtml(): string {
 				{ k: 'Recoverable memory', v: recMem > 0 ? '~' + fmtBytes(recMem) : '—' },
 				{ k: 'In progress', v: working.length },
 			];
+			if (dismissed.length > 0) { t.push({ k: 'Dismissed', v: dismissed.length }); }
 			document.getElementById('tiles').innerHTML = t.map((x) =>
 				'<div class="tile' + (x.hot ? ' hot' : '') + (x.good ? ' good' : '') + '"><div class="k">' + x.k + '</div><div class="v">' + x.v + '</div></div>').join('');
 		}
@@ -369,11 +373,15 @@ function getReportHtml(): string {
 						: 'the change landed inside the ±' + amt(c.unit, o.noise_band_ms || 0) + ' ' + gloss('noise band', 'noise') + ', so no honest win can be claimed.') +
 					ciNote + (kept || noAutoRevert) + '</div>';
 			}
+			if (c.status === 'dismissed') {
+				const note = o.dismiss_note ? ' ' + esc(o.dismiss_note) : '';
+				return '<div class="verdict dismissed"><b>Dismissed — not a real opportunity</b> — the coding agent disputed the premise and you agreed, so no change was made.' + note + '</div>';
+			}
 			return '';
 		}
 
 		function card(c, scale) {
-			const cls = c.status === 'dispatched' ? 'working' : (c.status === 'proven' ? 'proven' : (c.status === 'regressed' ? 'regressed' : ''));
+			const cls = c.status === 'dispatched' ? 'working' : (c.status === 'proven' ? 'proven' : (c.status === 'regressed' ? 'regressed' : (c.status === 'dismissed' ? 'dismissed' : '')));
 			let h = '<div class="row ' + cls + '">';
 			h += '<div class="rhd"><span class="nm">' + esc(c.name) + '</span>' +
 				'<span class="tag ' + esc(c.waste_kind) + '"' + (KIND_TIP[c.waste_kind] ? ' title="' + KIND_TIP[c.waste_kind] + '"' : '') + '>' + (KIND[c.waste_kind] || esc(c.waste_kind)) + '</span>' +

--- a/extension/src/views/optimizationSource.ts
+++ b/extension/src/views/optimizationSource.ts
@@ -18,6 +18,8 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
+import { execFileSync } from 'child_process';
+import { createHash } from 'crypto';
 import {
 	hasIndexStore,
 	indexStoreDir,
@@ -256,6 +258,9 @@ export class OptimizationSource implements vscode.Disposable {
 			// (paired-bootstrap CI bound to the episode); the capture watcher must
 			// leave them alone rather than reconcile against "any newer session".
 			frozen.outcome.engine = opts.engine ?? 'watch';
+			// Snapshot the working tree at dispatch, so the watcher can later tell a
+			// real fix (diff changed since here — incl. callee files) from a no-op.
+			frozen.outcome.dispatch_diff_sig = this.workingTreeDiffSig(root) ?? undefined;
 		}
 		this.tracked.set(row, frozen);
 		this.rebuildModelFrom(this.memoCandidates, root);
@@ -312,6 +317,45 @@ export class OptimizationSource implements vscode.Disposable {
 		return resolved;
 	}
 
+	/**
+	 * Marks a row DISMISSED — the operator agreed with the agent's dispute that
+	 * this is not a real optimization opportunity. Terminal: it stays visible in
+	 * the panel with the dispute note instead of leaving the row stuck at
+	 * 'dispatched' forever (a non-measurable symbol — e.g. a one-time import cost
+	 * — never gets a session-timing verdict, so nothing else ever resolves it).
+	 * No-op when the row was never a tracked/known candidate (e.g. a service-fix
+	 * episode's seed row) or already carries a measured terminal verdict.
+	 */
+	dismissRow(root: string, row: number, note?: string): OptimizationCandidate | undefined {
+		const existing = this.tracked.get(row) ?? this.model.candidates.find((c) => c.row === row);
+		if (!existing) {
+			return undefined; // not an optimize candidate — nothing to mark
+		}
+		if (
+			existing.status === 'proven' ||
+			existing.status === 'regressed' ||
+			existing.status === 'dismissed'
+		) {
+			return existing; // a real measured verdict (or a prior dismissal) wins
+		}
+		const dismissed: OptimizationCandidate = {
+			...existing,
+			status: 'dismissed',
+			outcome: {
+				predicted_ms: existing.outcome?.predicted_ms ?? existing.predicted_ms,
+				measured_before: existing.outcome?.measured_before ?? existing.total_ms,
+				noise_band_ms: existing.outcome?.noise_band_ms ?? 0,
+				baseline_sessions: existing.outcome?.baseline_sessions ?? 0,
+				before_session: existing.outcome?.before_session ?? '',
+				episode_title: existing.outcome?.episode_title ?? `Optimize ${existing.name}`,
+				dismiss_note: note?.slice(0, 600),
+			},
+		};
+		this.tracked.set(row, dismissed);
+		this.rebuildModelFrom(this.memoCandidates, root);
+		return dismissed;
+	}
+
 	private seedTrackedFromDisk(): void {
 		const root = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
 		if (!root) {
@@ -336,6 +380,35 @@ export class OptimizationSource implements vscode.Disposable {
 	private behaviorOk(overlay: Record<number, RuntimeOverlay>, row: number): boolean {
 		const rt = overlay[row];
 		return !rt || rt.current_errors === 0;
+	}
+
+	/**
+	 * A hash of the working tree (tracked diff vs HEAD + untracked status) — the
+	 * watcher's integrity signal. Captured at dispatch and compared at reconcile:
+	 * if it changed, a fix was applied SOMEWHERE (including a callee file the
+	 * symbol depends on), so a measured drop is attributable; if it is identical,
+	 * nothing was changed and a "proven" would be a cold→warm-variance false
+	 * positive. Returns null when git cannot answer, so the caller falls back to
+	 * the prior timing-only behavior rather than over-dismissing.
+	 */
+	private workingTreeDiffSig(root: string): string | null {
+		try {
+			const diff = execFileSync('git', ['diff', 'HEAD', '--'], {
+				cwd: root,
+				encoding: 'utf8',
+				maxBuffer: 32 * 1024 * 1024,
+				timeout: 6000,
+			});
+			const status = execFileSync('git', ['status', '--porcelain'], {
+				cwd: root,
+				encoding: 'utf8',
+				maxBuffer: 8 * 1024 * 1024,
+				timeout: 6000,
+			});
+			return createHash('sha1').update(diff).update(' ').update(status).digest('hex');
+		} catch {
+			return null; // no repo / git unavailable / timeout — cannot confirm
+		}
 	}
 
 	private async refresh(): Promise<void> {
@@ -450,9 +523,23 @@ export class OptimizationSource implements vscode.Disposable {
 		// outcome remains visible until a later analysis supersedes the row.
 		// Bridge-owned rows are exempt: their verdict comes from the episode-bound
 		// paired-bootstrap engine, never from whatever capture landed most recently.
+		//
+		// Integrity gate: the session-timing watcher may only credit a "proven"
+		// (or blame a "regressed") for a symbol whose fix actually landed in the
+		// working tree since dispatch — otherwise cold→warm variance on a
+		// network-I/O symbol fakes a huge win for a change that never happened. The
+		// dispatch-diff signature catches fixes in callee files too, not just the
+		// symbol's own. Unknown sig → fall back to prior behavior, never over-dismiss.
+		const currentSig = this.workingTreeDiffSig(root);
 		for (const [row, tracked] of this.tracked) {
 			if (tracked.status === 'dispatched' && tracked.outcome?.engine !== 'bridge') {
-				this.tracked.set(row, reconcileOutcome(tracked, timings.get(row), this.behaviorOk(overlay, row)));
+				const dispatchSig = tracked.outcome?.dispatch_diff_sig;
+				const codeChanged =
+					currentSig === null || !dispatchSig ? true : currentSig !== dispatchSig;
+				this.tracked.set(
+					row,
+					reconcileOutcome(tracked, timings.get(row), this.behaviorOk(overlay, row), codeChanged),
+				);
 			}
 		}
 


### PR DESCRIPTION
## Problem
The Optimize panel could show misleading verdicts:
- A disputed opportunity left **no marker** — the row stayed stuck at `dispatched`.
- The session-timing **watcher stamped a false `proven`** on a symbol that never changed (e.g. an MCP/TLS `connect` ~17s cold at boot vs ~3s warm — cold→warm variance dwarfing the noise band).
- An **accepted-but-unmeasured** optimization did nothing further (no before/after).

## Changes
- **`dismissed` terminal status** + verdict badge + panel tile; accepting an agent's dispute marks the row dismissed with its reasoning.
- **Watcher integrity gate**: the reconcile credits `proven`/`regressed` only when a **dispatch-time working-tree diff signature** changed — a fix that actually landed, **including in a callee file** the symbol depends on. No diff → dismissed (unit-aware note), never variance-driven false `proven`.
- **Auto-measure on accept** (`autoMeasureAfterUnproven`): when an accepted episode can't self-measure (`mode: 'fallback'`), auto-trigger the re-trace.
- Tests for the code-diff gate and the dismissed rendering.

## Verification
- `npm run check` (tsc) + `eslint` clean.
- Live in a VSIX build: `connect` (no change) → **Dismissed** instead of a fake "Proven 14s faster"; a real memory fix (`log_task` via `sanitize_for_rich`) → **Proven ~601 KB lighter**, correctly attributed to the callee-file change.

## Known limitation (follow-up)
Auth'd endpoints (e.g. `POST /chat` with a token'd body) still have no auto-replayable probe, so their before/after needs a recorded driver; the auto-measure fires but reports "needs a driver" for those.