### PR TITLE
Fix/target interpreter resolution

### DIFF
--- a/exerciser/src/exerciser/campaign.py
+++ b/exerciser/src/exerciser/campaign.py
@@ -146,6 +146,16 @@ class Play:
     # `issues.json`. So five complete oracles could run, find real defects, and
     # surface nothing: the dispatch path had no document to look at.
     clusters: tuple[dict[str, Any], ...] = ()
+    # What the oracle said about the RUN rather than about a target. An oracle
+    # that could not import the code under test reports it, and the campaign
+    # dropped it on the floor: `_functions_runner` kept clusters, violations and
+    # a two-key detail, so `status: "environment"` and the import canary died at
+    # the runner boundary and the campaign still answered `status: "ok"` with
+    # zero findings — the exact ambiguity the canary exists to remove, on the
+    # command the extension actually runs.
+    diagnostics: tuple[str, ...] = ()
+    #: Non-"ok" only when the oracle says the run itself was not valid.
+    status: str = "ok"
 
 
 # A runner is bound to its repo/config by ``default_runners``; the campaign
@@ -510,6 +520,21 @@ def _clusters_of(
     )
 
 
+def _diagnostics_of(result: dict[str, Any]) -> tuple[str, ...]:
+    """What an oracle said about the RUN, carried up to the campaign's report.
+
+    Every oracle already produced these and every runner threw them away, so a
+    finding about the apparatus — no importable target, an interpreter without
+    the repo installed, a shared unmet precondition — reached `functions.json`
+    and stopped there. The campaign's own summary is what the CLI prints and
+    what a human reads, and it said nothing.
+    """
+    found = result.get("diagnostics")
+    if not isinstance(found, list):
+        return ()
+    return tuple(str(d) for d in found if isinstance(d, str) and d)
+
+
 def _functions_runner(cfg: OracleConfig) -> OracleRunner:
     from .functions import run_functions
 
@@ -539,6 +564,7 @@ def _functions_runner(cfg: OracleConfig) -> OracleRunner:
         # oracle and the adjudication channel can put a real label on it.
         violations, signatures = _findings(result, target=action.target)
         clusters = _clusters_of(result, target=action.target)
+        canary = result.get("import_canary") or {}
         return Play(
             clusters=clusters,
             violations=violations,
@@ -546,7 +572,16 @@ def _functions_runner(cfg: OracleConfig) -> OracleRunner:
             covered=(action.target,),
             subprocesses=subprocesses,
             work=_as_count(result.get("calls")),
-            detail={"calls": result.get("calls"), "verdicts": result.get("verdicts")},
+            diagnostics=_diagnostics_of(result),
+            status=str(result.get("status") or "ok"),
+            detail={
+                "calls": result.get("calls"),
+                "verdicts": result.get("verdicts"),
+                # The one fact that decides whether this play's zero means
+                # anything: a worker that never imported the target found
+                # nothing BECAUSE it never ran it.
+                "own_packages_unimportable": list(canary.get("own_packages_unimportable") or ()),
+            },
         )
 
     return run
@@ -577,6 +612,8 @@ def _differential_runner(cfg: OracleConfig) -> OracleRunner:
             signatures=signatures,
             covered=(action.target,),
             subprocesses=1,
+            diagnostics=_diagnostics_of(result),
+            status=str(result.get("status") or "ok"),
             work=_as_count(result.get("comparisons")),
             detail={
                 "comparisons": result.get("comparisons"),
@@ -641,6 +678,8 @@ def _faults_runner(cfg: OracleConfig) -> OracleRunner:
             signatures=signatures,
             covered=(action.target,),
             subprocesses=1,
+            diagnostics=_diagnostics_of(result),
+            status=str(result.get("status") or "ok"),
             work=_as_count(result.get("faults_injected")),
             detail={"faults_injected": result.get("faults_injected")},
         )
@@ -693,6 +732,8 @@ def _concurrency_runner(cfg: OracleConfig) -> OracleRunner:
             signatures=signatures,
             covered=(action.target,),
             subprocesses=1,
+            diagnostics=_diagnostics_of(result),
+            status=str(result.get("status") or "ok"),
             detail={"worker_timed_out": result.get("worker_timed_out")},
         )
 
@@ -749,6 +790,8 @@ def _environment_runner(cfg: OracleConfig) -> OracleRunner:
             signatures=signatures,
             covered=(action.target,),
             subprocesses=1,
+            diagnostics=_diagnostics_of(result),
+            status=str(result.get("status") or "ok"),
             detail={"status": result.get("status")},
         )
 
@@ -836,7 +879,13 @@ def run_campaign(
         log.warning("campaign_empty %s", diagnostics[-1])
         return {
             "status": "ok",
+            # Same keys as the main return: a caller that reads `interpreter`
+            # must not have to know which branch produced the document, and the
+            # empty-action case is exactly when "which environment was this?" is
+            # the question being asked.
+            "own_packages_unimportable": [],
             "diagnostics": diagnostics,
+            "interpreter": interpreter_choice.to_json(),
             "repo": str(repo),
             "actions": 0,
             "budget": budget,
@@ -870,6 +919,11 @@ def run_campaign(
     rng = random.Random(seed)
     covered_ground: set[str] = set()
     plays: list[dict[str, Any]] = []
+    # An oracle's run-level findings, deduped: the campaign replays the same arm
+    # many times, and one unimportable repo repeated twenty times is one fact.
+    oracle_diagnostics: dict[str, None] = {}
+    unimportable: dict[str, None] = {}
+    environment_plays = 0
     # signature -> cluster object, for the issues document written at the end.
     reported_clusters: dict[str, dict[str, Any]] = {}
     stale = 0
@@ -902,6 +956,16 @@ def run_campaign(
             play = Play(error=f"{type(exc).__name__}: {exc}")
             log.warning("campaign: %s raised %s", action.key, exc)
         elapsed = time.perf_counter() - started
+
+        # What the oracle said about the run itself, kept once however many plays
+        # repeat it. Dropping this is how a campaign over a repo it could not
+        # import still answered `status: "ok"` with an empty `diagnostics`.
+        for diag in play.diagnostics:
+            oracle_diagnostics[diag] = None
+        if play.status == "environment":
+            environment_plays += 1
+        for name in play.detail.get("own_packages_unimportable") or ():
+            unimportable[str(name)] = None
 
         # An inconclusive play measured nothing, so it claims no ground and posts
         # no posterior update — it is billed for the time it burned (the budget
@@ -994,9 +1058,27 @@ def run_campaign(
             "--python at the interpreter where the target's own dependencies are "
             "installed."
         )
+    diagnostics.extend(oracle_diagnostics)
+
+    # A campaign that could not load the code under test found nothing BECAUSE it
+    # never ran it, and that is not the claim `status: "ok"` makes. The oracles
+    # already decided this per play; until now the answer stopped at the runner
+    # boundary and the campaign — the command the extension runs — reported a
+    # clean zero anyway, which is the whole failure this branch exists to fix.
+    blocked = bool(unimportable) and environment_plays > 0
+    if blocked:
+        diagnostics.append(
+            f"{environment_plays}/{len(plays)} plays could not import the repo's own "
+            f"package(s) {', '.join(sorted(unimportable))} under {python}. This run "
+            "measured the environment, not the code — its zero is not a clean result."
+        )
+        log.warning("campaign_environment %s", diagnostics[-1])
 
     result: dict[str, Any] = {
-        "status": "ok",
+        "status": "environment" if blocked else "ok",
+        # The repo's own packages no play could import, empty on a healthy run.
+        # `status` alone cannot be acted on; this says what to install where.
+        "own_packages_unimportable": sorted(unimportable),
         "diagnostics": diagnostics,
         # The interpreter every oracle's workers ran under. `inconclusive_plays`
         # says budget reached no target; this says which environment it was spent

--- a/exerciser/src/exerciser/campaign.py
+++ b/exerciser/src/exerciser/campaign.py
@@ -333,12 +333,30 @@ def enumerate_actions(
             # so in a note that no code path ever acted on. The drivable targets
             # are already catalogued and their annotations already declare a
             # domain, so derive from those instead of reporting the vacuum.
-            derived = faults.derive_boundaries(repo, function_targets[:max_targets], python)
+            #
+            # This is the one part of enumeration that IMPORTS the target: a
+            # signature cannot be read without loading the module that defines
+            # it. Batched into one subprocess for that reason — and it is why
+            # `python` is threaded in, so the import happens where the repo's
+            # dependencies are.
+            derived, refused = faults.derive_boundaries(
+                repo, function_targets[:max_targets], python
+            )
             if derived:
                 space.notes.append(
                     f"no boundaries.json — derived {len(derived)} boundary(ies) from the "
-                    "consumers' own annotations"
+                    f"consumers' own annotations, and refused {len(refused)}"
                 )
+            if refused:
+                # A refusal is a fact about the repo, and one it can act on:
+                # "annotate this parameter and the oracle arms here". Counting
+                # them without saying why is how the first cut of this armed 17
+                # boundaries that could never fire and said nothing.
+                by_reason: dict[str, int] = {}
+                for reason in refused.values():
+                    by_reason[reason] = by_reason.get(reason, 0) + 1
+                for reason, count in sorted(by_reason.items(), key=lambda kv: (-kv[1], kv[0])):
+                    space.notes.append(f"fault oracle skipped {count} target(s): {reason}")
             boundaries = derived
         for b in boundaries:
             space.boundaries[b.target] = b
@@ -399,6 +417,9 @@ class OracleConfig:
     # Cross-play state: HTTP issue clusters are cumulative in issues.json, so a
     # play's violations are the DELTA it caused.
     _http_clusters: int = 0
+    # target -> its annotated contract. Reading one costs a subprocess and a
+    # module import, and the bandit replays arms — see `_valid_kwargs_for`.
+    _signature_contracts: dict[str, dict[str, str]] = field(default_factory=dict)
 
 
 def _cluster_signature(cluster: dict[str, Any]) -> str:
@@ -696,14 +717,23 @@ def _valid_kwargs_for(cfg: OracleConfig, target: str) -> dict[str, Any]:
     oracle did not merely miss the bug, it actively CERTIFIED the target as
     concurrency-safe. ``functions`` already knows how to build these; the
     signature is read out-of-process by the same helper the faults oracle uses.
+
+    Memoised on the config, because the bandit REPLAYS an arm: reading one
+    signature costs a subprocess and a module import, and the campaign paid it
+    again on every draw of the same target. The answer cannot change mid-run —
+    it is read from the same files enumeration already read.
     """
     from .faults import infer_contract_from_signature
     from .functions import resolved_value_for
 
-    try:
-        contract = infer_contract_from_signature(target, cfg.python, cfg.repo)
-    except Exception:  # a signature we cannot read is not worth failing a play
-        return {}
+    cached = cfg._signature_contracts.get(target)
+    if cached is None:
+        try:
+            cached = infer_contract_from_signature(target, cfg.python, cfg.repo)
+        except Exception:  # a signature we cannot read is not worth failing a play
+            cached = {}
+        cfg._signature_contracts[target] = cached
+    contract = cached
     kwargs: dict[str, Any] = {}
     for name, annotation in contract.items():
         value, _resolved = resolved_value_for(annotation, "valid")

--- a/exerciser/src/exerciser/campaign.py
+++ b/exerciser/src/exerciser/campaign.py
@@ -101,6 +101,16 @@ def campaign_path(repo: Path) -> Path:
     return store.exercise_dir(repo) / "campaign.json"
 
 
+def result_path(repo: Path) -> Path:
+    """Where the last campaign's SUMMARY lands.
+
+    Distinct from ``campaign.json``, which is the bandit's persisted state and is
+    read back to warm-start the next run. This is the run's verdict, for whoever
+    reads artifacts rather than stdout.
+    """
+    return store.exercise_dir(repo) / "campaign_result.json"
+
+
 # =========================================================================
 # One play
 # =========================================================================
@@ -907,7 +917,7 @@ def run_campaign(
             "which oracle was missing what."
         )
         log.warning("campaign_empty %s", diagnostics[-1])
-        return {
+        empty: dict[str, Any] = {
             "status": "ok",
             # Same keys as the main return: a caller that reads `interpreter`
             # must not have to know which branch produced the document, and the
@@ -924,6 +934,11 @@ def run_campaign(
             "violations": 0,
             "stopped": "no-actions",
         }
+        # Persisted on this branch too: "no oracle could be armed" is a verdict
+        # about the run, and the reader must not have to guess from an absent
+        # file whether the campaign said nothing or never finished.
+        store.write_json(result_path(repo), {k: v for k, v in empty.items() if k != "plays"})
+        return empty
 
     # Warm start: last campaign's posteriors, decayed, restricted to the actions
     # that are STILL armed — a target that has since vanished must not keep a
@@ -1142,6 +1157,15 @@ def run_campaign(
         "plays": plays,
         "campaign_file": str(campaign_path(repo)),
     }
+    # PERSISTED, not only printed. `status`, `own_packages_unimportable` and the
+    # oracles' diagnostics describe the whole run, and they existed on stdout
+    # only — so the extension, which reads artifacts, fell back to
+    # `functions.json`. That file is rewritten by every crash play with
+    # `only_targets=[one]`, so the verdict it showed was ONE arm's, computed over
+    # a single module, presented as the run's — and stale from a previous run
+    # entirely when no crash play was drawn. Writing the summary is what lets a
+    # reader ask the run rather than the last play.
+    store.write_json(result_path(repo), {k: v for k, v in result.items() if k != "plays"})
     log.info(
         "campaign: %d/%d plays, %d new violations (%d repeats), stopped=%s, preferred=%s",
         len(plays),

--- a/exerciser/src/exerciser/campaign.py
+++ b/exerciser/src/exerciser/campaign.py
@@ -60,6 +60,7 @@ from typing import Any
 
 from . import exception_policy, store
 from .bandit import Action, ActionBandit, Outcome, seed_actions_from_prior
+from .interpreter import resolve_cached
 
 # Wall-clock seconds that count as ONE probe-equivalent. An HTTP probe against a
 # local traced service is the unit the budget was always denominated in, and it
@@ -781,6 +782,12 @@ def run_campaign(
     log = logger or logging.getLogger(__name__)
     repo = repo.resolve()
 
+    # Resolved ONCE for the whole campaign and handed to every oracle: five
+    # oracles independently defaulting to `sys.executable` was five separate
+    # ways to spend a budget importing nothing.
+    interpreter_choice = resolve_cached(repo, explicit=python, logger=log)
+    python = interpreter_choice.python
+
     space = ActionSpace(actions=list(actions)) if actions is not None else None
     if space is None:
         space = enumerate_actions(
@@ -803,7 +810,7 @@ def run_campaign(
         )
         runners = default_runners(cfg)
 
-    diagnostics = list(space.notes)
+    diagnostics = list(interpreter_choice.diagnostics) + list(space.notes)
     if not space.actions:
         diagnostics.append(
             "0 actions armed — no oracle is available for this repo, so there "
@@ -975,6 +982,10 @@ def run_campaign(
     result: dict[str, Any] = {
         "status": "ok",
         "diagnostics": diagnostics,
+        # The interpreter every oracle's workers ran under. `inconclusive_plays`
+        # says budget reached no target; this says which environment it was spent
+        # in, which is the first thing to check when that number is high.
+        "interpreter": interpreter_choice.to_json(),
         "repo": str(repo),
         "actions": len(bandit.actions),
         "armed": dict(sorted(space.armed.items())),

--- a/exerciser/src/exerciser/campaign.py
+++ b/exerciser/src/exerciser/campaign.py
@@ -208,6 +208,7 @@ def enumerate_actions(
     base_url: str | None = None,
     max_targets: int = DEFAULT_MAX_TARGETS,
     include_environment: bool = False,
+    python: str | None = None,
     logger: logging.Logger | None = None,
 ) -> ActionSpace:
     """Every ``(target, technique, oracle)`` armed for this repo.
@@ -315,6 +316,20 @@ def enumerate_actions(
         from . import faults
 
         boundaries = faults.load_boundaries(repo)[:max_targets]
+        if not boundaries:
+            # A declaration is the preferred source, not the only one. Waiting
+            # for a hand-written boundaries.json meant this oracle armed zero
+            # actions on every repo nobody had prepared — and the campaign said
+            # so in a note that no code path ever acted on. The drivable targets
+            # are already catalogued and their annotations already declare a
+            # domain, so derive from those instead of reporting the vacuum.
+            derived = faults.derive_boundaries(repo, function_targets[:max_targets], python)
+            if derived:
+                space.notes.append(
+                    f"no boundaries.json — derived {len(derived)} boundary(ies) from the "
+                    "consumers' own annotations"
+                )
+            boundaries = derived
         for b in boundaries:
             space.boundaries[b.target] = b
         _arm(
@@ -326,8 +341,8 @@ def enumerate_actions(
         )
         if not boundaries:
             space.notes.append(
-                "no boundaries.json — the fault oracle is not armed (declare "
-                "boundaries or run `exerciser faults --auto-target` once)"
+                "the fault oracle is not armed: no boundaries.json, and no catalogued "
+                "target carries enough annotation to derive a contract from"
             )
     except Exception as exc:
         space.notes.append(f"fault oracle unavailable: {exc}")
@@ -795,6 +810,7 @@ def run_campaign(
             base_url=base_url,
             max_targets=max_targets,
             include_environment=include_environment,
+            python=python,
             logger=log,
         )
 

--- a/exerciser/src/exerciser/concurrency.py
+++ b/exerciser/src/exerciser/concurrency.py
@@ -38,6 +38,7 @@ from typing import Any
 from . import store
 from ._worker import worker_entrypoint
 from .functions import detect_src_roots
+from .interpreter import resolve_cached
 from .issues import FailureCluster, build_clusters
 
 DEFAULT_WORKERS = 4
@@ -311,6 +312,7 @@ def run_concurrency(
     """Probe one target for hangs and schedule-dependent results."""
     log = logger or logging.getLogger(__name__)
     repo = repo.resolve()
+    python = resolve_cached(repo, explicit=python, logger=log).python
     tmp_dir = store.exercise_dir(repo) / "concurrency"
     tmp_dir.mkdir(parents=True, exist_ok=True)
 

--- a/exerciser/src/exerciser/differential.py
+++ b/exerciser/src/exerciser/differential.py
@@ -73,6 +73,7 @@ from typing import Any
 from . import store
 from ._worker import worker_entrypoint
 from .functions import annotation_base, detect_src_roots, discover_targets
+from .interpreter import resolve_cached
 from .issues import FailureCluster, build_clusters
 from .semantics_corpus import RAISING_CORPUS, SEMANTIC_CORPUS
 
@@ -892,6 +893,7 @@ def run_differential(
     """
     log = logger or logging.getLogger(__name__)
     repo = repo.resolve()
+    python = resolve_cached(repo, explicit=python, logger=log).python
 
     if target:
         refs = [

--- a/exerciser/src/exerciser/envconfig.py
+++ b/exerciser/src/exerciser/envconfig.py
@@ -58,8 +58,11 @@ import re
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from . import store
+from .agent_loop import AgentChannel, Question, question_key
+from .redact import is_secret_key, redact_text
 
 log = logging.getLogger(__name__)
 
@@ -519,3 +522,193 @@ def unsatisfied_names(error_text: str, supplied: dict[str, str]) -> list[str]:
     module as broken — the code is fine, one value is not.
     """
     return sorted(name for name in supplied if name in (error_text or ""))
+
+
+# =========================================================================
+# Escalation — the harness first, the human last
+# =========================================================================
+#
+# The ladder is deliberately shallow. It exists to get past a validator that
+# wants *a* well-shaped value, not to invent a value that is CORRECT — and
+# there are two failures it can never resolve on its own:
+#
+#   * a value with real-world meaning (an account id, a region, a project slug)
+#     that only the repo's own documentation or its author knows;
+#   * a credential, which nothing may synthesise, ever.
+#
+# Both escalate, and in that order. The coding harness goes first because it can
+# read the README, the docs and the provider's own site, and answering from
+# those costs the user nothing. Only what the harness cannot supply reaches a
+# human, and it reaches them as a described field rather than a stack trace.
+
+CONFIG_TOPIC = "config"
+
+
+def config_question(name: str, *, modules: list[str], reason: str, tried: list[str]) -> Question:
+    """One cached, budgeted question asking the harness for a value.
+
+    Keyed by the VARIABLE, not by the failure text, so the same answer is reused
+    across every module that needs it and across later runs — the whole point of
+    the channel. A repo needing eight variables asks eight questions once, not
+    eight per module per run.
+    """
+    return Question(
+        key=question_key(CONFIG_TOPIC, name),
+        topic=CONFIG_TOPIC,
+        subject=name,
+        prompt=(
+            f"The environment variable `{name}` has to be set before this repo's code "
+            f"can be imported — {len(modules)} module(s) fail without it, including "
+            f"{', '.join(modules[:3])}. The harness supplied placeholder values "
+            f"({', '.join(tried) or 'none'}) and the target rejected them:\n\n"
+            f"{reason[:600]}\n\n"
+            "Read the repo's own README, .env.example, settings class or docs and give a "
+            "value that is VALID for local, offline use — it will run inside a sandbox "
+            "with no network. Never invent a real credential: if this variable is a "
+            "secret, say so and leave `value` null, and the user will be asked instead."
+        ),
+        reply_schema=(
+            '{"value": "<string>"|null, "is_secret": true|false, '
+            '"description": "<what this variable is, in one sentence>", '
+            '"example": "<a well-formed example>"|null}'
+        ),
+        context={"variable": name, "modules": modules[:20], "tried": tried},
+    )
+
+
+def _describe(name: str, answer: Any) -> dict[str, Any]:
+    """Whatever the harness managed to say about a variable, defensively read."""
+    if not isinstance(answer, dict):
+        return {}
+    return {
+        k: answer.get(k)
+        for k in ("value", "is_secret", "description", "example")
+        if answer.get(k) is not None
+    }
+
+
+def build_config_requests(
+    repo: Path,
+    unresolved: dict[str, dict[str, Any]],
+    *,
+    channel: AgentChannel | None = None,
+    max_new: int = 25,
+) -> tuple[AgentChannel, dict[str, str], list[dict[str, Any]]]:
+    """Ask the harness for every unresolved variable; escalate what it cannot give.
+
+    Returns ``(channel, answered, requests)``:
+
+    * ``answered`` — values the harness supplied, ready to feed straight back
+      into the next run's environment;
+    * ``requests`` — the ones a human has to provide, each carrying enough to
+      RENDER an input rather than to debug a stack trace: what it is, an example
+      of a well-formed value, whether it is a secret (so the field masks and the
+      value never reaches a log), which modules are blocked, and what was already
+      tried.
+
+    A credential is never in ``answered`` even if the harness returned one:
+    ``is_secret`` routes it to the human unconditionally. A model that helpfully
+    hallucinates an API key must not be able to get it used.
+    """
+    channel = channel or AgentChannel(repo, CONFIG_TOPIC, max_new=max_new)
+    answered: dict[str, str] = {}
+    requests: list[dict[str, Any]] = []
+
+    for name, detail in sorted(unresolved.items()):
+        modules = [str(m) for m in (detail.get("modules") or [])]
+        reason = redact_text(str(detail.get("reason") or ""))
+        tried = [str(t) for t in (detail.get("tried") or [])]
+        answer = channel.ask(config_question(name, modules=modules, reason=reason, tried=tried))
+        described = _describe(name, answer)
+        secret = bool(described.get("is_secret")) or is_secret_key(name)
+        value = described.get("value")
+
+        if value is not None and not secret:
+            answered[name] = str(value)
+            continue
+
+        requests.append(
+            {
+                "variable": name,
+                # Everything a field needs to render itself.
+                "secret": secret,
+                "description": described.get("description")
+                or f"Required before {modules[0] if modules else 'this repo'} can be imported.",
+                "example": described.get("example"),
+                "blocked_modules": modules[:20],
+                "blocked_count": len(modules),
+                "tried": tried,
+                "reason": reason[:400],
+                "status": "awaiting-harness" if not described else "awaiting-user",
+            }
+        )
+    return channel, answered, requests
+
+
+def config_requests_path(repo: Path) -> Path:
+    return store.exercise_dir(repo) / "config_requests.json"
+
+
+def answers_path(repo: Path) -> Path:
+    return store.exercise_dir(repo) / "config_answers.json"
+
+
+def write_config_requests(repo: Path, requests: list[dict[str, Any]]) -> Path:
+    """Publish what a human still has to supply, for the extension to render.
+
+    Written even when EMPTY, so the UI can distinguish "nothing is being asked
+    of you" from "the last run never got this far" — a stale prompt asking for a
+    variable that is now satisfied is worse than no prompt.
+    """
+    path = config_requests_path(repo)
+    store.write_json(
+        path,
+        {
+            "version": 1,
+            "repo": str(repo),
+            "answers_path": str(answers_path(repo)),
+            "requests": requests,
+        },
+    )
+    return path
+
+
+def read_config_answers(repo: Path) -> dict[str, str]:
+    """Values a human supplied, read back on the next run.
+
+    The write-back file is the contract with the UI: the extension collects the
+    fields, writes ``{"answers": {"NAME": "value"}}``, and re-runs. Values are
+    read into the worker's environment and never copied into any artifact —
+    ``config_requests.json`` carries the QUESTION, never the answer.
+    """
+    doc = store.read_json(answers_path(repo)) or {}
+    answers = doc.get("answers")
+    if not isinstance(answers, dict):
+        return {}
+    return {str(k): str(v) for k, v in answers.items() if v is not None}
+
+
+def answered_config(repo: Path) -> dict[str, str]:
+    """Values the HARNESS answered on the config channel, without asking anything new.
+
+    Read at the start of a run, the way ``services.answered_fixtures`` is: the
+    asking happens after the run, from what actually failed, and the answers are
+    picked up by the run after that.
+    """
+    doc = store.read_json(store.exercise_dir(repo) / f"agent_{CONFIG_TOPIC}.json") or {}
+    out: dict[str, str] = {}
+    for entry in (doc.get("questions") or {}).values():
+        if not isinstance(entry, dict):
+            continue
+        answer = entry.get("answer")
+        name = (entry.get("context") or {}).get("variable")
+        if not isinstance(answer, dict) or not name:
+            continue
+        # A secret never comes back through the agent channel, whatever the
+        # model said — those go to the human and arrive via `config_answers`.
+        if answer.get("is_secret") or is_secret_key(str(name)):
+            continue
+        value = answer.get("value")
+        if value is not None:
+            out[str(name)] = str(value)
+    return out

--- a/exerciser/src/exerciser/envconfig.py
+++ b/exerciser/src/exerciser/envconfig.py
@@ -388,11 +388,17 @@ _NEVER_SYNTHESIZE = frozenset(
 #: a URL") is exactly the hardcoding this avoids: the same field is spelled
 #: `DSN`, `ENDPOINT`, `*_URI` and `SERVER` across four projects, and the
 #: validator is the only thing that knows.
+#: The email is deliberately NOT at an RFC 2606 reserved domain. `.invalid`,
+#: `.test` and `example.com` read as the obviously-fake choice, and
+#: `email-validator` — what pydantic's `EmailStr` uses — REFUSES special-use
+#: domains outright. Found live on demo-fastapi: the ladder reached the email
+#: rung, `vinv@example.invalid` was rejected as "a special-use or reserved
+#: name", and the run stalled one step from succeeding.
 _VALUE_LADDER = (
     "vinv-placeholder",
     "0",
     "http://127.0.0.1:1",
-    "vinv@example.invalid",
+    "vinv@vinvharness.com",
     "postgresql://vinv:vinv@127.0.0.1:1/vinv",
     "/tmp/vinv-placeholder",
     "[]",
@@ -502,3 +508,14 @@ def declared_env(repo: Path, workdir: Path | None = None) -> dict[str, str]:
             for key, value in _parse_env_file(text).items():
                 collected.setdefault(key, value)
     return collected
+
+
+def unsatisfied_names(error_text: str, supplied: dict[str, str]) -> list[str]:
+    """Of the values the harness supplied, which the target is still rejecting.
+
+    The precise thing an agent or a human has to be asked for. A run that stalls
+    with "FIRST_SUPERUSER is not a valid email address" knows exactly which
+    variable defeated the ladder, and passing that on beats reporting the whole
+    module as broken — the code is fine, one value is not.
+    """
+    return sorted(name for name in supplied if name in (error_text or ""))

--- a/exerciser/src/exerciser/envconfig.py
+++ b/exerciser/src/exerciser/envconfig.py
@@ -561,6 +561,11 @@ def unsatisfied_names(error_text: str, supplied: dict[str, str]) -> list[str]:
 
 CONFIG_TOPIC = "config"
 
+#: Modules whose import failure named nothing any pattern could read. A separate
+#: topic from `config` because the QUESTION is different: not "what is this
+#: variable" but "what does this module need".
+BLOCKED_TOPIC = "blocked-import"
+
 
 def config_question(name: str, *, modules: list[str], reason: str, tried: list[str]) -> Question:
     """One cached, budgeted question asking the harness for a value.
@@ -730,3 +735,83 @@ def answered_config(repo: Path) -> dict[str, str]:
         if value is not None:
             out[str(name)] = str(value)
     return out
+
+
+def blocked_module_question(module: str, reason: str) -> Question:
+    """Ask the harness what a module needs, when no pattern recognised the failure.
+
+    ``missing_env_names`` reads the shapes in which a program says "I needed
+    this and did not get it", and that set is finite while the ways to say it
+    are not. A repo that raises its own ``NeedsSetup("the widget registry has
+    not been provisioned")`` names no variable in any form a regex anticipates,
+    so nothing is induced, nothing is unsatisfied, and — before this — nothing
+    escalated either. The module simply stayed blocked and no one was asked.
+
+    That is the case the agent channel exists for. A pattern that fails should
+    hand the question on, not end the ladder: the harness can read the module,
+    find what it reaches for, and answer in the same cached, budgeted way it
+    answers everything else. The regexes stay because they are free and settle
+    the common shapes without a model call; this is what happens when they miss.
+    """
+    return Question(
+        key=question_key(BLOCKED_TOPIC, module),
+        topic=BLOCKED_TOPIC,
+        subject=module,
+        prompt=(
+            f"The module `{module}` cannot be imported, and the harness could not "
+            "tell from the error what it is missing:\n\n"
+            f"{reason[:800]}\n\n"
+            "Read this module and whatever it imports at module scope. If it needs "
+            "environment variables to import, name them and give values valid for "
+            "local, offline use inside a sandbox with no network. If it cannot be "
+            "imported without something else entirely — a file on disk, a running "
+            "service, a build step — say so in `blocker` and leave `variables` "
+            "empty. Never invent a real credential."
+        ),
+        reply_schema=(
+            '{"variables": {"<NAME>": "<value>"}, ' '"blocker": "<what else is needed>"|null}'
+        ),
+        context={"module": module},
+    )
+
+
+def blocked_module_answers(repo: Path) -> dict[str, str]:
+    """Variables the harness supplied for modules whose failure was unrecognised."""
+    doc = store.read_json(store.exercise_dir(repo) / f"agent_{BLOCKED_TOPIC}.json") or {}
+    out: dict[str, str] = {}
+    for entry in (doc.get("questions") or {}).values():
+        if not isinstance(entry, dict):
+            continue
+        answer = entry.get("answer")
+        if not isinstance(answer, dict):
+            continue
+        variables = answer.get("variables")
+        if not isinstance(variables, dict):
+            continue
+        for name, value in variables.items():
+            # A secret never returns through the agent channel, whatever the
+            # model said — those go to the human via `config_answers`.
+            if value is None or is_secret_key(str(name)):
+                continue
+            out[str(name)] = str(value)
+    return out
+
+
+def ask_about_blocked_modules(
+    repo: Path,
+    blocked: dict[str, str],
+    *,
+    max_new: int = 25,
+) -> tuple[AgentChannel, list[dict[str, Any]]]:
+    """Raise one cached question per module the patterns could not read.
+
+    Returns the channel and a report of what is now pending, so a run says it
+    handed the question on rather than appearing to have given up.
+    """
+    channel = AgentChannel(repo, BLOCKED_TOPIC, max_new=max_new)
+    pending: list[dict[str, Any]] = []
+    for module, reason in sorted(blocked.items()):
+        answer = channel.ask(blocked_module_question(module, redact_text(reason)))
+        if answer is None:
+            pending.append({"module": module, "reason": redact_text(reason)[:300]})
+    return channel, pending

--- a/exerciser/src/exerciser/envconfig.py
+++ b/exerciser/src/exerciser/envconfig.py
@@ -492,14 +492,32 @@ def declared_env(repo: Path, workdir: Path | None = None) -> dict[str, str]:
 
     Values already present in the real environment always win: a developer who
     exported ``DATABASE_URL`` meant it.
+
+    Bounded to the repo, and that bound is load-bearing. ``workdir.parent`` is
+    the right place to look when the workdir is ``backend/`` — but the repo root
+    is itself a workdir candidate, and there ``.parent`` is the directory
+    CONTAINING the checkout. A developer whose projects live side by side under
+    one folder, or whose repo sits in their home directory, would have had an
+    unrelated project's ``.env`` — or their own — read and exported into the
+    worker. "Environment the repo itself publishes" has to mean the repo.
     """
     collected: dict[str, str] = {}
     roots: list[Path] = []
+    try:
+        base = repo.resolve()
+    except OSError:  # pragma: no cover - a hostile path
+        base = repo
     if workdir is not None:
         roots.append(workdir)
         roots.append(workdir.parent)
     roots.append(repo)
     for root in roots:
+        try:
+            inside = root.resolve() == base or root.resolve().is_relative_to(base)
+        except (OSError, ValueError):  # pragma: no cover - a hostile path
+            inside = False
+        if not inside:
+            continue
         for name in _ENV_FILES:
             path = root / name
             if not path.is_file():

--- a/exerciser/src/exerciser/envconfig.py
+++ b/exerciser/src/exerciser/envconfig.py
@@ -323,3 +323,182 @@ def workdir_for(
         ):
             best = claim
     return best
+
+
+# =========================================================================
+# Environment: what the repo provides, then what its own failures ask for
+# =========================================================================
+#
+# Same discipline as the working directory, and as `service_doubles.induce`
+# before it: the repo's declarations are a STARTING POINT, and what settles the
+# question is running the code and reading its complaint.
+#
+# A list of config mechanisms to understand — pydantic-settings, environs,
+# django.conf, dynaconf, plain `os.environ` — is a list, and it goes stale the
+# week someone writes another one. But every one of them fails the same way:
+# the process raises, and the message names what it wanted. That message is the
+# interface, it is written by the library the repo actually uses, and it needs
+# no registry of libraries to read.
+
+#: Shapes in which a program says "I needed this and did not get it".
+#:
+#: Not a catalogue of config libraries — a catalogue of the ways a MISSING NAME
+#: appears in an exception message, which is a much smaller and much more stable
+#: set. `KeyError: 'X'` from `os.environ[...]` is the stdlib's spelling; the
+#: `field required` line is what a validating settings object prints above the
+#: offending name; the rest are the plain-English forms.
+_MISSING_ENV = (
+    # `KeyError: 'DATABASE_URL'` — os.environ subscript, the stdlib spelling.
+    re.compile(r"KeyError:?\s*['\"]([A-Z][A-Z0-9_]{2,})['\"]"),
+    # A validating settings object lists the field, then why, on the next line.
+    re.compile(r"^\s*([A-Z][A-Z0-9_]{2,})\s*$\n\s*(?:Field|Value) required", re.M),
+    # "environment variable X is not set" / "X environment variable not set"
+    re.compile(
+        r"(?:variable|env(?:ironment)?)\s+['\"]?([A-Z][A-Z0-9_]{2,})['\"]?\s+"
+        r"(?:is\s+)?(?:not\s+set|missing|required)",
+        re.I,
+    ),
+    re.compile(r"['\"]?([A-Z][A-Z0-9_]{2,})['\"]?\s+environment variable", re.I),
+    # "Missing X" / "X must be set"
+    re.compile(r"[Mm]issing\s+(?:required\s+)?['\"]?([A-Z][A-Z0-9_]{2,})['\"]?"),
+    re.compile(r"['\"]?([A-Z][A-Z0-9_]{2,})['\"]?\s+must be set", re.I),
+)
+
+#: Names that are the RUNTIME's, not the repo's. Setting these would change what
+#: the interpreter itself does, which is not configuration of the target.
+_NEVER_SYNTHESIZE = frozenset(
+    {
+        "PATH",
+        "PYTHONPATH",
+        "PYTHONHOME",
+        "HOME",
+        "TMPDIR",
+        "TEMP",
+        "TMP",
+        "LD_LIBRARY_PATH",
+        "DYLD_LIBRARY_PATH",
+        "VIRTUAL_ENV",
+    }
+)
+
+#: The value ladder. A settings object does not merely want A value, it wants
+#: one its validator accepts, and the validator says so on the next round — so
+#: the shapes escalate on the target's own complaint rather than on a guess
+#: about what a name means. Name-based guessing ("it is called *_URL so give it
+#: a URL") is exactly the hardcoding this avoids: the same field is spelled
+#: `DSN`, `ENDPOINT`, `*_URI` and `SERVER` across four projects, and the
+#: validator is the only thing that knows.
+_VALUE_LADDER = (
+    "vinv-placeholder",
+    "0",
+    "http://127.0.0.1:1",
+    "vinv@example.invalid",
+    "postgresql://vinv:vinv@127.0.0.1:1/vinv",
+    "/tmp/vinv-placeholder",
+    "[]",
+)
+
+
+def missing_env_names(error_text: str) -> list[str]:
+    """Environment names an error message says were wanted and absent.
+
+    Deduplicated, order-preserving. Runtime names are never returned: a target
+    complaining about ``PATH`` is not asking to be configured.
+    """
+    found: list[str] = []
+    for pattern in _MISSING_ENV:
+        for match in pattern.finditer(error_text or ""):
+            name = match.group(1)
+            # The patterns spell the name as `[A-Z][A-Z0-9_]{2,}`, but the ones
+            # carrying `re.I` — needed so "Environment variable" matches
+            # "environment variable" — make that class case-insensitive too, and
+            # the surrounding English words start matching as names. Checked
+            # here rather than by dropping `re.I`, because the prose around the
+            # name genuinely varies in case and the NAME genuinely does not.
+            if not name.isupper():
+                continue
+            if name in _NEVER_SYNTHESIZE or name in found:
+                continue
+            found.append(name)
+    return found
+
+
+def next_value(current: str | None) -> str | None:
+    """The next shape to try for a value the target rejected, or None when spent."""
+    if current is None:
+        return _VALUE_LADDER[0]
+    try:
+        index = _VALUE_LADDER.index(current)
+    except ValueError:
+        return None
+    return _VALUE_LADDER[index + 1] if index + 1 < len(_VALUE_LADDER) else None
+
+
+#: Files a project uses to SHOW what its environment looks like. `.env` itself
+#: is included and ranked first: it is the real one, and a repo that ships it
+#: has already answered the question. The `.example`/`.template`/`.sample`
+#: variants exist precisely to be read by someone setting the project up, which
+#: is exactly what the harness is doing.
+_ENV_FILES = (
+    ".env",
+    ".env.local",
+    ".env.example",
+    ".env.template",
+    ".env.sample",
+    ".env.defaults",
+    ".env.test",
+    "env.example",
+)
+
+_ENV_LINE = re.compile(r"^\s*(?:export\s+)?(?P<k>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*(?P<v>.*?)\s*$")
+
+
+def _parse_env_file(text: str) -> dict[str, str]:
+    """``KEY=value`` pairs, comments and blanks dropped, quotes stripped."""
+    out: dict[str, str] = {}
+    for line in text.splitlines():
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        found = _ENV_LINE.match(line)
+        if not found:
+            continue
+        value = found.group("v")
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in "'\"":
+            value = value[1:-1]
+        # An unexpanded reference (`${OTHER}`) is not a value.
+        if value.startswith("$"):
+            continue
+        out[found.group("k")] = value
+    return out
+
+
+def declared_env(repo: Path, workdir: Path | None = None) -> dict[str, str]:
+    """Environment the repo itself publishes, nearest the working directory first.
+
+    A repo that ships a ``.env.example`` has already written down every name its
+    code needs and a plausible value for each — which is the whole question,
+    answered by the people who know, at no cost and with no model call. Reading
+    it is not a substitute for the induction loop below; it is what usually makes
+    the loop unnecessary.
+
+    Values already present in the real environment always win: a developer who
+    exported ``DATABASE_URL`` meant it.
+    """
+    collected: dict[str, str] = {}
+    roots: list[Path] = []
+    if workdir is not None:
+        roots.append(workdir)
+        roots.append(workdir.parent)
+    roots.append(repo)
+    for root in roots:
+        for name in _ENV_FILES:
+            path = root / name
+            if not path.is_file():
+                continue
+            try:
+                text = path.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            for key, value in _parse_env_file(text).items():
+                collected.setdefault(key, value)
+    return collected

--- a/exerciser/src/exerciser/envconfig.py
+++ b/exerciser/src/exerciser/envconfig.py
@@ -1,0 +1,325 @@
+"""How this repo expects to be run — read from what it already declares.
+
+Every oracle spawned its worker with ``cwd=repo``, and a repo's relative paths
+resolve against the working directory, so that choice silently decides what the
+code under test reads. It was never a decision: five call sites hardcoded it and
+nothing modelled "where is this meant to run from" as a question at all.
+
+demo-fastapi answers that question **twice**, in machine-readable form, and
+neither answer was consulted:
+
+* ``.github/workflows/test-backend.yml`` — ``working-directory: backend``
+* ``backend/Dockerfile`` — ``WORKDIR /app/backend/``, with compose's
+  ``context: .`` mapping the repo root onto ``/app``
+
+Its settings then declare ``env_file="../.env"``, relative because the app runs
+from ``backend/``. Started at the repo root instead, ``../.env`` resolved
+outside the repo entirely, every required setting was missing, 14 of 15 modules
+failed to import, and the engine reported fifteen defects in a clean repo.
+
+**What this module does NOT do is decide.** A list of places to read a
+declaration from is a list, and a list only ever covers the build systems
+someone thought of — Bazel, Nix, Earthly, a shell script or a sentence in a
+README are all equally valid ways for a project to say where it runs, and
+enumerating them does not converge. Any design that has to recognise the
+mechanism fails on the next repo.
+
+So these are HINTS that order an empirical search, and the search is what
+settles it: ``functions.candidate_workdirs`` puts these first, the distribution
+that owns the file next, and the repo root last, and then the worker is RUN
+from each in turn until the module actually imports. That is the discipline the
+rest of the engine already uses — ``containment`` ("the answer comes from a
+PROBE, never from the presence of a binary on PATH"), ``interpreter`` for
+candidate interpreters, ``service_doubles.induce`` for schema: act, read the
+failure, try the next thing, converge.
+
+The consequence worth stating plainly: a repo that declares nothing this module
+recognises is still handled correctly, because being unable to read a project's
+automation is not the same as being unable to run its code. What the hints buy
+is speed — the right directory first, so the retry is usually never paid.
+
+The sources happen to be easy to read, and that is their only claim:
+
+* CI ``working-directory:``, the strongest, because it is literally "how this
+  project runs its own code", written by the people who know;
+* ``WORKDIR`` in a Dockerfile, mapped back through the build context that says
+  which host directory the image root corresponds to;
+* ``Procfile`` / Makefile / justfile recipes that ``cd`` before running;
+* ``[tool.pytest.ini_options] testpaths``.
+
+Every claim carries its source, so a chosen directory is auditable from the run
+summary rather than being a silent default.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+from . import store
+
+log = logging.getLogger(__name__)
+
+#: Bounded so a repo with a large `.github` tree cannot make discovery expensive.
+_MAX_FILES_PER_SOURCE = 40
+
+#: Ranked. A repo that both runs CI from `backend` and builds an image with a
+#: different WORKDIR is telling us two things; CI is about running THIS
+#: checkout, while a Dockerfile describes a built image whose layout may not
+#: mirror the source tree at all.
+_SOURCE_RANK = {
+    "ci-working-directory": 0,
+    "procfile": 1,
+    "make-recipe": 1,
+    "pytest-testpaths": 2,
+    "dockerfile-workdir": 3,
+}
+
+
+@dataclass(frozen=True)
+class WorkdirClaim:
+    """One repo-relative directory the project says it runs from, and where it said so."""
+
+    path: str
+    source: str
+    detail: str = ""
+
+    @property
+    def rank(self) -> int:
+        return _SOURCE_RANK.get(self.source, 9)
+
+    def to_json(self) -> dict[str, str]:
+        return {"path": self.path, "source": self.source, "detail": self.detail}
+
+
+def _rel(repo: Path, candidate: Path) -> str | None:
+    """``candidate`` as a repo-relative directory, or None when it escapes the repo."""
+    try:
+        resolved = candidate.resolve()
+        rel = resolved.relative_to(repo.resolve()).as_posix()
+    except (OSError, ValueError):
+        return None
+    if not resolved.is_dir():
+        return None
+    return rel or "."
+
+
+def _yaml_scalars(text: str, key: str) -> list[str]:
+    """Values of ``key:`` in a YAML-ish document, without a YAML dependency.
+
+    Deliberately a line scan rather than a parser: this reads two specific keys
+    out of CI and compose files, a full YAML dependency for that is not worth
+    it, and a file this cannot parse contributes nothing rather than raising.
+    """
+    out: list[str] = []
+    pattern = re.compile(rf"^\s*{re.escape(key)}\s*:\s*(?P<v>[^\s#][^#\n]*?)\s*(?:#.*)?$")
+    for line in text.splitlines():
+        found = pattern.match(line)
+        if found:
+            out.append(found.group("v").strip().strip("'\""))
+    return out
+
+
+def _ci_workdirs(repo: Path) -> list[WorkdirClaim]:
+    """``working-directory:`` from GitHub Actions / GitLab CI."""
+    claims: list[WorkdirClaim] = []
+    files: list[Path] = []
+    for pattern in (".github/workflows/*.yml", ".github/workflows/*.yaml", ".gitlab-ci.yml"):
+        files.extend(sorted(repo.glob(pattern))[:_MAX_FILES_PER_SOURCE])
+    for path in files:
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for raw in _yaml_scalars(text, "working-directory"):
+            # A CI expression (`${{ ... }}`) is not a path we can resolve.
+            if "$" in raw:
+                continue
+            rel = _rel(repo, repo / raw)
+            if rel:
+                claims.append(
+                    WorkdirClaim(rel, "ci-working-directory", path.relative_to(repo).as_posix())
+                )
+    return claims
+
+
+def _dockerfile_workdirs(repo: Path) -> list[WorkdirClaim]:
+    """``WORKDIR`` mapped back through the compose build context.
+
+    A Dockerfile's ``WORKDIR /app/backend`` is a path inside the IMAGE. It only
+    names a host directory once the build context says which host directory the
+    image was built from — compose's ``context: .`` plus ``COPY . /app`` means
+    ``/app`` is the repo root, so ``/app/backend`` is ``<repo>/backend``. The
+    mapping is recovered from the longest ``COPY``/``ADD`` of the context root.
+    """
+    claims: list[WorkdirClaim] = []
+    for path in sorted(repo.rglob("Dockerfile*"))[:_MAX_FILES_PER_SOURCE]:
+        try:
+            parts = path.relative_to(repo).parts
+        except ValueError:
+            continue
+        if any(p in store.SKIP_DIRS for p in parts):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        image_roots: list[str] = []
+        for line in text.splitlines():
+            copy = re.match(r"^\s*(?:COPY|ADD)\s+(?:--\S+\s+)*\.\s+(?P<dest>\S+)", line, re.I)
+            if copy:
+                image_roots.append(copy.group("dest").rstrip("/") or "/")
+        workdirs = [
+            m.group("d").strip().strip("'\"")
+            for m in (
+                re.match(r"^\s*WORKDIR\s+(?P<d>\S+)", line, re.I) for line in text.splitlines()
+            )
+            if m
+        ]
+        if not workdirs:
+            continue
+        final = workdirs[-1].rstrip("/") or "/"
+        for image_root in sorted(image_roots, key=len, reverse=True):
+            if final == image_root:
+                sub = ""
+            elif final.startswith(image_root + "/"):
+                sub = final[len(image_root) + 1 :]
+            else:
+                continue
+            rel = _rel(repo, repo / sub if sub else repo)
+            if rel:
+                claims.append(
+                    WorkdirClaim(rel, "dockerfile-workdir", path.relative_to(repo).as_posix())
+                )
+            break
+    return claims
+
+
+_CD_RE = re.compile(r"\bcd\s+(?P<dir>[A-Za-z0-9_./-]+)\s*(?:&&|;)")
+
+
+def _cd_workdirs(repo: Path) -> list[WorkdirClaim]:
+    """Directories a Procfile / Makefile / justfile recipe ``cd``s into before running."""
+    claims: list[WorkdirClaim] = []
+    for name, source in (
+        ("Procfile", "procfile"),
+        ("Makefile", "make-recipe"),
+        ("makefile", "make-recipe"),
+        ("justfile", "make-recipe"),
+        ("Justfile", "make-recipe"),
+    ):
+        path = repo / name
+        if not path.is_file():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for found in _CD_RE.finditer(text):
+            rel = _rel(repo, repo / found.group("dir"))
+            if rel and rel != ".":
+                claims.append(WorkdirClaim(rel, source, name))
+    return claims
+
+
+def _pytest_workdirs(repo: Path) -> list[WorkdirClaim]:
+    """``testpaths`` names where a project's own tests are rooted."""
+    claims: list[WorkdirClaim] = []
+    for path in sorted(repo.rglob("pyproject.toml"))[:_MAX_FILES_PER_SOURCE]:
+        try:
+            parts = path.parent.relative_to(repo).parts
+        except ValueError:
+            continue
+        if any(p in store.SKIP_DIRS for p in parts):
+            continue
+        try:
+            data = tomllib.loads(path.read_text(encoding="utf-8", errors="replace"))
+        except (OSError, ValueError):
+            continue
+        tool = data.get("tool") if isinstance(data.get("tool"), dict) else {}
+        pytest_cfg = tool.get("pytest") if isinstance(tool.get("pytest"), dict) else {}
+        ini = pytest_cfg.get("ini_options") if isinstance(pytest_cfg, dict) else None
+        if not isinstance(ini, dict) or not ini.get("testpaths"):
+            continue
+        rel = _rel(repo, path.parent)
+        if rel:
+            claims.append(WorkdirClaim(rel, "pytest-testpaths", path.relative_to(repo).as_posix()))
+    return claims
+
+
+def declared_workdirs(repo: Path) -> list[WorkdirClaim]:
+    """Every working directory this repo declares, best source first.
+
+    Deduplicated on ``(path, source)`` and ordered by source rank then depth, so
+    the answer is deterministic and a reader can see WHY it was chosen.
+    """
+    claims: list[WorkdirClaim] = []
+    for gather in (_ci_workdirs, _cd_workdirs, _pytest_workdirs, _dockerfile_workdirs):
+        try:
+            claims.extend(gather(repo))
+        except OSError:  # pragma: no cover - unreadable tree
+            continue
+    seen: set[tuple[str, str]] = set()
+    unique: list[WorkdirClaim] = []
+    for claim in claims:
+        key = (claim.path, claim.source)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(claim)
+    return sorted(unique, key=lambda c: (c.rank, -len(Path(c.path).parts), c.path))
+
+
+def workdir_claims_for(
+    repo: Path,
+    rel_file: str,
+    claims: list[WorkdirClaim] | None = None,
+) -> list[WorkdirClaim]:
+    """Every declared working directory containing ``rel_file``, best first.
+
+    A LIST, not a winner. These are hints that order an empirical search — the
+    sources below are the ones that happen to be easy to read, never a claim to
+    have enumerated how projects state their layout. A repo built with Bazel,
+    Nix or a shell script contributes nothing here and is still handled, because
+    what settles the question is whether the module imports.
+    """
+    candidates = declared_workdirs(repo) if claims is None else claims
+    target = Path(rel_file).as_posix()
+    containing = [
+        c for c in candidates if c.path == "." or target.startswith(c.path.rstrip("/") + "/")
+    ]
+    return sorted(containing, key=lambda c: (c.rank, -len(Path(c.path).parts), c.path))
+
+
+def workdir_for(
+    repo: Path,
+    rel_file: str,
+    claims: list[WorkdirClaim] | None = None,
+) -> WorkdirClaim | None:
+    """The best declared working directory that CONTAINS ``rel_file``, if any.
+
+    Containment is the whole test. A repo may declare several — ``backend`` for
+    the API and ``frontend`` for the UI — and the one that applies to a module
+    is the one the module lives under. A claim that does not contain the file
+    says nothing about it, and the deepest containing claim wins for the same
+    reason the deepest distribution does.
+    """
+    candidates = declared_workdirs(repo) if claims is None else claims
+    target = Path(rel_file).as_posix()
+    best: WorkdirClaim | None = None
+    for claim in candidates:
+        if claim.path != "." and not target.startswith(claim.path.rstrip("/") + "/"):
+            continue
+        if best is None:
+            best = claim
+            continue
+        # Rank first (CI beats a Dockerfile), then depth.
+        if (claim.rank, -len(Path(claim.path).parts)) < (
+            best.rank,
+            -len(Path(best.path).parts),
+        ):
+            best = claim
+    return best

--- a/exerciser/src/exerciser/faults.py
+++ b/exerciser/src/exerciser/faults.py
@@ -58,6 +58,7 @@ from . import store
 from ._worker import worker_entrypoint
 from .agent_loop import AgentChannel, Question, question_key
 from .functions import detect_src_roots
+from .interpreter import resolve_cached
 from .issues import FailureCluster, build_clusters
 
 DEFAULT_TIMEOUT_S = 60.0
@@ -733,6 +734,7 @@ def run_faults(
     """
     log = logger or logging.getLogger(__name__)
     repo = repo.resolve()
+    python = resolve_cached(repo, explicit=python, logger=log).python
     store.exercise_dir(repo).mkdir(parents=True, exist_ok=True)
     channel = AgentChannel(repo, "contract", max_new=max_questions)
     # Bound on every branch: an auto-derived boundary has no declared sweep.

--- a/exerciser/src/exerciser/faults.py
+++ b/exerciser/src/exerciser/faults.py
@@ -50,6 +50,7 @@ import re
 import subprocess
 import sys
 import traceback
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -57,7 +58,7 @@ from typing import Any
 from . import store
 from ._worker import worker_entrypoint
 from .agent_loop import AgentChannel, Question, question_key
-from .functions import detect_src_roots
+from .functions import annotation_resolved, detect_src_roots
 from .interpreter import resolve_cached
 from .issues import FailureCluster, build_clusters
 
@@ -707,6 +708,44 @@ def load_boundaries(repo: Path) -> list[FaultBoundary]:
                 target=str(entry["target"]),
                 contract=dict(entry.get("contract") or {}),
                 baseline=dict(entry.get("baseline") or {}),
+            )
+        )
+    return out
+
+
+def derive_boundaries(
+    repo: Path, targets: Sequence[str], python: str | None = None
+) -> list[FaultBoundary]:
+    """Boundaries derived from consumers' own annotations, for a repo with no
+    declaration.
+
+    ``boundaries.json`` is written by hand, and ``--auto-target`` has to be
+    pointed at a consumer by name — so on a repo nobody has prepared, the fault
+    oracle armed ZERO actions and the campaign said so in a note nothing acted
+    on. An annotated parameter already declares its admissible domain, and the
+    engine has a catalogue of drivable targets, so the declaration was never the
+    only possible source: it is the *preferred* one.
+
+    A target is skipped unless the harness can build a value that genuinely
+    SATISFIES every annotation in the derived contract. Deriving from a
+    signature it cannot satisfy is worse than deriving nothing: for
+    ``validate_hostname(hostname: str, policy: SSRFPolicy)`` the baseline would
+    carry the string family's ``"vinv"`` for ``policy``, the first attribute
+    access raises ``AttributeError``, and the harness reports a defect it caused
+    itself. ``annotation_resolved`` is the same honesty gate the function
+    channel applies, and it exists for exactly this.
+    """
+    out: list[FaultBoundary] = []
+    for target in targets:
+        contract = infer_contract_from_signature(target, python, repo)
+        if not contract or not all(annotation_resolved(a) for a in contract.values()):
+            continue
+        out.append(
+            FaultBoundary(
+                name=target,
+                target=target,
+                contract=contract,
+                baseline=baseline_from_contract(contract),
             )
         )
     return out

--- a/exerciser/src/exerciser/faults.py
+++ b/exerciser/src/exerciser/faults.py
@@ -553,6 +553,128 @@ def cluster_fault_failures(rows: list[dict[str, Any]]) -> list[FailureCluster]:
     )
 
 
+#: Runs in the TARGET's interpreter. Reads a JSON list of targets on stdin and
+#: answers with, per target, the annotated contract AND the required parameters
+#: no contract can describe. Batched because it is called once per catalogued
+#: target during action enumeration: one subprocess per target cost 0.35s each
+#: on a trivial module (17s for a campaign's 50) and re-imported the same modules
+#: 50 times, all of it before a single unit of budget was spent.
+_SIGNATURE_PROBE_SRC = r"""
+import importlib, inspect, json, sys
+
+def describe(annotation):
+    # `getattr(ann, '__name__')` is the usual "pretty type name" recipe and is
+    # right for a plain class — but for a typing alias `__name__` is the
+    # CONSTRUCTOR's name, so `Optional[str]` renders as bare "Optional" and every
+    # parameter of it lost 3 of its 4 faults (only `none` survived;
+    # empty/whitespace/surrogate never fired). `list[int]`/`dict[...]` survived
+    # only by accident, because the lowercased constructor name still starts with
+    # "list"/"dict". `str(ann)` keeps the parameters, so prefer it whenever the
+    # annotation is subscripted.
+    origin = getattr(annotation, "__origin__", None)
+    args = getattr(annotation, "__args__", None)
+    if origin is not None or args:
+        return str(annotation)
+    return getattr(annotation, "__name__", None) or str(annotation)
+
+out = {}
+for target in json.loads(sys.stdin.read()):
+    mod_name, _, qual = target.partition(":")
+    try:
+        obj = importlib.import_module(mod_name)
+        for part in qual.split("."):
+            obj = getattr(obj, part)
+        sig = inspect.signature(obj)
+    except BaseException:
+        continue
+    contract, undescribable = {}, []
+    for name, p in sig.parameters.items():
+        if name in ("self", "cls") or p.kind in (p.VAR_POSITIONAL, p.VAR_KEYWORD):
+            continue
+        if p.annotation is p.empty:
+            # A parameter with a default is optional: omitting it is legal, so
+            # it costs nothing. One with neither annotation nor default cannot
+            # be supplied at all, and every call that omits it dies in the
+            # signature before reaching the target's own code.
+            if p.default is p.empty:
+                undescribable.append(name)
+            continue
+        contract[name] = describe(p.annotation)
+    out[target] = {"contract": contract, "undescribable": undescribable}
+json.dump(out, sys.stdout)
+"""
+
+
+@dataclass(frozen=True)
+class SignatureFacts:
+    """What one consumer's signature says, and what it withholds."""
+
+    #: Annotated parameters and their rendered types.
+    contract: dict[str, str] = field(default_factory=dict)
+    #: REQUIRED parameters with no annotation. A contract cannot describe them
+    #: and `baseline_from_contract` cannot supply them, so any call built from
+    #: the contract alone is missing an argument before it starts.
+    undescribable: tuple[str, ...] = ()
+
+    @property
+    def complete(self) -> bool:
+        """Can a payload built from ``contract`` alone actually reach the target?"""
+        return bool(self.contract) and not self.undescribable
+
+
+def infer_signature_facts(
+    targets: Sequence[str], python: str | None = None, repo: Path | None = None
+) -> dict[str, SignatureFacts]:
+    """Signature facts for many targets, in ONE subprocess.
+
+    Reading a signature means importing the module that defines it, so this
+    executes target code — which is why it is batched: 50 separate processes
+    paid 50 interpreter startups and 50 sets of module imports for the same
+    answer one process gives.
+    """
+    import subprocess as _sp
+
+    wanted = list(dict.fromkeys(targets))
+    if not wanted:
+        return {}
+    roots = detect_src_roots(repo) if repo is not None else ["."]
+    base = repo.resolve() if repo is not None else Path.cwd()
+    sys_path = "".join(f"sys.path.insert(0, {str((base / r).resolve())!r})\n" for r in roots)
+    code = "import sys\n" + sys_path + _SIGNATURE_PROBE_SRC
+    try:
+        proc = _sp.run(  # noqa: S603 (fixed argv, no shell)
+            [python or sys.executable, "-c", code],
+            input=json.dumps(wanted),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            # Scales with the batch: the per-target budget is what it always was.
+            timeout=min(300.0, 30.0 + 2.0 * len(wanted)),
+            cwd=str(base),
+        )
+        data = json.loads((proc.stdout or "{}").strip() or "{}")
+    except (OSError, ValueError, _sp.TimeoutExpired):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    out: dict[str, SignatureFacts] = {}
+    for target, doc in data.items():
+        if not isinstance(doc, dict):
+            continue
+        contract = doc.get("contract")
+        undescribable = doc.get("undescribable")
+        out[str(target)] = SignatureFacts(
+            contract={str(k): str(v) for k, v in contract.items()}
+            if isinstance(contract, dict)
+            else {},
+            undescribable=tuple(str(n) for n in undescribable or ())
+            if isinstance(undescribable, list)
+            else (),
+        )
+    return out
+
+
 def infer_contract_from_signature(
     target: str, python: str | None = None, repo: Path | None = None
 ) -> dict[str, str]:
@@ -564,59 +686,7 @@ def infer_contract_from_signature(
     parameter already DECLARES its admissible domain. Unannotated parameters
     are left out — they are what the agent channel is for.
     """
-    import subprocess as _sp
-
-    roots = detect_src_roots(repo) if repo is not None else ["."]
-    base = repo.resolve() if repo is not None else Path.cwd()
-    sys_path_lines = "".join(f"sys.path.insert(0, {str((base / r).resolve())!r})\n" for r in roots)
-    code = (
-        "import importlib, inspect, json, sys\n"
-        + sys_path_lines
-        + f"mod_name, _, qual = {target!r}.partition(':')\n"
-        "try:\n"
-        "    obj = importlib.import_module(mod_name)\n"
-        "    for part in qual.split('.'):\n"
-        "        obj = getattr(obj, part)\n"
-        "    sig = inspect.signature(obj)\n"
-        "except BaseException:\n"
-        "    print('{}'); sys.exit(0)\n"
-        "out = {}\n"
-        "for name, p in sig.parameters.items():\n"
-        "    if name in ('self', 'cls') or p.kind in (p.VAR_POSITIONAL, p.VAR_KEYWORD):\n"
-        "        continue\n"
-        "    ann = p.annotation\n"
-        "    if ann is p.empty:\n"
-        "        continue\n"
-        # `getattr(ann, '__name__')` is the usual "pretty type name" recipe and
-        # is right for a plain class — but for a typing alias `__name__` is the
-        # CONSTRUCTOR's name, so `Optional[str]` renders as bare "Optional" and
-        # every parameter of it lost 3 of its 4 faults (only `none` survived;
-        # empty/whitespace/surrogate never fired). `list[int]`/`dict[...]`
-        # survived only by accident, because the lowercased constructor name
-        # still starts with "list"/"dict". `str(ann)` keeps the parameters, so
-        # prefer it whenever the annotation is subscripted.
-        "    origin = getattr(ann, '__origin__', None)\n"
-        "    args = getattr(ann, '__args__', None)\n"
-        "    if origin is not None or args:\n"
-        "        out[name] = str(ann)\n"
-        "    else:\n"
-        "        out[name] = getattr(ann, '__name__', None) or str(ann)\n"
-        "print(json.dumps(out))\n"
-    )
-    try:
-        proc = _sp.run(  # noqa: S603 (fixed argv, no shell)
-            [python or sys.executable, "-c", code],
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            timeout=30,
-            cwd=str(base),
-        )
-        data = json.loads((proc.stdout or "{}").strip() or "{}")
-        return {k: str(v) for k, v in data.items()} if isinstance(data, dict) else {}
-    except (OSError, ValueError, _sp.TimeoutExpired):
-        return {}
+    return infer_signature_facts([target], python, repo).get(target, SignatureFacts()).contract
 
 
 def baseline_from_contract(contract: dict[str, str]) -> dict[str, Any]:
@@ -713,9 +783,22 @@ def load_boundaries(repo: Path) -> list[FaultBoundary]:
     return out
 
 
+#: Why a catalogued target did not become a derived boundary. Fixed strings so
+#: the campaign can group them without parsing prose back apart.
+SKIP_NO_ANNOTATION = "no annotated parameter to derive a contract from"
+SKIP_UNDESCRIBABLE = (
+    "a required parameter carries no annotation, so every fault would omit it "
+    "and die in the signature before reaching the target"
+)
+SKIP_UNSATISFIABLE = (
+    "no value the harness can build satisfies a declared type, and guessing one "
+    "fabricates the crash it would then report"
+)
+
+
 def derive_boundaries(
     repo: Path, targets: Sequence[str], python: str | None = None
-) -> list[FaultBoundary]:
+) -> tuple[list[FaultBoundary], dict[str, str]]:
     """Boundaries derived from consumers' own annotations, for a repo with no
     declaration.
 
@@ -734,21 +817,46 @@ def derive_boundaries(
     access raises ``AttributeError``, and the harness reports a defect it caused
     itself. ``annotation_resolved`` is the same honesty gate the function
     channel applies, and it exists for exactly this.
+
+    That gate is necessary and was not sufficient, because it only inspects the
+    annotations a contract HAS. ``infer_signature_facts`` drops unannotated
+    parameters, so ``def f(a: str, helper)`` derived the contract ``{"a": "str"}``
+    and passed — and then every fault built on it omitted ``helper``, raised
+    ``TypeError`` in the signature, and ``TypeError`` is a typed rejection, so
+    the whole boundary was 100% dead SILENTLY. That is the same shape as the
+    ``baseline={}`` bug ``baseline_from_contract`` was written to fix, and it
+    made the oracle anti-correlated with code quality again: the less annotated
+    a repo, the more certainly it reported clean. Measured on a 50-target mix,
+    17 boundaries were derived in that state. ``complete`` is the other half of
+    the gate — a contract that cannot reach the target is not a boundary.
+
+    Returns ``(boundaries, skipped)`` where ``skipped`` maps each refused target
+    to why, because a boundary the oracle declined to arm is a fact about the
+    repo and reporting nothing is how the first version of this hid 17 of them.
     """
     out: list[FaultBoundary] = []
+    skipped: dict[str, str] = {}
+    facts = infer_signature_facts(list(targets), python, repo)
     for target in targets:
-        contract = infer_contract_from_signature(target, python, repo)
-        if not contract or not all(annotation_resolved(a) for a in contract.values()):
+        fact = facts.get(target)
+        if fact is None or not fact.contract:
+            skipped[target] = SKIP_NO_ANNOTATION
+            continue
+        if fact.undescribable:
+            skipped[target] = SKIP_UNDESCRIBABLE
+            continue
+        if not all(annotation_resolved(a) for a in fact.contract.values()):
+            skipped[target] = SKIP_UNSATISFIABLE
             continue
         out.append(
             FaultBoundary(
                 name=target,
                 target=target,
-                contract=contract,
-                baseline=baseline_from_contract(contract),
+                contract=fact.contract,
+                baseline=baseline_from_contract(fact.contract),
             )
         )
-    return out
+    return out, skipped
 
 
 def run_faults(

--- a/exerciser/src/exerciser/functions.py
+++ b/exerciser/src/exerciser/functions.py
@@ -115,7 +115,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
-from . import store
+from . import envconfig, store
 from ._worker import worker_entrypoint
 from .exception_policy import DECAY, ExceptionPolicy, family_of, provenance_of, signature
 from .interpreter import resolve_cached
@@ -573,6 +573,171 @@ def detect_src_roots(repo: Path) -> list[str]:
     # root, so it only applies to files no distribution claims.
     roots.append(".")
     return roots
+
+
+def _rel_dir(repo: Path, rel: str) -> Path | None:
+    """A repo-relative directory as an absolute path, or None when it is gone."""
+    try:
+        resolved = (repo / rel).resolve()
+    except OSError:  # pragma: no cover - a hostile path
+        return None
+    return resolved if resolved.is_dir() else None
+
+
+def distribution_cwd(repo: Path, rel_file: str) -> Path:
+    """The directory a module's own distribution is run from.
+
+    Every worker was spawned with ``cwd=repo``, and that is not a neutral
+    choice: a repo's relative paths resolve against the process working
+    directory, so choosing it wrong silently changes what the code under test
+    reads.
+
+    Found on demo-fastapi, a repo that was correctly configured the whole time.
+    Its settings declare ``env_file="../.env"`` — relative, because the app is
+    meant to run from ``backend/`` and the file sits at the repo root. Started
+    from the repo root instead, ``../.env`` resolves OUTSIDE the repo, every
+    required setting was missing, and 14 of 15 modules failed to import. Run
+    from ``backend/``, the same code loads a 37-line ``.env`` and imports
+    cleanly. The engine reported that as fifteen defects in someone's clean
+    repo, and the cause was its own choice of directory.
+
+    This returns the FIRST candidate to try. It is not the answer — the answer
+    is decided by whether the import actually succeeds, in
+    ``candidate_workdirs``/the retry loop, because no amount of reading a repo's
+    automation proves the code runs from where it says.
+    """
+    ordered = candidate_workdirs(repo, rel_file)
+    return ordered[0] if ordered else repo
+
+
+def candidate_workdirs(repo: Path, rel_file: str) -> list[Path]:
+    """Working directories worth TRYING for ``rel_file``, most likely first.
+
+    A list of places to read declarations from — CI files, Dockerfiles,
+    Procfiles, pytest config — is a list, and a list only ever covers the build
+    systems someone thought of. Bazel, Nix, Earthly, a shell script or a line in
+    a README are all equally valid ways for a project to say where it runs, and
+    enumerating them does not converge.
+
+    So declarations do not DECIDE here; they only ORDER. What decides is whether
+    the module imports, which the harness finds out by running it — the same
+    discipline ``containment`` uses for its mechanisms ("the answer comes from a
+    PROBE, never from the presence of a binary on PATH"), ``interpreter`` uses
+    for candidate interpreters, and ``service_doubles.induce`` uses for schema:
+    act, read the failure, try the next thing, converge.
+
+    The list is short and always ends at the repo root, so the retry is bounded
+    and its last element is the historical behaviour.
+    """
+    ordered: list[Path] = []
+
+    def _push(path: Path | None) -> None:
+        if path is None:
+            return
+        resolved = path.resolve()
+        if resolved not in ordered:
+            ordered.append(resolved)
+
+    # 1. Anything the repo's own automation states, best source first. A hint,
+    #    and hints are allowed to be incomplete because they are not the ruling.
+    for claim in envconfig.workdir_claims_for(repo, rel_file):
+        _push(_rel_dir(repo, claim.path))
+    # 2. The distribution that owns the file — the unit `detect_src_roots`
+    #    already uses for imports, and the right guess for a repo that automates
+    #    nothing.
+    _push(_owning_distribution(repo, rel_file))
+    # 3. Every directory BETWEEN the repo and the module, shallowest first.
+    #
+    #    Without this the search space is only "somewhere that declared itself",
+    #    so a package living in a plain subdirectory that nothing declares and no
+    #    manifest claims has no reachable answer at all — the retry runs out of
+    #    candidates while the directory that works was never a candidate. These
+    #    are the directories a relative path could resolve from and still land
+    #    inside the repo, which is the whole space worth searching, and it is
+    #    bounded by the file's own depth.
+    for ancestor in _ancestors_within(repo, rel_file):
+        _push(ancestor)
+    # 4. The repo root: previously the only choice, now the last resort.
+    _push(repo)
+    return ordered
+
+
+#: Cap on the between-repo-and-module walk. Deeply nested packages exist; paying
+#: a worker per level for one is not worth it, and the answer is nearly always
+#: within a level or two of the distribution.
+_MAX_ANCESTOR_CANDIDATES = 4
+
+
+def _ancestors_within(repo: Path, rel_file: str) -> list[Path]:
+    """Directories from just below the repo down to the module's own, shallowest first.
+
+    Shallowest first because run directories are shallow in practice — a repo
+    runs from ``backend/``, not from ``backend/app/core/``.
+    """
+    parts = Path(rel_file).parent.parts
+    out: list[Path] = []
+    for depth in range(1, min(len(parts), _MAX_ANCESTOR_CANDIDATES) + 1):
+        candidate = repo.joinpath(*parts[:depth])
+        if candidate.is_dir():
+            out.append(candidate)
+    return out
+
+
+def _repo_relative(repo: Path, path: Path) -> str:
+    try:
+        return path.resolve().relative_to(repo.resolve()).as_posix() or "."
+    except (OSError, ValueError):  # pragma: no cover - outside the repo
+        return str(path)
+
+
+def _import_blocked(stdout: str) -> bool:
+    """True when a worker's rows say EVERY target failed at import.
+
+    The signal a working-directory retry needs, read off the worker protocol
+    that already exists rather than by inspecting the filesystem. Partial
+    success is not blocked: a module where one target imports and another does
+    not has a per-target problem, and re-running it from elsewhere would trade
+    the successes away for a guess.
+    """
+    imports = 0
+    failures = 0
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except ValueError:
+            continue
+        if row.get("phase") != "import":
+            continue
+        imports += 1
+        if row.get("status") == "error":
+            failures += 1
+    return imports > 0 and failures == imports
+
+
+def _owning_distribution(repo: Path, rel_file: str) -> Path | None:
+    """Deepest directory declaring itself a distribution that contains ``rel_file``."""
+    candidates = [d for d in _distribution_dirs(repo)]
+    if not candidates:
+        return repo
+    try:
+        target = (repo / rel_file).resolve()
+    except OSError:  # pragma: no cover - a hostile path
+        return repo
+    best: Path | None = None
+    for directory in candidates:
+        try:
+            resolved = directory.resolve()
+        except OSError:  # pragma: no cover
+            continue
+        if resolved == target or resolved in target.parents:
+            # Deepest wins: in a monorepo `libs/core` owns its files, not the
+            # repo root that also carries a manifest.
+            if best is None or len(resolved.parts) > len(best.parts):
+                best = resolved
+    return best or repo
 
 
 def _distribution_dirs(repo: Path) -> list[Path]:
@@ -3255,6 +3420,9 @@ def run_functions(
     tmp_dir.mkdir(parents=True, exist_ok=True)
     rows: list[dict[str, Any]] = []
     timeouts: list[str] = []
+    # Modules that only imported once the working directory moved. Recorded so a
+    # run says WHERE it decided to run each module from, and why.
+    workdir_resolutions: list[dict[str, Any]] = []
 
     for module, mod_targets in sorted(by_module.items()):
         plan_file = tmp_dir / f"{module.replace('.', '_')}.plan.json"
@@ -3278,6 +3446,13 @@ def run_functions(
             "--repo",
             str(repo),
         ]
+        # WHERE to run this module from is decided by trying, not by reading.
+        # A repo's relative paths resolve against the working directory, so the
+        # choice changes what the code under test reads — and no list of build
+        # systems to parse ever covers them all. `candidate_workdirs` orders a
+        # short list using whatever the repo happens to declare, and the loop
+        # below lets the IMPORT settle it.
+        workdir_candidates = candidate_workdirs(repo, mod_targets[0].file)
         env = dict(os.environ)
         # The worker imports TARGET code; keep our own package importable too.
         env["PYTHONPATH"] = os.pathsep.join(
@@ -3289,24 +3464,67 @@ def run_functions(
         # target printing an emoji or any CJK text raised UnicodeEncodeError in
         # the worker and cost that module all of its rows.
         env["PYTHONIOENCODING"] = "utf-8"
+
+        # Try each candidate directory until the module actually imports. The
+        # cost is paid ONLY on failure: a module that imports from the first
+        # candidate — every module in a healthy repo — runs exactly one worker,
+        # as before. A module that cannot import anywhere ends on the last
+        # candidate's rows, which is the repo root, which is what it used to do.
+        proc = None
+        attempts: list[dict[str, Any]] = []
         try:
-            proc = subprocess.run(  # noqa: S603 (fixed argv, no shell)
-                cmd,
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                # OUTER backstop only: import allowance plus the call budget the
-                # worker enforces itself, plus slack for interpreter startup. The
-                # worker stops on its own budget and reports why; reaching this
-                # deadline means it could not even do that — wedged in import, or
-                # in a call that ignores the clock (a C-level spin, a SIGKILL-only
-                # hang). Setting it AT the call budget is what made every slow
-                # import look like a hung call.
-                timeout=module_timeout_s + call_budget_s + 5.0,
-                cwd=str(repo),
-                env=env,
-            )
+            for attempt, module_cwd in enumerate(workdir_candidates):
+                proc = subprocess.run(  # noqa: S603 (fixed argv, no shell)
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    # OUTER backstop only: import allowance plus the call budget
+                    # the worker enforces itself, plus slack for interpreter
+                    # startup. The worker stops on its own budget and reports
+                    # why; reaching this deadline means it could not even do
+                    # that — wedged in import, or in a call that ignores the
+                    # clock (a C-level spin, a SIGKILL-only hang). Setting it AT
+                    # the call budget is what made every slow import look like a
+                    # hung call.
+                    timeout=module_timeout_s + call_budget_s + 5.0,
+                    cwd=str(module_cwd),
+                    env=env,
+                )
+                blocked = _import_blocked(proc.stdout or "")
+                attempts.append(
+                    {
+                        "cwd": _repo_relative(repo, module_cwd),
+                        "import_blocked": blocked,
+                    }
+                )
+                if not blocked or attempt == len(workdir_candidates) - 1:
+                    if blocked and len(workdir_candidates) > 1:
+                        # Every directory was tried and none of them imported, so
+                        # this is not a directory problem. Said out loud rather
+                        # than left as an unexplained failure.
+                        log.info(
+                            "functions: %s failed to import from all %d candidate "
+                            "directories — not a working-directory problem",
+                            module,
+                            len(workdir_candidates),
+                        )
+                    elif attempt > 0:
+                        workdir_resolutions.append(
+                            {
+                                "module": module,
+                                "chosen": _repo_relative(repo, module_cwd),
+                                "attempts": attempts,
+                            }
+                        )
+                        log.info(
+                            "functions: %s imports from %s, not from %s",
+                            module,
+                            attempts[-1]["cwd"],
+                            attempts[0]["cwd"],
+                        )
+                    break
         except subprocess.TimeoutExpired:
             timeouts.append(module)
             # PARENT side — collected, never written to stdout (stdout here is
@@ -3523,6 +3741,9 @@ def run_functions(
         # Withheld from `clusters` because they are not per-module defects, and
         # stated here because they are not nothing either.
         "import_preconditions": preconditions,
+        # Where each module was actually run from, for the ones the first guess
+        # got wrong. Empty on a repo whose layout the first candidate matched.
+        "workdir_resolutions": workdir_resolutions,
         "diagnostics": diagnostics,
         "repo": str(repo),
         "service": service,

--- a/exerciser/src/exerciser/functions.py
+++ b/exerciser/src/exerciser/functions.py
@@ -570,8 +570,12 @@ def detect_src_roots(repo: Path) -> list[str]:
     if (repo / "src").is_dir() and "src" not in roots:
         roots.append("src")
     # The repo root stays last: `module_name_for` prefers the longest matching
-    # root, so it only applies to files no distribution claims.
-    roots.append(".")
+    # root, so it only applies to files no distribution claims. Appended only if
+    # it is not already there — a single-distribution repo whose manifest sits at
+    # the root yields `.` from the loop above, and `['.', '.']` was reaching the
+    # worker, which inserts each root onto `sys.path`.
+    if "." not in roots:
+        roots.append(".")
     return roots
 
 
@@ -3659,7 +3663,17 @@ def run_functions(
                                 )
                                 if blocked
                                 else [],
-                                "reason": _import_error_text(proc.stdout or "")[:400]
+                                # REDACTED, because of what this field is. The
+                                # induction fires when a settings object rejects
+                                # its configuration, and a settings object that
+                                # fails validation renders its whole input dict
+                                # into the message — including the values
+                                # `declared_env` just loaded out of the repo's
+                                # real `.env` and whatever a human typed into
+                                # `config_answers.json`. `variables` beside it is
+                                # names only; this was the exception to the
+                                # comment that claims the whole entry is.
+                                "reason": redact_text(_import_error_text(proc.stdout or ""))[:400]
                                 if blocked
                                 else "",
                             }
@@ -3951,7 +3965,9 @@ def run_functions(
         # got wrong. Empty on a repo whose layout the first candidate matched.
         "workdir_resolutions": workdir_resolutions,
         # Configuration the repo did not provide and the harness supplied from
-        # the module's own complaint. Names only, never values.
+        # the module's own complaint. Variable NAMES only — and the target's
+        # complaint is redacted before it is quoted here, because the complaint
+        # is a settings object rendering the very values it was given.
         "env_inductions": env_inductions,
         # Configuration the harness could not synthesise. `requests` is what a
         # human is being asked for — described fields, never values — and

--- a/exerciser/src/exerciser/functions.py
+++ b/exerciser/src/exerciser/functions.py
@@ -118,7 +118,9 @@ from typing import Any
 from . import store
 from ._worker import worker_entrypoint
 from .exception_policy import DECAY, ExceptionPolicy, family_of, provenance_of, signature
+from .interpreter import resolve_cached
 from .issues import FailureCluster, build_clusters
+from .redact import redact_text
 from .sandbox import SandboxPolicy, run_sandboxed_targets
 
 # =========================================================================
@@ -524,15 +526,66 @@ def module_name_for(rel_file: str, src_roots: list[str]) -> str | None:
     return ".".join(parts)
 
 
+#: How deep to look for nested distributions. A monorepo nests its packages a
+#: level or two down (``libs/core``, ``packages/api``, ``libs/partners/openai``);
+#: past that a match is far more likely to be a fixture or a vendored copy.
+_MAX_DIST_DEPTH = 4
+
+#: Files that mark a directory as a distribution root — the thing that ends up
+#: on ``sys.path`` once installed.
+_DIST_MARKERS = ("pyproject.toml", "setup.py", "setup.cfg")
+
+
 def detect_src_roots(repo: Path) -> list[str]:
     """Repo-relative directories that behave as import roots.
 
-    ``src/`` when present (the src-layout convention), plus the repo root.
+    A repo with ONE distribution has one root (``src/`` under the src-layout
+    convention, else the repo itself). A monorepo has one per distribution, and
+    treating it as a single root is not a smaller answer but a wrong one: with
+    only ``.``, ``libs/core/langchain_core/utils.py`` resolves to the module
+    ``libs.core.langchain_core.utils``, which imports a SECOND copy of the
+    package alongside the installed one (implicit namespace packages make it
+    succeed rather than fail). Two copies means ``isinstance`` across them is
+    false and every cross-package import gets the other copy — so the harness
+    reports phantom errors it caused itself.
+
+    The extra roots come from the distributions declared in the tree, because
+    that is what packaging already records; nothing is inferred from directory
+    names. They are ADDITIVE — the src-layout convention still holds for a tree
+    that carries no packaging metadata at all.
     """
-    roots = ["."]
-    if (repo / "src").is_dir():
-        roots.insert(0, "src")
+    roots: list[str] = []
+    for marker_dir in _distribution_dirs(repo):
+        src = marker_dir / "src"
+        root = src if src.is_dir() else marker_dir
+        rel = root.relative_to(repo).as_posix()
+        if rel and rel not in roots:
+            roots.append(rel)
+    if (repo / "src").is_dir() and "src" not in roots:
+        roots.append("src")
+    # The repo root stays last: `module_name_for` prefers the longest matching
+    # root, so it only applies to files no distribution claims.
+    roots.append(".")
     return roots
+
+
+def _distribution_dirs(repo: Path) -> list[Path]:
+    """Every directory in the tree that declares itself an installable package."""
+    found: list[Path] = []
+    for marker in _DIST_MARKERS:
+        for path in repo.rglob(marker):
+            parent = path.parent
+            try:
+                depth = len(parent.relative_to(repo).parts)
+            except ValueError:
+                continue
+            if depth > _MAX_DIST_DEPTH:
+                continue
+            if any(part in store.SKIP_DIRS for part in parent.relative_to(repo).parts):
+                continue
+            if parent not in found:
+                found.append(parent)
+    return found
 
 
 # =========================================================================
@@ -2126,9 +2179,17 @@ def discover_with_refusals(
         if module is None:
             continue
         for name in index_syms.get(rel, []):
-            if name.startswith("_"):
-                continue  # private by convention
-            _add(module, name, rel, "exported")
+            # A leading underscore is a statement about API STABILITY, not about
+            # whether calling the function is safe or worth doing — and it is
+            # where the parsing, merging and normalising helpers live, which is
+            # where input-shaped defects concentrate. Safety is decided by the
+            # purity guard, the destructive-name vocabulary and containment, all
+            # of which apply here unchanged. Dunders stay out: they are the
+            # interpreter's protocol, driven through the operation that invokes
+            # them rather than by name.
+            if name.startswith("__"):
+                continue
+            _add(module, name, rel, "internal" if name.startswith("_") else "exported")
 
     log.info(
         "functions: %d targets, %d skipped (%d sandboxable) (roots=%s)",
@@ -2856,6 +2917,158 @@ def cluster_function_failures(
     )
 
 
+#: Share of the modules that ATTEMPTED an import which must fail with one
+#: identical exception before it is read as a shared precondition rather than as
+#: a defect per module. Paired with an absolute floor, because "both of my two
+#: modules raised the same thing" is not dispersion, it is a small repo.
+_SHARED_PRECONDITION_SHARE = 0.5
+_SHARED_PRECONDITION_MIN_MODULES = 3
+
+
+def shared_import_preconditions(
+    rows: list[dict[str, Any]],
+    clusters: list[FailureCluster],
+) -> tuple[list[FailureCluster], list[dict[str, Any]]]:
+    """Split import failures that are ONE unmet precondition off from defects.
+
+    ``classify_row`` already exempts the two import failures that say nothing
+    about the code: a dependency this machine lacks (the ``ImportError`` family)
+    and an exception the repo defines about itself. A third shape reaches a
+    verdict and should not, and it became common the moment workers started
+    running under the target's own interpreter: a service that reads REQUIRED
+    configuration at import time. Every module that transitively imports the
+    settings object raises the same third-party validation error — on
+    demo-fastapi, ``pydantic_core.ValidationError`` from 14 of the 14 modules
+    that attempted an import — and each one was reported as its own defect. That
+    is fifteen fabricated findings on a repo whose only problem is an unset
+    environment variable.
+
+    Provenance cannot separate these: the exception belongs to pydantic, not to
+    the repo, so the "package stating its own precondition" exemption misses it.
+    DISPERSION can, and it is a fact about the run rather than a vocabulary: one
+    error taking out every module is a single unmet precondition, because a
+    genuine defect in one module does not stop the others from importing.
+
+    Returns ``(clusters_to_report, preconditions)``. Nothing is discarded — the
+    withheld group comes back described, so the caller reports it as the
+    environment finding it is instead of as silence.
+    """
+    imports = [r for r in rows if r.get("phase") == "import" and r.get("status") == "error"]
+    attempted = {str(r.get("module", "")) for r in rows if r.get("phase") == "import"}
+    if len(attempted) < _SHARED_PRECONDITION_MIN_MODULES:
+        return clusters, []
+
+    by_signature: dict[tuple[str, str], set[str]] = {}
+    for row in imports:
+        key = (str(row.get("error_type", "")), str(row.get("error_module", "")))
+        by_signature.setdefault(key, set()).add(str(row.get("module", "")))
+
+    blocked: dict[str, tuple[str, str]] = {}
+    findings: list[dict[str, Any]] = []
+    for (error_type, error_module), modules in sorted(by_signature.items()):
+        share = len(modules) / len(attempted)
+        if len(modules) < _SHARED_PRECONDITION_MIN_MODULES or share < _SHARED_PRECONDITION_SHARE:
+            continue
+        for module in modules:
+            blocked[module] = (error_type, error_module)
+        exemplar = next(
+            (r for r in imports if str(r.get("module", "")) in modules),
+            {},
+        )
+        findings.append(
+            {
+                "error_type": error_type,
+                "error_module": error_module,
+                "modules_blocked": len(modules),
+                "modules_attempted": len(attempted),
+                # A settings object that fails validation renders its whole
+                # input dict — API keys included — into the message, and this
+                # field is persisted and printed.
+                "detail": redact_text(str(exemplar.get("error", "")))[:400],
+                "modules": sorted(modules)[:50],
+            }
+        )
+
+    if not blocked:
+        return clusters, []
+
+    kept: list[FailureCluster] = []
+    withheld_by_signature: dict[tuple[str, str], int] = {}
+    for cluster in clusters:
+        doc = cluster.to_json()
+        endpoint = str(doc.get("endpoint_id") or "")
+        signature = blocked.get(endpoint)
+        if doc.get("kind") == "import-error" and signature is not None:
+            withheld_by_signature[signature] = withheld_by_signature.get(signature, 0) + 1
+        else:
+            kept.append(cluster)
+    for finding in findings:
+        key = (finding["error_type"], finding["error_module"])
+        finding["clusters_withheld"] = withheld_by_signature.get(key, 0)
+    return kept, findings
+
+
+#: Share of attempted modules that must fail to import a repo-owned package
+#: before the run is called an environment failure rather than a clean result.
+_ENVIRONMENT_FAILURE_SHARE = 0.5
+
+#: The two shapes an unimportable package takes. A package that is absent
+#: entirely raises the first; one that is present but STALE — an older release
+#: installed over the checkout, so a name the source expects is not there yet —
+#: raises the second. Both mean the interpreter is not carrying this repo's
+#: code, which is the only question this canary asks.
+_UNIMPORTABLE_RES = (
+    re.compile(r"No module named ['\"]([\w.]+)['\"]"),
+    re.compile(r"cannot import name .+ from (?:partially initialized module )?['\"]([\w.]+)['\"]"),
+)
+
+
+def _unimportable_package(message: str) -> str | None:
+    """The top-level package an import-phase error says could not be loaded."""
+    for pattern in _UNIMPORTABLE_RES:
+        found = pattern.search(message)
+        if found:
+            return found.group(1).partition(".")[0]
+    return None
+
+
+def import_canary(rows: list[dict[str, Any]], modules_attempted: int) -> dict[str, Any]:
+    """Whether the interpreter driving the targets can import the target's code.
+
+    The function channel imports the repo under test. When the chosen
+    interpreter has not installed it, EVERY import raises and the run finds
+    nothing — and "found nothing" is exactly what a clean repo looks like. That
+    ambiguity is the failure mode this exists to remove: a run that could not
+    load the code must never be reported as a run that found no defects.
+
+    A missing module is only evidence about the ENVIRONMENT when the repo owns
+    it; a target that fails to import ``qdrant_client`` is telling us about an
+    optional extra, and the run is still meaningful for everything else. That
+    ownership test reads ``repo_packages``, which is only correct once
+    ``detect_src_roots`` has resolved each distribution to its real import name
+    — the two are load-bearing for each other.
+    """
+    missing: dict[str, int] = {}
+    failed_modules: set[str] = set()
+    for row in rows:
+        if row.get("phase") != "import" or row.get("status") != "error":
+            continue
+        top = _unimportable_package(str(row.get("error", "")))
+        if top is None:
+            continue
+        if top not in {str(n) for n in (row.get("repo_packages") or [])}:
+            continue
+        missing[top] = missing.get(top, 0) + 1
+        failed_modules.add(str(row.get("module", "")))
+    share = len(failed_modules) / modules_attempted if modules_attempted else 0.0
+    return {
+        "own_packages_unimportable": sorted(missing),
+        "modules_failed": len(failed_modules),
+        "modules_attempted": modules_attempted,
+        "blocking": share >= _ENVIRONMENT_FAILURE_SHARE and bool(missing),
+    }
+
+
 def run_functions(
     repo: Path,
     *,
@@ -2960,6 +3173,16 @@ def run_functions(
         refusals = [r for r in refusals if r.id in wanted]
 
     diagnostics: list[str] = []
+
+    # WHICH interpreter, before any worker is spawned. `python or sys.executable`
+    # meant Vinv's own venv on every repo that was not installed into it, so the
+    # workers imported nothing and the run reported a clean zero. An explicit
+    # `--python` still wins; without one this picks the interpreter that has the
+    # code under test installed, and says so.
+    choice = resolve_cached(repo, explicit=python, logger=log)
+    python = choice.python
+    diagnostics.extend(choice.diagnostics)
+
     if opted_out and refusals:
         # LOUD, not silent. The impure set is where the interesting functions
         # live; a run that leaves it undriven has to say so on the summary as
@@ -3191,6 +3414,17 @@ def run_functions(
     # clustering and the verdict tally below cannot disagree about a row.
     rng = random.Random(seed) if explore else None
     clusters = cluster_function_failures(rows, policy, total_targets=total_targets, rng=rng)
+    # One unmet precondition is one finding, not one per module it blocked.
+    clusters, preconditions = shared_import_preconditions(rows, clusters)
+    for precondition in preconditions:
+        diagnostics.append(
+            f"{precondition['modules_blocked']}/{precondition['modules_attempted']} module(s) "
+            f"failed to import with the SAME {precondition['error_type']} from "
+            f"{precondition['error_module']} — one unmet precondition, not "
+            f"{precondition['clusters_withheld']} defects, so it is reported here rather than "
+            f"clustered: {precondition['detail'][:200]}"
+        )
+        log.warning("functions_shared_precondition %s", diagnostics[-1])
     store.write_jsonl(store.exercise_dir(repo) / "function_results.jsonl", rows)
 
     called = sum(1 for r in rows if r.get("phase") == "call")
@@ -3207,8 +3441,44 @@ def run_functions(
                 sandbox_verdicts[v] = sandbox_verdicts.get(v, 0) + 1
     if sandbox_report.get("enabled"):
         sandbox_report["verdicts"] = dict(sorted(sandbox_verdicts.items()))
+
+    canary = import_canary(rows, len(by_module))
+    if canary["own_packages_unimportable"]:
+        names = ", ".join(canary["own_packages_unimportable"])
+        # Discovery already ran, so the advice has to depend on what it found:
+        # telling a human to "point --python at the repo's venv" when resolution
+        # searched the tree and found no better interpreter sends them looking
+        # for a venv that does not exist.
+        remedy = (
+            "Install the target into that interpreter, or pass --python explicitly."
+            if choice.handed_off
+            else (
+                f"No interpreter with {names} installed was found among "
+                f"{len(choice.considered)} candidate(s) — create the target's venv and "
+                "install it, or pass --python explicitly."
+            )
+        )
+        detail = (
+            f"{canary['modules_failed']}/{canary['modules_attempted']} module(s) could not be "
+            f"imported by {python}: the repo's own package(s) {names} are not "
+            f"installed for it. {remedy}"
+        )
+        diagnostics.append(detail)
+        log.warning("functions_import_canary %s", detail)
+
     result: dict[str, Any] = {
-        "status": "ok",
+        # A run that could not import the code under test found nothing BECAUSE
+        # it never ran it, which is not the same claim as a clean repo.
+        "status": "environment" if canary["blocking"] else "ok",
+        "import_canary": canary,
+        # Which interpreter drove the workers, and the evidence for it. Without
+        # this a run is unreproducible: the single most important input to the
+        # result was chosen and never written down.
+        "interpreter": choice.to_json(),
+        # Import failures that were ONE unmet precondition across many modules.
+        # Withheld from `clusters` because they are not per-module defects, and
+        # stated here because they are not nothing either.
+        "import_preconditions": preconditions,
         "diagnostics": diagnostics,
         "repo": str(repo),
         "service": service,

--- a/exerciser/src/exerciser/functions.py
+++ b/exerciser/src/exerciser/functions.py
@@ -3073,6 +3073,22 @@ def classify_row(
         # The sandbox refused an effect. Nothing about the target's own
         # correctness follows from that, at import or at call time.
         return None
+    if row.get("status") == "error" and (
+        row.get("substitution_dependent") or row.get("seed_dependent")
+    ):
+        # This call stood on data the harness invented — a doubled HTTP response
+        # or a seeded/induced row — so its failure is not attributable to the
+        # repo. The double answers with a plausibly-SHAPED body and never a
+        # correct one, and a target that then reads a field the real provider
+        # would have filled fails on OUR value, not its own logic.
+        #
+        # The row already carried the evidence: `sandbox` drains the service
+        # ledger per call and writes `service_events` onto it, under a comment
+        # saying "so downstream consumers can down-weight it". This is that
+        # consumer, and until it existed the flags had exactly one write site and
+        # zero read sites — the verdict path ran as if the substitution had not
+        # happened, and reported the gap as a defect in the repo.
+        return None
     if row.get("phase") == "import" and row.get("status") == "error":
         # Import supplies NO input, so nothing the harness did can explain the
         # failure. Two structural exemptions, and everything else is the
@@ -3685,6 +3701,65 @@ def run_functions(
                             ", ".join(sorted(induced)),
                             "imports now" if not blocked else "still blocked",
                         )
+                        if len(workdir_candidates) > 1:
+                            # The candidate list is ORDERED by likelihood and
+                            # induction fires at its LAST entry, which is the
+                            # repo root — the historical fallback. The two
+                            # mechanisms were therefore ordered so they could not
+                            # compose, and a module needing BOTH a real working
+                            # directory and a supplied variable had no reachable
+                            # answer: the directory sweep ran before the variable
+                            # existed, and the variable arrived only at the
+                            # directory the sweep had already given up on.
+                            #
+                            # Retried whether or not the root now imports, and
+                            # that is the case that matters. If it does, an
+                            # earlier candidate is still the likelier answer and
+                            # "imports at the root" is how a module ends up
+                            # running with every relative path pointing at the
+                            # wrong place while reporting success. If it does
+                            # not, the directory is the REMAINING blocker and
+                            # this is the only pass that can find it.
+                            env.update(induced)
+                            for better in workdir_candidates[:-1]:
+                                retry = subprocess.run(  # noqa: S603 (fixed argv, no shell)
+                                    cmd,
+                                    capture_output=True,
+                                    text=True,
+                                    encoding="utf-8",
+                                    errors="replace",
+                                    timeout=module_timeout_s + call_budget_s + 5.0,
+                                    cwd=str(better),
+                                    env=env,
+                                )
+                                if _import_blocked(retry.stdout or ""):
+                                    continue
+                                proc, module_cwd, blocked = retry, better, False
+                                # The induction DID resolve it — the directory
+                                # was the other half. Recorded as resolved, or
+                                # the escalation would ask a human for a variable
+                                # that is already satisfied.
+                                if env_inductions:
+                                    env_inductions[-1]["resolved"] = True
+                                    env_inductions[-1]["unsatisfied"] = []
+                                    env_inductions[-1]["resolved_from"] = _repo_relative(
+                                        repo, better
+                                    )
+                                attempts.append(
+                                    {
+                                        "cwd": _repo_relative(repo, better),
+                                        "import_blocked": False,
+                                        "induced_env": sorted(induced),
+                                        "reordered_after_induction": True,
+                                    }
+                                )
+                                log.info(
+                                    "functions: %s imports from %s once its environment "
+                                    "is supplied — preferred over the repo root",
+                                    module,
+                                    _repo_relative(repo, better),
+                                )
+                                break
                 if not blocked or attempt == len(workdir_candidates) - 1:
                     if blocked and len(workdir_candidates) > 1:
                         # Every directory was tried and none of them imported, so
@@ -3890,6 +3965,39 @@ def run_functions(
     if sandbox_report.get("enabled"):
         sandbox_report["verdicts"] = dict(sorted(sandbox_verdicts.items()))
 
+    # Calls that failed on data the harness invented. `classify_row` declines to
+    # blame the repo for these, and declining silently is what the rest of this
+    # module refuses to do: an exempted row is COUNTED, always. The number is
+    # also the honest measure of the substitution's reach — a repo where most
+    # calls land here was made reachable, not exercised.
+    substitution_gaps = [
+        {
+            "target_id": r.get("target_id"),
+            "error_type": r.get("error_type"),
+            "kind": "substitution" if r.get("substitution_dependent") else "seeded-data",
+            "services": sorted(
+                {
+                    str(e.get("service"))
+                    for e in (r.get("service_events") or [])
+                    if isinstance(e, dict) and e.get("service")
+                }
+            ),
+        }
+        for r in rows
+        if r.get("phase") == "call"
+        and r.get("status") == "error"
+        and (r.get("substitution_dependent") or r.get("seed_dependent"))
+    ]
+    if substitution_gaps:
+        detail = (
+            f"{len(substitution_gaps)} call(s) failed on data the harness supplied "
+            "(a doubled response or a seeded row), so they are reported as substitution "
+            "gaps rather than as defects — the double answers with a plausible SHAPE and "
+            "never a correct value"
+        )
+        diagnostics.append(detail)
+        log.info("functions_substitution_gaps %s", detail)
+
     # Configuration the ladder could not satisfy: ask the harness, and publish
     # whatever only a human can answer. Done AFTER the run, from what actually
     # failed, exactly as `services.fixture_questions` asks from what induction
@@ -3988,6 +4096,9 @@ def run_functions(
         # is usually the function working, and a `contained` outcome is the
         # sandbox working — but they are counted, never hidden.
         "verdicts": dict(sorted(verdicts.items())),
+        # Calls whose failure is attributable to a substituted response or a
+        # seeded row rather than to the repo. Never silently dropped.
+        "substitution_gaps": substitution_gaps[:50],
         # What the LEARNED policy currently believes — the DECISION probability
         # (structural priors blended with accumulated evidence), not the raw
         # posterior, so a run is auditable rather than an oracle handing down

--- a/exerciser/src/exerciser/functions.py
+++ b/exerciser/src/exerciser/functions.py
@@ -683,6 +683,101 @@ def _ancestors_within(repo: Path, rel_file: str) -> list[Path]:
     return out
 
 
+#: Rounds the environment repair loop may run. Monotone — each round only ADDS
+#: names or advances one value along its ladder — so it terminates on its own;
+#: the cap bounds a target that keeps naming new variables forever.
+_MAX_ENV_INDUCTION_ROUNDS = 6
+
+
+def _import_error_text(stdout: str) -> str:
+    """The import failures a worker reported, joined — what the module asked for."""
+    parts: list[str] = []
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except ValueError:
+            continue
+        if row.get("phase") == "import" and row.get("status") == "error":
+            parts.append(str(row.get("error") or ""))
+    return "\n".join(parts)
+
+
+def _induce_env(
+    cmd: list[str],
+    *,
+    env: dict[str, str],
+    cwd: Path,
+    stdout: str,
+    timeout_s: float,
+) -> tuple[dict[str, str], Any]:
+    """Supply what the module's own failure says it wanted, until it imports.
+
+    The same loop ``service_doubles.induce`` runs for database schema: act, read
+    the failure, repair, retry. It never inspects WHICH configuration library
+    the repo uses, because it does not have to — every one of them raises, and
+    the message names the variable. That is an interface no registry can go
+    stale against.
+
+    Two ways a round makes progress, and both come from the target:
+
+    * a name the message says is MISSING gets a value;
+    * a name whose supplied value the message REJECTS moves one step along the
+      value ladder — the validator is the only thing that knows whether a field
+      wants a URL, an int or an email, so it is asked rather than guessed at
+      from the variable's name.
+
+    Mutates ``env`` in place with whatever it supplied, and returns that mapping
+    alongside the last worker result. An empty mapping means the failure named
+    nothing this could act on, which is the honest answer for a module that is
+    simply broken.
+    """
+    supplied: dict[str, str] = {}
+    last_proc: Any = None
+    text = _import_error_text(stdout)
+
+    for _ in range(_MAX_ENV_INDUCTION_ROUNDS):
+        progressed = False
+        for name in envconfig.missing_env_names(text):
+            if name not in supplied:
+                value = envconfig.next_value(None)
+                if value is not None:
+                    supplied[name] = value
+                    env[name] = value
+                    progressed = True
+        if not progressed:
+            # Nothing new was NAMED. The other way forward is that a value we
+            # already supplied was rejected — advance the ones the message still
+            # mentions, which is the validator telling us the shape was wrong.
+            for name, current in list(supplied.items()):
+                if name not in text:
+                    continue
+                nxt = envconfig.next_value(current)
+                if nxt is not None:
+                    supplied[name] = nxt
+                    env[name] = nxt
+                    progressed = True
+        if not progressed:
+            break
+        last_proc = subprocess.run(  # noqa: S603 (fixed argv, no shell)
+            cmd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout_s,
+            cwd=str(cwd),
+            env=env,
+        )
+        if not _import_blocked(last_proc.stdout or ""):
+            return supplied, last_proc
+        text = _import_error_text(last_proc.stdout or "")
+
+    return supplied, last_proc
+
+
 def _repo_relative(repo: Path, path: Path) -> str:
     try:
         return path.resolve().relative_to(repo.resolve()).as_posix() or "."
@@ -3423,6 +3518,9 @@ def run_functions(
     # Modules that only imported once the working directory moved. Recorded so a
     # run says WHERE it decided to run each module from, and why.
     workdir_resolutions: list[dict[str, Any]] = []
+    # Modules that only imported once environment variables were supplied, and
+    # which ones. Never the values — some of them are credentials.
+    env_inductions: list[dict[str, Any]] = []
 
     for module, mod_targets in sorted(by_module.items()):
         plan_file = tmp_dir / f"{module.replace('.', '_')}.plan.json"
@@ -3454,6 +3552,13 @@ def run_functions(
         # below lets the IMPORT settle it.
         workdir_candidates = candidate_workdirs(repo, mod_targets[0].file)
         env = dict(os.environ)
+        # WHAT the module needs in its environment, from what the repo itself
+        # publishes — `.env`, `.env.example`, and the rest. A project that ships
+        # one has already written down every name its code needs and a plausible
+        # value for each, answered by the people who know. `setdefault`, because
+        # a developer who exported a value in this shell meant it.
+        for key, value in envconfig.declared_env(repo, workdir_candidates[0]).items():
+            env.setdefault(key, value)
         # The worker imports TARGET code; keep our own package importable too.
         env["PYTHONPATH"] = os.pathsep.join(
             [p for p in (env.get("PYTHONPATH"), *(str(Path(__file__).parents[1]),)) if p]
@@ -3499,6 +3604,42 @@ def run_functions(
                         "import_blocked": blocked,
                     }
                 )
+                if blocked and attempt == len(workdir_candidates) - 1:
+                    # No directory worked, so this is not a directory problem.
+                    # Before giving up, ask the module's own failure what it
+                    # wanted: a program that needs configuration SAYS SO, and
+                    # the message is written by whichever settings library the
+                    # repo actually uses — no registry of libraries required.
+                    induced, induced_proc = _induce_env(
+                        cmd,
+                        env=env,
+                        cwd=module_cwd,
+                        stdout=proc.stdout or "",
+                        timeout_s=module_timeout_s + call_budget_s + 5.0,
+                    )
+                    # Only adopt the retry's result when there WAS one. A module
+                    # whose failure named nothing actionable keeps the rows it
+                    # already earned — the original failure is the finding, and
+                    # discarding it for an empty result would lose it.
+                    if induced and induced_proc is not None:
+                        proc = induced_proc
+                        blocked = _import_blocked(proc.stdout or "")
+                        attempts.append(
+                            {
+                                "cwd": _repo_relative(repo, module_cwd),
+                                "import_blocked": blocked,
+                                "induced_env": sorted(induced),
+                            }
+                        )
+                        if not blocked:
+                            env_inductions.append({"module": module, "variables": sorted(induced)})
+                            log.info(
+                                "functions: %s imports once %d environment "
+                                "variable(s) are supplied: %s",
+                                module,
+                                len(induced),
+                                ", ".join(sorted(induced)),
+                            )
                 if not blocked or attempt == len(workdir_candidates) - 1:
                     if blocked and len(workdir_candidates) > 1:
                         # Every directory was tried and none of them imported, so
@@ -3744,6 +3885,9 @@ def run_functions(
         # Where each module was actually run from, for the ones the first guess
         # got wrong. Empty on a repo whose layout the first candidate matched.
         "workdir_resolutions": workdir_resolutions,
+        # Configuration the repo did not provide and the harness supplied from
+        # the module's own complaint. Names only, never values.
+        "env_inductions": env_inductions,
         "diagnostics": diagnostics,
         "repo": str(repo),
         "service": service,

--- a/exerciser/src/exerciser/functions.py
+++ b/exerciser/src/exerciser/functions.py
@@ -3631,15 +3631,32 @@ def run_functions(
                                 "induced_env": sorted(induced),
                             }
                         )
-                        if not blocked:
-                            env_inductions.append({"module": module, "variables": sorted(induced)})
-                            log.info(
-                                "functions: %s imports once %d environment "
-                                "variable(s) are supplied: %s",
-                                module,
-                                len(induced),
-                                ", ".join(sorted(induced)),
-                            )
+                        # Recorded whether or not it WORKED. An induction that
+                        # got partway and stalled is the most useful record
+                        # there is: it names the variables this repo needs, and
+                        # the one value the harness could not satisfy — which is
+                        # exactly what has to be asked of an agent or a human.
+                        # Reporting only the successes made the harness look
+                        # idle on precisely the runs where it had done the most.
+                        env_inductions.append(
+                            {
+                                "module": module,
+                                "variables": sorted(induced),
+                                "resolved": not blocked,
+                                "unsatisfied": envconfig.unsatisfied_names(
+                                    _import_error_text(proc.stdout or ""), induced
+                                )
+                                if blocked
+                                else [],
+                            }
+                        )
+                        log.info(
+                            "functions: %s — supplied %d environment variable(s): %s (%s)",
+                            module,
+                            len(induced),
+                            ", ".join(sorted(induced)),
+                            "imports now" if not blocked else "still blocked",
+                        )
                 if not blocked or attempt == len(workdir_candidates) - 1:
                     if blocked and len(workdir_candidates) > 1:
                         # Every directory was tried and none of them imported, so

--- a/exerciser/src/exerciser/functions.py
+++ b/exerciser/src/exerciser/functions.py
@@ -694,7 +694,16 @@ _MAX_ENV_INDUCTION_ROUNDS = 6
 
 
 def _import_error_text(stdout: str) -> str:
-    """The import failures a worker reported, joined — what the module asked for."""
+    """The import failures a worker reported, joined — what the module asked for.
+
+    Rendered as ``TypeName: message``, because the worker stores the two apart
+    and the TYPE carries most of the meaning. ``os.environ["DATABASE_URL"]``
+    raises a ``KeyError`` whose ``str()`` is just ``'DATABASE_URL'`` — a bare
+    quoted word. Without the class name in front, the stdlib's own spelling of
+    "this variable is missing" is unrecognisable, so the most common way a
+    Python program says it needs configuration was the one shape the induction
+    could not read.
+    """
     parts: list[str] = []
     for line in stdout.splitlines():
         line = line.strip()
@@ -705,7 +714,9 @@ def _import_error_text(stdout: str) -> str:
         except ValueError:
             continue
         if row.get("phase") == "import" and row.get("status") == "error":
-            parts.append(str(row.get("error") or ""))
+            kind = str(row.get("error_type") or "").strip()
+            message = str(row.get("error") or "")
+            parts.append(f"{kind}: {message}" if kind else message)
     return "\n".join(parts)
 
 
@@ -3541,11 +3552,16 @@ def run_functions(
     # Modules that only imported once environment variables were supplied, and
     # which ones. Never the values — some of them are credentials.
     env_inductions: list[dict[str, Any]] = []
+    # Modules that stayed blocked while the patterns extracted NOTHING. Their
+    # failure is unreadable to a regex, which is precisely when the agent
+    # channel earns its keep — so they are handed on rather than dropped.
+    unreadable_blocks: dict[str, str] = {}
     # Values already answered — by a human through the extension, or by the
     # harness on the config channel — so a question is asked once, not once per
     # run forever.
     supplied_config: dict[str, str] = dict(envconfig.read_config_answers(repo))
     supplied_config.update(envconfig.answered_config(repo))
+    supplied_config.update(envconfig.blocked_module_answers(repo))
 
     for module, mod_targets in sorted(by_module.items()):
         plan_file = tmp_dir / f"{module.replace('.', '_')}.plan.json"
@@ -3652,6 +3668,11 @@ def run_functions(
                     # whose failure named nothing actionable keeps the rows it
                     # already earned — the original failure is the finding, and
                     # discarding it for an empty result would lose it.
+                    if not induced:
+                        # The patterns read nothing out of this failure. Keep the
+                        # message so the harness can be asked what the regexes
+                        # could not tell.
+                        unreadable_blocks[module] = _import_error_text(proc.stdout or "")
                     if induced and induced_proc is not None:
                         proc = induced_proc
                         blocked = _import_blocked(proc.stdout or "")
@@ -4016,6 +4037,15 @@ def run_functions(
     config_channel, harness_answers, config_requests = envconfig.build_config_requests(
         repo, unresolved
     )
+    blocked_channel, blocked_pending = envconfig.ask_about_blocked_modules(repo, unreadable_blocks)
+    blocked_report = blocked_channel.save(logger=log)
+    if blocked_pending:
+        diagnostics.append(
+            f"{len(blocked_pending)} module(s) could not be imported and the failure named "
+            "nothing recognisable — asked the coding harness what they need: "
+            + ", ".join(entry["module"] for entry in blocked_pending[:5])
+        )
+        log.warning("functions_blocked_asked %s", diagnostics[-1])
     channel_report = config_channel.save(logger=log)
     envconfig.write_config_requests(repo, config_requests)
     if config_requests:
@@ -4084,6 +4114,11 @@ def run_functions(
         "config_requests": config_requests,
         "config_supplied_by_harness": sorted(harness_answers),
         "config_channel": channel_report,
+        # Modules whose import failure no pattern could read, handed to the
+        # harness. A regex that misses must pass the question on, not end the
+        # ladder.
+        "blocked_imports_asked": blocked_pending,
+        "blocked_channel": blocked_report,
         "diagnostics": diagnostics,
         "repo": str(repo),
         "service": service,

--- a/exerciser/src/exerciser/functions.py
+++ b/exerciser/src/exerciser/functions.py
@@ -382,7 +382,13 @@ class FunctionTarget:
     module: str
     qualname: str
     file: str
-    kind: str  # "entrypoint" | "exported"
+    #: "entrypoint" (a decorated handler) | "exported" (a public module-level
+    #: function) | "internal" (one whose name leads with a single underscore).
+    #: Reported, never filtered on: the underscore states API stability, and
+    #: what may be CALLED is decided by the purity guard and the destructive-name
+    #: vocabulary. It does order discovery, so the published surface claims the
+    #: target budget first — see `discover_with_refusals`.
+    kind: str
     is_async: bool = False
     params: list[dict[str, Any]] = field(default_factory=list)
 
@@ -570,22 +576,15 @@ def detect_src_roots(repo: Path) -> list[str]:
 
 
 def _distribution_dirs(repo: Path) -> list[Path]:
-    """Every directory in the tree that declares itself an installable package."""
-    found: list[Path] = []
-    for marker in _DIST_MARKERS:
-        for path in repo.rglob(marker):
-            parent = path.parent
-            try:
-                depth = len(parent.relative_to(repo).parts)
-            except ValueError:
-                continue
-            if depth > _MAX_DIST_DEPTH:
-                continue
-            if any(part in store.SKIP_DIRS for part in parent.relative_to(repo).parts):
-                continue
-            if parent not in found:
-                found.append(parent)
-    return found
+    """Every directory in the tree that declares itself an installable package.
+
+    One pruned walk rather than three ``rglob``s: the pattern form cannot stop a
+    descent, so each marker was matched against the whole tree — ``.venv`` and
+    its ``site-packages`` included — and filtered afterwards, three times, on
+    every call.
+    """
+    dirs, _venvs = store.walk_source_dirs(repo, max_depth=_MAX_DIST_DEPTH)
+    return [d for d, names in dirs if any(m in names for m in _DIST_MARKERS)]
 
 
 # =========================================================================
@@ -2102,6 +2101,17 @@ def discover_with_refusals(
     refused: list[Refusal] = []
     seen: set[str] = set()
 
+    # One parse per FILE, not one per target. `_add` runs once per callable and
+    # a module contributes many, so re-reading and re-`ast.parse`-ing the file
+    # each time was already the bulk of discovery — and the exported-then-
+    # internal ordering above walks every file twice.
+    facts_by_file: dict[str, dict[str, dict[str, Any]] | None] = {}
+
+    def _facts_for(rel: str) -> dict[str, dict[str, Any]] | None:
+        if rel not in facts_by_file:
+            facts_by_file[rel] = source_facts(repo / rel)
+        return facts_by_file[rel]
+
     def _add(module: str, qualname: str, rel: str, kind: str) -> None:
         tid = f"{module}:{qualname}"
         if tid in seen or len(targets) >= max_targets:
@@ -2117,7 +2127,7 @@ def discover_with_refusals(
             skipped.append({"id": tid, "reason": f"destructive-name: {reason}"})
             return
         # 3) Primary guard: what the body actually DOES, read from source.
-        facts = source_facts(repo / rel)
+        facts = _facts_for(rel)
         if facts is None:
             skipped.append({"id": tid, "reason": "unverifiable-source — refusing to call unread"})
             return
@@ -2174,22 +2184,31 @@ def discover_with_refusals(
     # handful of decorated entry points — for a LIBRARY that is the whole
     # surface. Names are read from source (no import) via the code index.
     index_syms = _index_functions_by_file(repo)
-    for rel in sorted(index_syms if not files_seen else (files_seen | set(index_syms))):
-        module = module_name_for(rel, src_roots)
-        if module is None:
-            continue
-        for name in index_syms.get(rel, []):
-            # A leading underscore is a statement about API STABILITY, not about
-            # whether calling the function is safe or worth doing — and it is
-            # where the parsing, merging and normalising helpers live, which is
-            # where input-shaped defects concentrate. Safety is decided by the
-            # purity guard, the destructive-name vocabulary and containment, all
-            # of which apply here unchanged. Dunders stay out: they are the
-            # interpreter's protocol, driven through the operation that invokes
-            # them rather than by name.
-            if name.startswith("__"):
+    # TWO passes, exported before internal. `_add` stops at `max_targets` and the
+    # walk is alphabetical by file, so a single pass spent the budget in file
+    # order: with private functions now eligible they are the majority of a real
+    # repo's module-level definitions (851 of langchain's 1,365), and `_helper`
+    # in `a.py` took the slot that the public API in `z.py` never got. Which
+    # functions are driven should not depend on their filename.
+    for internal_pass in (False, True):
+        for rel in sorted(index_syms if not files_seen else (files_seen | set(index_syms))):
+            module = module_name_for(rel, src_roots)
+            if module is None:
                 continue
-            _add(module, name, rel, "internal" if name.startswith("_") else "exported")
+            for name in index_syms.get(rel, []):
+                # A leading underscore is a statement about API STABILITY, not
+                # about whether calling the function is safe or worth doing — and
+                # it is where the parsing, merging and normalising helpers live,
+                # which is where input-shaped defects concentrate. Safety is
+                # decided by the purity guard, the destructive-name vocabulary
+                # and containment, all of which apply here unchanged. Dunders
+                # stay out: they are the interpreter's protocol, driven through
+                # the operation that invokes them rather than by name.
+                if name.startswith("__"):
+                    continue
+                if name.startswith("_") is not internal_pass:
+                    continue
+                _add(module, name, rel, "internal" if internal_pass else "exported")
 
     log.info(
         "functions: %d targets, %d skipped (%d sandboxable) (roots=%s)",
@@ -2945,13 +2964,18 @@ def shared_import_preconditions(
 
     Provenance cannot separate these: the exception belongs to pydantic, not to
     the repo, so the "package stating its own precondition" exemption misses it.
-    DISPERSION can, and it is a fact about the run rather than a vocabulary: one
-    error taking out every module is a single unmet precondition, because a
-    genuine defect in one module does not stop the others from importing.
+    DISPERSION can, and it is a fact about the run rather than a vocabulary.
 
-    Returns ``(clusters_to_report, preconditions)``. Nothing is discarded — the
-    withheld group comes back described, so the caller reports it as the
-    environment finding it is instead of as silence.
+    What dispersion establishes is that the group has ONE cause — not that the
+    cause is benign. A broken shared ``__init__`` takes out every module that
+    imports it and is a real defect, so collapsing the group to zero clusters
+    would trade fifteen fabricated findings for one missed one. The group is
+    therefore collapsed to a single REPRESENTATIVE cluster: the count stops being
+    per-module, the finding stays on ``clusters`` — which is what reaches
+    ``issues.json``, the dispatch path, and the extension — and the rest of the
+    group is summarised under ``import_preconditions``.
+
+    Returns ``(clusters_to_report, preconditions)``. Nothing is discarded.
     """
     imports = [r for r in rows if r.get("phase") == "import" and r.get("status") == "error"]
     attempted = {str(r.get("module", "")) for r in rows if r.get("phase") == "import"}
@@ -2994,17 +3018,25 @@ def shared_import_preconditions(
 
     kept: list[FailureCluster] = []
     withheld_by_signature: dict[tuple[str, str], int] = {}
+    represented: dict[tuple[str, str], str] = {}
     for cluster in clusters:
         doc = cluster.to_json()
         endpoint = str(doc.get("endpoint_id") or "")
         signature = blocked.get(endpoint)
-        if doc.get("kind") == "import-error" and signature is not None:
-            withheld_by_signature[signature] = withheld_by_signature.get(signature, 0) + 1
-        else:
+        if doc.get("kind") != "import-error" or signature is None:
             kept.append(cluster)
+            continue
+        if signature not in represented:
+            # The first is the group's representative and stays reportable. The
+            # rest are the same cause counted again.
+            represented[signature] = endpoint
+            kept.append(cluster)
+            continue
+        withheld_by_signature[signature] = withheld_by_signature.get(signature, 0) + 1
     for finding in findings:
         key = (finding["error_type"], finding["error_module"])
         finding["clusters_withheld"] = withheld_by_signature.get(key, 0)
+        finding["reported_as"] = represented.get(key)
     return kept, findings
 
 
@@ -3382,6 +3414,18 @@ def run_functions(
                 log.warning("functions_sandbox_unobservable %s", classes)
     total_targets = len(targets) + len(refusals)
 
+    # ONE chokepoint, upstream of every consumer. A target's exception message is
+    # quoted into `function_results.jsonl`, into a cluster's title, into its
+    # exemplar, into `issues.json` and onto stdout — and a settings object that
+    # fails validation renders its whole input dict, API keys included, into that
+    # message. Redacting at one report field left the credential in all the other
+    # copies; redacting the rows before anything reads them covers the lot, and
+    # the placeholder is a constant so cluster signatures stay stable.
+    for row in rows:
+        message = row.get("error")
+        if isinstance(message, str) and message:
+            row["error"] = redact_text(message)
+
     # Ctrl-C must not destroy the evidence. Every row below this point was
     # already paid for — a subprocess was spawned, a target was called, an
     # effect may have been left behind — and until this write happened, the
@@ -3420,9 +3464,9 @@ def run_functions(
         diagnostics.append(
             f"{precondition['modules_blocked']}/{precondition['modules_attempted']} module(s) "
             f"failed to import with the SAME {precondition['error_type']} from "
-            f"{precondition['error_module']} — one unmet precondition, not "
-            f"{precondition['clusters_withheld']} defects, so it is reported here rather than "
-            f"clustered: {precondition['detail'][:200]}"
+            f"{precondition['error_module']} — one cause, so it is reported once (as "
+            f"{precondition['reported_as']}) and {precondition['clusters_withheld']} duplicate "
+            f"cluster(s) were folded into it: {precondition['detail'][:200]}"
         )
         log.warning("functions_shared_precondition %s", diagnostics[-1])
     store.write_jsonl(store.exercise_dir(repo) / "function_results.jsonl", rows)

--- a/exerciser/src/exerciser/functions.py
+++ b/exerciser/src/exerciser/functions.py
@@ -3521,6 +3521,11 @@ def run_functions(
     # Modules that only imported once environment variables were supplied, and
     # which ones. Never the values — some of them are credentials.
     env_inductions: list[dict[str, Any]] = []
+    # Values already answered — by a human through the extension, or by the
+    # harness on the config channel — so a question is asked once, not once per
+    # run forever.
+    supplied_config: dict[str, str] = dict(envconfig.read_config_answers(repo))
+    supplied_config.update(envconfig.answered_config(repo))
 
     for module, mod_targets in sorted(by_module.items()):
         plan_file = tmp_dir / f"{module.replace('.', '_')}.plan.json"
@@ -3559,6 +3564,12 @@ def run_functions(
         # a developer who exported a value in this shell meant it.
         for key, value in envconfig.declared_env(repo, workdir_candidates[0]).items():
             env.setdefault(key, value)
+        # Values a human supplied through the extension on a previous run, and
+        # values the harness answered on the channel. These OVERRIDE the
+        # declared file: they were given specifically because the declared ones
+        # were not enough, so losing them to a `setdefault` would ask the same
+        # question forever.
+        env.update(supplied_config)
         # The worker imports TARGET code; keep our own package importable too.
         env["PYTHONPATH"] = os.pathsep.join(
             [p for p in (env.get("PYTHONPATH"), *(str(Path(__file__).parents[1]),)) if p]
@@ -3648,6 +3659,9 @@ def run_functions(
                                 )
                                 if blocked
                                 else [],
+                                "reason": _import_error_text(proc.stdout or "")[:400]
+                                if blocked
+                                else "",
                             }
                         )
                         log.info(
@@ -3862,6 +3876,40 @@ def run_functions(
     if sandbox_report.get("enabled"):
         sandbox_report["verdicts"] = dict(sorted(sandbox_verdicts.items()))
 
+    # Configuration the ladder could not satisfy: ask the harness, and publish
+    # whatever only a human can answer. Done AFTER the run, from what actually
+    # failed, exactly as `services.fixture_questions` asks from what induction
+    # actually saw — asking before there is evidence is how a channel fills with
+    # questions nobody needed.
+    unresolved: dict[str, dict[str, Any]] = {}
+    for entry in env_inductions:
+        if entry.get("resolved"):
+            continue
+        for name in entry.get("unsatisfied") or []:
+            record = unresolved.setdefault(
+                name, {"modules": [], "tried": [], "reason": entry.get("reason", "")}
+            )
+            record["modules"].append(entry["module"])
+            record["tried"] = sorted(set(record["tried"]) | set(entry.get("variables") or []))
+    config_channel, harness_answers, config_requests = envconfig.build_config_requests(
+        repo, unresolved
+    )
+    channel_report = config_channel.save(logger=log)
+    envconfig.write_config_requests(repo, config_requests)
+    if config_requests:
+        awaiting_user = [r["variable"] for r in config_requests if r["status"] == "awaiting-user"]
+        diagnostics.append(
+            f"{len(config_requests)} environment variable(s) could not be synthesised and "
+            f"were escalated: {', '.join(r['variable'] for r in config_requests[:8])}. "
+            + (
+                f"{len(awaiting_user)} need a value only you can give "
+                f"({', '.join(awaiting_user[:5])}) — answer them in Vinv and re-run."
+                if awaiting_user
+                else "The coding harness has been asked; re-run once it answers."
+            )
+        )
+        log.warning("functions_config_escalated %s", diagnostics[-1])
+
     canary = import_canary(rows, len(by_module))
     if canary["own_packages_unimportable"]:
         names = ", ".join(canary["own_packages_unimportable"])
@@ -3905,6 +3953,13 @@ def run_functions(
         # Configuration the repo did not provide and the harness supplied from
         # the module's own complaint. Names only, never values.
         "env_inductions": env_inductions,
+        # Configuration the harness could not synthesise. `requests` is what a
+        # human is being asked for — described fields, never values — and
+        # `harness_answers` is what the coding agent supplied without troubling
+        # anyone. `config_channel` is the queue's own accounting.
+        "config_requests": config_requests,
+        "config_supplied_by_harness": sorted(harness_answers),
+        "config_channel": channel_report,
         "diagnostics": diagnostics,
         "repo": str(repo),
         "service": service,

--- a/exerciser/src/exerciser/interpreter.py
+++ b/exerciser/src/exerciser/interpreter.py
@@ -31,10 +31,22 @@ The resolution here is EVIDENCE, not a name convention:
 
 The explicit ``--python`` is never overridden. It is still probed, because a
 human who points the flag at the wrong venv deserves to be told.
+
+TRUST BOUNDARY, stated because this module moves one. Choosing the interpreter
+that has the target installed means EXECUTING a binary that lives inside the
+target repo — ``<repo>/.venv/bin/python`` is the repo's file, and a probe runs
+it before any sandbox exists. That is not incidental; it is what "run the code
+under test in the environment it was built for" requires, and no design that
+resolves an interpreter by evidence can avoid it. What is bounded is the blast
+radius: the probe is ``-I``-isolated, reads ``.dist-info`` only, imports no
+target code, installs nothing, and is killed on a timeout. ``_ENV_TOOLS``
+likewise only runs commands that REPORT. A repo you would not run is still a
+repo you should not exercise.
 """
 
 from __future__ import annotations
 
+import configparser
 import json
 import logging
 import os
@@ -126,47 +138,28 @@ def _requirement_name(spec: str) -> str | None:
     return normalize_dist(head)
 
 
-def _venv_roots(repo: Path) -> list[Path]:
-    """Every virtualenv root in the tree, by ``pyvenv.cfg``.
+def _scan(repo: Path) -> tuple[list[Path], list[Path]]:
+    """``(directories carrying a manifest, virtualenv roots)`` from ONE walk.
 
-    Used both to nominate interpreters and to PRUNE: a venv's site-packages is
-    full of other projects' manifests, and reading those as the repo's own
-    declarations would measure every candidate against pandas' dependencies.
-    Pruning by marker rather than by directory name is the same decision made
-    twice for the same reason — the venv that exposed this bug was called
+    Both answers come off the same traversal because they are the same
+    traversal: a venv is pruned from the manifest scan for exactly the reason it
+    is nominated as an interpreter. Discovery is by ``pyvenv.cfg`` rather than by
+    directory name — the venv that exposed the bug this module fixes was called
     ``.venv-target``, and a name list would have walked straight into it.
     """
-    roots: list[Path] = []
-    for cfg in repo.rglob("pyvenv.cfg"):
-        try:
-            if len(cfg.parent.relative_to(repo).parts) > _MAX_MANIFEST_DEPTH:
-                continue
-        except ValueError:
-            continue
-        roots.append(cfg.parent)
-    return roots
+    dirs, venvs = store.walk_source_dirs(repo, max_depth=_MAX_MANIFEST_DEPTH)
+    manifests = [d for d, names in dirs if any(m in names for m in _MANIFESTS)]
+    return sorted(manifests, key=lambda p: (len(p.parts), str(p))), venvs
+
+
+def _venv_roots(repo: Path) -> list[Path]:
+    """Every virtualenv root in the tree, by ``pyvenv.cfg``."""
+    return _scan(repo)[1]
 
 
 def _manifest_dirs(repo: Path) -> list[Path]:
     """Directories carrying a packaging manifest, vendored trees and venvs pruned."""
-    venvs = _venv_roots(repo)
-    found: list[Path] = []
-    for marker in _MANIFESTS:
-        for path in repo.rglob(marker):
-            parent = path.parent
-            try:
-                parts = parent.relative_to(repo).parts
-            except ValueError:
-                continue
-            if len(parts) > _MAX_MANIFEST_DEPTH:
-                continue
-            if any(p in store.SKIP_DIRS for p in parts):
-                continue
-            if any(parent == v or v in parent.parents for v in venvs):
-                continue
-            if parent not in found:
-                found.append(parent)
-    return sorted(found, key=lambda p: (len(p.parts), str(p)))
+    return _scan(repo)[0]
 
 
 def _from_pyproject(path: Path) -> tuple[str | None, list[str]]:
@@ -208,6 +201,26 @@ def _from_pyproject(path: Path) -> tuple[str | None, list[str]]:
             if isinstance(table, dict):
                 for key in table:
                     names.append(_requirement_name(str(key)) or "")
+    return own, [n for n in names if n]
+
+
+def _from_setup_cfg(path: Path) -> tuple[str | None, list[str]]:
+    """``(this distribution's own name, its install_requires)`` from setup.cfg.
+
+    ``setup.cfg`` was in ``_MANIFESTS`` from the start but nothing ever parsed
+    it, so a setuptools-configured repo declared no OWN distribution — and the
+    ranking silently fell back to the flat third-party count that this module's
+    own docstring says is too weak to trust.
+    """
+    parser = configparser.ConfigParser()
+    try:
+        parser.read_string(path.read_text(encoding="utf-8", errors="replace"))
+    except (OSError, configparser.Error):
+        return None, []
+    declared = parser.get("metadata", "name", fallback="").strip()
+    own = normalize_dist(declared) if declared else None
+    requires = parser.get("options", "install_requires", fallback="")
+    names = [_requirement_name(line) for line in requires.splitlines()]
     return own, [n for n in names if n]
 
 
@@ -263,6 +276,12 @@ def declared_requirements(repo: Path) -> Requirements:
         pyproject = directory / "pyproject.toml"
         if pyproject.is_file():
             name, requires = _from_pyproject(pyproject)
+            if name:
+                own.append(name)
+            deps.extend(requires)
+        cfg = directory / "setup.cfg"
+        if cfg.is_file():
+            name, requires = _from_setup_cfg(cfg)
             if name:
                 own.append(name)
             deps.extend(requires)
@@ -433,7 +452,8 @@ def discover_candidates(repo: Path, explicit: str | None = None) -> list[Candida
 
     out.extend(_in_repo_venvs(repo))
     out.extend(_tool_venvs(repo))
-    out.append(Candidate(sys.executable, "vinv's own interpreter", "fallback"))
+    fallback = Candidate(sys.executable, "vinv's own interpreter", "fallback")
+    out.append(fallback)
 
     seen: set[str] = set()
     unique: list[Candidate] = []
@@ -443,7 +463,18 @@ def discover_candidates(repo: Path, explicit: str | None = None) -> list[Candida
             continue
         seen.add(k)
         unique.append(cand)
-    return unique[:MAX_CANDIDATES]
+    if len(unique) <= MAX_CANDIDATES:
+        return unique
+    # The cap truncates the TAIL, and the fallback is last — so a monorepo with
+    # a venv per package dropped `sys.executable` off the end of its own list.
+    # `resolve_interpreter` then scored it (0, 0) without ever probing it, which
+    # both fabricates the baseline the handoff diagnostic quotes and lets a
+    # candidate with one third-party package beat an interpreter that may have
+    # the whole repo installed. The fallback keeps a reserved slot.
+    self_key = fallback.key()
+    kept = [c for c in unique if c.key() != self_key][: MAX_CANDIDATES - 1]
+    kept.append(next((c for c in unique if c.key() == self_key), fallback))
+    return kept
 
 
 # =========================================================================
@@ -760,6 +791,13 @@ def _cached(repo_key: str, explicit: str | None, timeout: float) -> InterpreterC
     return resolve_interpreter(Path(repo_key), explicit=explicit, probe_timeout_s=timeout)
 
 
+#: The FIRST answer reached for a repo in this process, by resolved path. See
+#: `resolve_cached` — this is what tells an answer coming back round from the
+#: campaign apart from a human naming an interpreter.
+_ANSWERED: dict[str, InterpreterChoice] = {}
+_LOGGED: set[tuple[str, str]] = set()
+
+
 def resolve_cached(
     repo: Path,
     *,
@@ -772,9 +810,26 @@ def resolve_cached(
     The campaign resolves the same answer for five oracles in one run, and a
     fan-out of probe subprocesses per oracle is pure cost — the filesystem it
     reads does not change mid-run.
+
+    An answer HANDED BACK is not a flag. The campaign resolves once and passes
+    the result to every oracle as its ``python`` argument, which each oracle then
+    offers here as ``explicit`` — a different cache key, so it re-probed, and
+    worse, took the explicit branch and reported ``--python <path> has NONE of
+    the distributions this repo publishes`` about a flag nobody passed. When the
+    request names the interpreter this repo has already resolved to, the prior
+    choice IS the answer.
     """
-    choice = _cached(str(repo.resolve()), explicit, probe_timeout_s)
-    if logger and choice.diagnostics:
+    key = str(repo.resolve())
+    prior = _ANSWERED.get(key)
+    if prior is not None and explicit == prior.python:
+        choice = prior
+    else:
+        choice = _cached(key, explicit, probe_timeout_s)
+        _ANSWERED.setdefault(key, choice)
+    if logger and choice.diagnostics and (key, choice.python) not in _LOGGED:
+        # Once per repo per interpreter: five oracles repeating one handoff
+        # notice reads as five handoffs.
+        _LOGGED.add((key, choice.python))
         for diag in choice.diagnostics:
             logger.info("interpreter: %s", diag)
     return choice
@@ -783,3 +838,5 @@ def resolve_cached(
 def reset_cache() -> None:
     """Drop the memo — tests build a fresh tree per case."""
     _cached.cache_clear()
+    _ANSWERED.clear()
+    _LOGGED.clear()

--- a/exerciser/src/exerciser/interpreter.py
+++ b/exerciser/src/exerciser/interpreter.py
@@ -1,0 +1,785 @@
+"""Which Python actually has the target's dependencies installed.
+
+Every oracle in this engine drives target code in a worker subprocess, and every
+one of them took the interpreter as ``python or sys.executable``. The fallback
+is Vinv's own venv, which contains Vinv's dependencies and nothing else — so
+against any repo that was not installed into that same venv, every worker died
+in ``import`` with ``ModuleNotFoundError`` and the run reported a clean zero.
+
+Measured on a clone of langchain-ai/langchain: 185 of 288 outcomes were import
+failures, ``issue_clusters: 0``, ``diagnostics: []``, ``status: "ok"``. Pointing
+``--python`` at the repo's own venv turned the same command into 642 calls and 5
+defect clusters. The flag existed the whole time. Nothing ever inferred it, so
+the engine's default behaviour on an arbitrary repo was to find nothing and say
+so in a way that read as good news.
+
+The resolution here is EVIDENCE, not a name convention:
+
+* **candidates** come from the explicit flag, an env override, every
+  ``pyvenv.cfg`` in the tree (a venv can carry any directory name — the one that
+  exposed this was ``.venv-target``), the environment-manager tools the repo's
+  own manifests declare, and finally ``sys.executable``, which is always in the
+  list so there is always an answer;
+* **each candidate is PROBED** — a short, isolated subprocess asks
+  ``importlib.metadata`` which of the distributions this repo DECLARES are
+  actually installed there. Metadata only: no target code is imported and
+  nothing is installed, resolved or written;
+* **the winner is the one with the most of the target's dependencies present**,
+  and ``sys.executable`` wins every tie. A handoff happens only when another
+  interpreter is measurably better, so a repo installed into Vinv's own venv
+  (the test suite's own case) keeps today's behaviour exactly.
+
+The explicit ``--python`` is never overridden. It is still probed, because a
+human who points the flag at the wrong venv deserves to be told.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import subprocess
+import sys
+import tomllib
+from dataclasses import dataclass, field
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+from . import store
+
+log = logging.getLogger(__name__)
+
+#: Floor from this package's own ``requires-python``. A worker is OUR code, so
+#: an interpreter that cannot run it is not a candidate however complete its
+#: dependency set is — and saying that out loud beats handing the worker to a
+#: 3.9 venv and reporting the SyntaxError as the repo's problem.
+MIN_WORKER_PYTHON = (3, 12)
+
+#: Bound on the probe fan-out. A monorepo can carry a venv per package; probing
+#: every one costs a subprocess each, and the ranking is not improved by the
+#: tail.
+MAX_CANDIDATES = 12
+
+#: Bound on what we ask about. The probe is O(names) inside one subprocess, and
+#: a few dozen distributions already separate "this venv has the repo installed"
+#: from "this venv has never seen it".
+MAX_REQUIREMENTS = 150
+
+DEFAULT_PROBE_TIMEOUT_S = 20.0
+
+#: Read-only introspection commands, keyed by evidence that the repo actually
+#: uses that tool. Every one of these PRINTS a path and creates nothing:
+#: `poetry env info` reports, `pipenv --venv` reports, `pdm info` reports.
+#: Deliberately absent: anything that would materialise an environment as a side
+#: effect of being asked where it is — discovering an interpreter must not
+#: change the machine.
+#:
+#: The evidence is a lock file or the tool's OWN table in pyproject, never bare
+#: ``pyproject.toml``: nearly every Python repo has one, and `poetry env info`
+#: reports the ACTIVATED virtualenv when there is one — which is always Vinv's
+#: own while the CLI is running. Gating on the bare manifest therefore
+#: re-nominated the exact interpreter this module exists to move off, wearing a
+#: "poetry environment" label that looks like corroboration.
+_ENV_TOOLS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
+    ("poetry", ("poetry.lock",), ("poetry", "env", "info", "--path")),
+    ("pipenv", ("Pipfile",), ("pipenv", "--venv")),
+    ("pdm", ("pdm.lock",), ("pdm", "info", "--python")),
+)
+
+#: ``[tool.<name>]`` in pyproject is equally good evidence, for a repo that
+#: keeps its lock file out of version control.
+_ENV_TOOL_TABLES = ("poetry", "pdm")
+
+_MANIFESTS = ("pyproject.toml", "setup.cfg")
+_REQUIREMENT_GLOBS = ("requirements.txt", "requirements-*.txt", "requirements/*.txt")
+_MAX_MANIFEST_DEPTH = 4
+
+
+# =========================================================================
+# What the repo declares
+# =========================================================================
+
+
+def normalize_dist(name: str) -> str:
+    """PEP 503 normalisation — ``Foo.Bar_baz`` and ``foo-bar-baz`` are one name."""
+    return re.sub(r"[-_.]+", "-", name).strip().lower()
+
+
+def _requirement_name(spec: str) -> str | None:
+    """Distribution name out of one requirement string.
+
+    Handles the shapes a manifest actually carries: ``foo``, ``foo>=1,<2``,
+    ``foo[extra]==1.0``, ``foo ; python_version < '3.12'``, ``foo @ url``.
+    Anything that is not a bare name (a URL, a path, a pip flag) yields None —
+    a probe cannot ask ``importlib.metadata`` about a git URL.
+    """
+    spec = spec.strip()
+    if not spec or spec.startswith(("#", "-", ".", "/")):
+        return None
+    head = re.split(r"[\s\[\](<>=!~;@,]", spec, maxsplit=1)[0]
+    if not head or not re.fullmatch(r"[A-Za-z0-9._-]+", head):
+        return None
+    if head.lower() in {"python", "python_version"}:
+        return None
+    return normalize_dist(head)
+
+
+def _venv_roots(repo: Path) -> list[Path]:
+    """Every virtualenv root in the tree, by ``pyvenv.cfg``.
+
+    Used both to nominate interpreters and to PRUNE: a venv's site-packages is
+    full of other projects' manifests, and reading those as the repo's own
+    declarations would measure every candidate against pandas' dependencies.
+    Pruning by marker rather than by directory name is the same decision made
+    twice for the same reason — the venv that exposed this bug was called
+    ``.venv-target``, and a name list would have walked straight into it.
+    """
+    roots: list[Path] = []
+    for cfg in repo.rglob("pyvenv.cfg"):
+        try:
+            if len(cfg.parent.relative_to(repo).parts) > _MAX_MANIFEST_DEPTH:
+                continue
+        except ValueError:
+            continue
+        roots.append(cfg.parent)
+    return roots
+
+
+def _manifest_dirs(repo: Path) -> list[Path]:
+    """Directories carrying a packaging manifest, vendored trees and venvs pruned."""
+    venvs = _venv_roots(repo)
+    found: list[Path] = []
+    for marker in _MANIFESTS:
+        for path in repo.rglob(marker):
+            parent = path.parent
+            try:
+                parts = parent.relative_to(repo).parts
+            except ValueError:
+                continue
+            if len(parts) > _MAX_MANIFEST_DEPTH:
+                continue
+            if any(p in store.SKIP_DIRS for p in parts):
+                continue
+            if any(parent == v or v in parent.parents for v in venvs):
+                continue
+            if parent not in found:
+                found.append(parent)
+    return sorted(found, key=lambda p: (len(p.parts), str(p)))
+
+
+def _from_pyproject(path: Path) -> tuple[str | None, list[str]]:
+    """``(this distribution's own name, the distributions it depends on)``."""
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8", errors="replace"))
+    except (OSError, ValueError):
+        return None, []
+    names: list[str] = []
+    project = data.get("project") if isinstance(data.get("project"), dict) else {}
+    tool = data.get("tool") if isinstance(data.get("tool"), dict) else {}
+    poetry = tool.get("poetry") if isinstance(tool.get("poetry"), dict) else {}
+
+    own: str | None = None
+    for owner in (project, poetry):
+        declared = owner.get("name")
+        if own is None and isinstance(declared, str) and declared.strip():
+            own = normalize_dist(declared)
+
+    for spec in project.get("dependencies") or []:
+        if isinstance(spec, str):
+            names.append(_requirement_name(spec) or "")
+    optional = project.get("optional-dependencies")
+    if isinstance(optional, dict):
+        for group in optional.values():
+            for spec in group if isinstance(group, list) else []:
+                if isinstance(spec, str):
+                    names.append(_requirement_name(spec) or "")
+    # Poetry keeps dependencies as a table keyed by name.
+    for table_key in ("dependencies", "dev-dependencies"):
+        table = poetry.get(table_key)
+        if isinstance(table, dict):
+            for key in table:
+                names.append(_requirement_name(str(key)) or "")
+    groups = poetry.get("group")
+    if isinstance(groups, dict):
+        for group in groups.values():
+            table = group.get("dependencies") if isinstance(group, dict) else None
+            if isinstance(table, dict):
+                for key in table:
+                    names.append(_requirement_name(str(key)) or "")
+    return own, [n for n in names if n]
+
+
+def _from_requirements(path: Path) -> list[str]:
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return []
+    return [n for n in (_requirement_name(line) for line in lines) if n]
+
+
+@dataclass(frozen=True)
+class Requirements:
+    """What the repo declares, split by who owns it.
+
+    The split is the whole discriminator. Measured on langchain, the two
+    candidate interpreters scored 20/74 and 15/74 on the flat set — Vinv's own
+    venv genuinely has pydantic, requests, PyYAML, SQLAlchemy and a dozen other
+    ordinary libraries, so a flat count nearly ties and would invert on any repo
+    whose dependencies are more common still.
+
+    On the repo's OWN distributions the same two interpreters scored 4 and 0.
+    "Is the code under test installed here" is a far sharper question than "does
+    this interpreter have some libraries", and it is the one that actually
+    predicts whether a worker can import the target.
+    """
+
+    #: Distributions the repo itself declares (``[project].name`` of every
+    #: manifest in the tree) — its own packages and, in a monorepo, its siblings.
+    own: tuple[str, ...] = ()
+    #: Everything the repo depends on that it does not also publish.
+    third_party: tuple[str, ...] = ()
+
+    @property
+    def all(self) -> list[str]:
+        return [*self.own, *self.third_party]
+
+    def __len__(self) -> int:
+        return len(self.own) + len(self.third_party)
+
+
+def declared_requirements(repo: Path) -> Requirements:
+    """Every distribution this repo declares, normalised, split own vs third-party.
+
+    Deliberately the DECLARED set rather than an installed set or an import
+    scan: declarations are what packaging already records, they exist before
+    anything is installed anywhere, and they are the same list whichever
+    interpreter is asked.
+    """
+    own: list[str] = []
+    deps: list[str] = []
+    for directory in _manifest_dirs(repo):
+        pyproject = directory / "pyproject.toml"
+        if pyproject.is_file():
+            name, requires = _from_pyproject(pyproject)
+            if name:
+                own.append(name)
+            deps.extend(requires)
+    for pattern in _REQUIREMENT_GLOBS:
+        for path in sorted(repo.glob(pattern)):
+            deps.extend(_from_requirements(path))
+    own_ordered = list(dict.fromkeys(own))
+    owned = set(own_ordered)
+    # A monorepo declares its siblings as dependencies too; they belong to the
+    # repo, so they are counted once, on the side that discriminates.
+    third = [n for n in dict.fromkeys(deps) if n not in owned]
+    return Requirements(
+        own=tuple(own_ordered[:MAX_REQUIREMENTS]),
+        third_party=tuple(third[:MAX_REQUIREMENTS]),
+    )
+
+
+# =========================================================================
+# Candidates
+# =========================================================================
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """One interpreter worth asking, and where the suggestion came from."""
+
+    python: str
+    origin: str
+    detail: str = ""
+
+    def key(self) -> str:
+        """Identity for deduplication — the venv PREFIX, not the binary.
+
+        ``bin/python3`` inside a venv is a symlink to the base interpreter, so
+        ``realpath`` collapses every venv built from the same Python into one
+        key: the target's venv and Vinv's own venv become indistinguishable
+        while having entirely different ``site-packages``. A venv's identity is
+        its prefix, which is exactly what ``pyvenv.cfg`` marks. Outside a venv
+        (a system or pyenv interpreter) ``realpath`` is the right answer and
+        still collapses ``python`` with ``python3``.
+        """
+        exe = Path(self.python)
+        try:
+            for prefix in (exe.parent.parent, exe.parent):
+                if (prefix / "pyvenv.cfg").is_file():
+                    return str(prefix.resolve())
+            return os.path.realpath(exe)
+        except OSError:  # pragma: no cover - a hostile path
+            return self.python
+
+
+def _venv_python(venv_root: Path) -> str | None:
+    """The interpreter inside a venv root, on either platform layout."""
+    for rel in ("bin/python3", "bin/python", "Scripts/python.exe", "Scripts/python3.exe"):
+        exe = venv_root / rel
+        if exe.is_file() and os.access(exe, os.X_OK):
+            return str(exe)
+    return None
+
+
+def _in_repo_venvs(repo: Path) -> list[Candidate]:
+    """Every venv in the tree, recognised by ``pyvenv.cfg`` rather than by name.
+
+    Name lists are what made this invisible: the venv that exposed the bug was
+    called ``.venv-target``, and a repo is free to call one anything at all.
+    ``pyvenv.cfg`` is the marker the interpreter itself writes.
+    """
+    found: list[Candidate] = []
+    for root in _venv_roots(repo):
+        parts = root.relative_to(repo).parts
+        # A venv nested inside vendored or VCS metadata is not this repo's env.
+        # The venv's OWN directory name is never judged — that is the point.
+        if any(p in {".git", "node_modules", "__pycache__", ".vinv"} for p in parts[:-1]):
+            continue
+        exe = _venv_python(root)
+        if exe:
+            found.append(Candidate(exe, "in-repo venv", root.relative_to(repo).as_posix()))
+    # Shallowest first: a top-level `.venv` is more likely the project's env
+    # than one nested inside a single package. Probing settles it either way;
+    # this only makes the ORDER deterministic.
+    return sorted(found, key=lambda c: (len(Path(c.detail).parts), c.detail))
+
+
+def _declares_tool(repo: Path, tool: str) -> bool:
+    """Does the repo's own pyproject carry a ``[tool.<tool>]`` table?"""
+    if tool not in _ENV_TOOL_TABLES:
+        return False
+    path = repo / "pyproject.toml"
+    if not path.is_file():
+        return False
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8", errors="replace"))
+    except (OSError, ValueError):
+        return False
+    table = data.get("tool")
+    return isinstance(table, dict) and isinstance(table.get(tool), dict)
+
+
+def _tool_venvs(repo: Path, *, timeout_s: float = 10.0) -> list[Candidate]:
+    """Out-of-tree environments the repo's own tooling knows about.
+
+    Gated on a manifest marker so no tool is invoked for a repo that does not
+    use it, and every command is read-only (see ``_ENV_TOOLS``). A tool that is
+    absent, slow, or unhappy contributes nothing — this is a source of
+    suggestions, not a requirement.
+    """
+    found: list[Candidate] = []
+    for tool, markers, argv in _ENV_TOOLS:
+        if not any((repo / m).is_file() for m in markers) and not _declares_tool(repo, tool):
+            continue
+        try:
+            proc = subprocess.run(  # noqa: S603 (fixed argv, no shell)
+                list(argv),
+                capture_output=True,
+                text=True,
+                timeout=timeout_s,
+                cwd=str(repo),
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            continue
+        out = (proc.stdout or "").strip().splitlines()
+        if proc.returncode != 0 or not out:
+            continue
+        raw = Path(out[-1].strip())
+        exe = str(raw) if raw.is_file() else _venv_python(raw)
+        if exe and Path(exe).is_file():
+            found.append(Candidate(exe, f"{tool} environment", str(raw)))
+    return found
+
+
+def discover_candidates(repo: Path, explicit: str | None = None) -> list[Candidate]:
+    """Interpreters worth probing for ``repo``, best-guess first.
+
+    Order is a tie-break only — the ranking that matters comes from the probe.
+    ``sys.executable`` is always present and always last, so the list is never
+    empty and the status quo is always reachable.
+    """
+    out: list[Candidate] = []
+    if explicit:
+        out.append(Candidate(explicit, "--python", "explicit"))
+
+    override = os.environ.get("VINV_TARGET_PYTHON")
+    if override:
+        out.append(Candidate(override, "VINV_TARGET_PYTHON", "environment override"))
+
+    # An ACTIVE virtualenv counts only when it belongs to this repo. Vinv's own
+    # venv is active whenever the CLI runs, and treating that as a signal would
+    # re-elect exactly the interpreter this module exists to stop electing.
+    active = os.environ.get("VIRTUAL_ENV")
+    if active:
+        try:
+            inside = Path(active).resolve().is_relative_to(repo.resolve())
+        except (OSError, ValueError):
+            inside = False
+        exe = _venv_python(Path(active)) if inside else None
+        if exe:
+            out.append(Candidate(exe, "VIRTUAL_ENV", active))
+
+    # `uv` puts the project environment in `<repo>/.venv` unless told otherwise;
+    # the walk below finds that, and this covers the relocated case.
+    uv_env = os.environ.get("UV_PROJECT_ENVIRONMENT")
+    if uv_env:
+        base = Path(uv_env)
+        exe = _venv_python(base if base.is_absolute() else repo / base)
+        if exe:
+            out.append(Candidate(exe, "UV_PROJECT_ENVIRONMENT", uv_env))
+
+    out.extend(_in_repo_venvs(repo))
+    out.extend(_tool_venvs(repo))
+    out.append(Candidate(sys.executable, "vinv's own interpreter", "fallback"))
+
+    seen: set[str] = set()
+    unique: list[Candidate] = []
+    for cand in out:
+        k = cand.key()
+        if k in seen:
+            continue
+        seen.add(k)
+        unique.append(cand)
+    return unique[:MAX_CANDIDATES]
+
+
+# =========================================================================
+# The probe
+# =========================================================================
+
+#: Runs in the CANDIDATE interpreter. Reads a JSON name list on stdin and
+#: reports which distributions are installed. `importlib.metadata` reads
+#: `.dist-info` off the filesystem — no target package is imported, so a
+#: candidate cannot execute repo code, spend real time, or have side effects
+#: just by being measured.
+_PROBE_SRC = r"""
+import json, sys
+from importlib import metadata
+names = json.loads(sys.stdin.read())
+have = set()
+for dist in metadata.distributions():
+    try:
+        name = dist.metadata["Name"]
+    except Exception:
+        name = None
+    if name:
+        have.add("".join("-" if c in "-_." else c for c in name).lower())
+present = [n for n in names if n in have]
+missing = [n for n in names if n not in have]
+json.dump(
+    {
+        "executable": sys.executable,
+        "version": list(sys.version_info[:3]),
+        "present": present,
+        "missing": missing,
+    },
+    sys.stdout,
+)
+"""
+
+
+@dataclass
+class Probe:
+    """What one candidate interpreter answered."""
+
+    ok: bool = False
+    version: tuple[int, ...] = ()
+    #: The repo's OWN distributions this interpreter has installed.
+    own_present: tuple[str, ...] = ()
+    #: Its third-party dependencies this interpreter has installed.
+    third_present: tuple[str, ...] = ()
+    missing: tuple[str, ...] = ()
+    error: str = ""
+
+    @property
+    def score(self) -> tuple[int, int]:
+        """Rank key: the repo's own packages first, everything else as tie-break.
+
+        Lexicographic on purpose. An interpreter with the code under test
+        installed beats one with more third-party libraries, every time — the
+        second number only separates candidates that are indistinguishable on
+        the first.
+        """
+        return (len(self.own_present), len(self.third_present))
+
+    @property
+    def present(self) -> tuple[str, ...]:
+        return (*self.own_present, *self.third_present)
+
+    @property
+    def runnable(self) -> bool:
+        """Can this interpreter run an exerciser worker at all?"""
+        return self.ok and self.version >= MIN_WORKER_PYTHON
+
+
+def probe_candidate(
+    candidate: Candidate,
+    requirements: Requirements,
+    *,
+    timeout_s: float = DEFAULT_PROBE_TIMEOUT_S,
+    cwd: Path | None = None,
+) -> Probe:
+    """Ask one interpreter which of ``requirements`` it has installed.
+
+    ``-I`` isolates the probe: no user site directory, no ``PYTHON*`` env
+    inherited from Vinv's own process, and — the one that matters — no working
+    directory on ``sys.path``, so a repo with a ``json.py`` at its root cannot
+    shadow the probe's own imports.
+    """
+    try:
+        proc = subprocess.run(  # noqa: S603 (fixed argv, no shell)
+            [candidate.python, "-I", "-c", _PROBE_SRC],
+            input=json.dumps(requirements.all),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout_s,
+            cwd=str(cwd) if cwd else None,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return Probe(error=f"probe timed out after {timeout_s:g}s")
+    except OSError as exc:
+        return Probe(error=f"not executable: {exc}")
+    if proc.returncode != 0:
+        tail = (proc.stderr or "").strip().splitlines()[-1:]
+        return Probe(error=f"exit {proc.returncode}: {tail[0] if tail else 'no stderr'}"[:200])
+    try:
+        doc = json.loads(proc.stdout or "")
+    except ValueError:
+        return Probe(error="probe produced no parseable answer")
+    present = set(doc.get("present") or ())
+    return Probe(
+        ok=True,
+        version=tuple(int(p) for p in doc.get("version") or ()),
+        own_present=tuple(n for n in requirements.own if n in present),
+        third_present=tuple(n for n in requirements.third_party if n in present),
+        missing=tuple(doc.get("missing") or ()),
+    )
+
+
+# =========================================================================
+# The choice
+# =========================================================================
+
+
+@dataclass
+class InterpreterChoice:
+    """The interpreter the workers will use, and the evidence for it."""
+
+    python: str
+    origin: str
+    #: How many of the repo's OWN distributions this interpreter has installed —
+    #: the number that decided the choice.
+    own_present: int = 0
+    own_declared: int = 0
+    #: The same for third-party dependencies (the tie-break).
+    third_present: int = 0
+    third_declared: int = 0
+    #: The declared distributions it does NOT have, capped for the report.
+    missing: tuple[str, ...] = ()
+    version: tuple[int, ...] = ()
+    #: Every candidate considered, with its score — so a wrong choice is
+    #: debuggable from the run summary alone.
+    considered: list[dict[str, Any]] = field(default_factory=list)
+    diagnostics: list[str] = field(default_factory=list)
+    #: True when the choice moved off `sys.executable`.
+    handed_off: bool = False
+
+    @property
+    def target_installed(self) -> bool:
+        """Does this interpreter have the code under test installed?"""
+        return self.own_declared > 0 and self.own_present > 0
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "python": self.python,
+            "origin": self.origin,
+            "handed_off": self.handed_off,
+            "python_version": ".".join(str(p) for p in self.version) or None,
+            "target_installed": self.target_installed,
+            "repo_distributions": {
+                "declared": self.own_declared,
+                "present": self.own_present,
+            },
+            "third_party": {
+                "declared": self.third_declared,
+                "present": self.third_present,
+            },
+            "missing_sample": list(self.missing[:20]),
+            "considered": self.considered,
+        }
+
+
+def _summarise(cand: Candidate, probe: Probe, reqs: Requirements) -> dict[str, Any]:
+    own, third = probe.score
+    return {
+        "python": cand.python,
+        "origin": cand.origin,
+        "detail": cand.detail,
+        "ok": probe.ok,
+        "python_version": ".".join(str(p) for p in probe.version) or None,
+        "repo_distributions_present": f"{own}/{len(reqs.own)}",
+        "third_party_present": f"{third}/{len(reqs.third_party)}",
+        "error": probe.error or None,
+    }
+
+
+def resolve_interpreter(
+    repo: Path,
+    *,
+    explicit: str | None = None,
+    probe_timeout_s: float = DEFAULT_PROBE_TIMEOUT_S,
+    logger: logging.Logger | None = None,
+) -> InterpreterChoice:
+    """Pick the interpreter whose installed set best matches what ``repo`` declares.
+
+    ``explicit`` (the ``--python`` flag) is HONOURED unconditionally — a human
+    who names an interpreter has said something this function cannot outrank —
+    but it is still probed, so pointing the flag at the wrong venv produces a
+    diagnostic instead of another silent zero.
+
+    With no explicit flag the answer is the candidate with the most of the
+    repo's OWN distributions installed (third-party count as tie-break), and
+    ``sys.executable`` wins every remaining tie. Strictly-greater is the whole
+    rule: a repo that IS installed into Vinv's venv, or one that declares
+    nothing at all, keeps today's behaviour exactly and pays only the probe.
+    """
+    log_ = logger or log
+    reqs = declared_requirements(repo)
+    candidates = discover_candidates(repo, explicit)
+
+    probes: list[tuple[Candidate, Probe]] = []
+    for cand in candidates:
+        probe = probe_candidate(cand, reqs, timeout_s=probe_timeout_s, cwd=repo)
+        probes.append((cand, probe))
+        if explicit and cand.origin == "--python":
+            # The human's answer stands; nothing after this can change it, so
+            # there is no reason to pay for the rest of the fan-out.
+            break
+
+    considered = [_summarise(c, p, reqs) for c, p in probes]
+    diagnostics: list[str] = []
+
+    def _build(cand: Candidate, probe: Probe, *, handed_off: bool) -> InterpreterChoice:
+        own, third = probe.score
+        return InterpreterChoice(
+            python=cand.python,
+            origin=cand.origin,
+            own_present=own,
+            own_declared=len(reqs.own),
+            third_present=third,
+            third_declared=len(reqs.third_party),
+            missing=probe.missing,
+            version=probe.version,
+            considered=considered,
+            handed_off=handed_off,
+        )
+
+    self_key = Candidate(sys.executable, "").key()
+
+    if explicit:
+        cand, probe = probes[0]
+        choice = _build(cand, probe, handed_off=cand.key() != self_key)
+        if not probe.ok:
+            diagnostics.append(
+                f"--python {cand.python} could not be probed ({probe.error}) — the "
+                "workers will use it anyway, because an explicit flag is not "
+                "second-guessed, but nothing here confirms it can import the target."
+            )
+        elif reqs.own and probe.score[0] == 0:
+            diagnostics.append(
+                f"--python {cand.python} has NONE of the {len(reqs.own)} distribution(s) "
+                f"this repo publishes ({', '.join(reqs.own[:5])}) — the code under test "
+                "is not installed there, and every worker will fail in import."
+            )
+        elif not probe.runnable and probe.ok:
+            diagnostics.append(
+                f"--python {cand.python} is Python "
+                f"{'.'.join(str(p) for p in probe.version)}, below exerciser's "
+                f"{'.'.join(str(p) for p in MIN_WORKER_PYTHON)} floor — the worker "
+                "itself will not run there."
+            )
+        choice.diagnostics = diagnostics
+        return choice
+
+    runnable = [(c, p) for c, p in probes if p.runnable]
+    unrunnable = [(c, p) for c, p in probes if p.ok and not p.runnable]
+
+    fallback = next(
+        ((c, p) for c, p in probes if c.key() == self_key),
+        (Candidate(sys.executable, "vinv's own interpreter", "fallback"), Probe()),
+    )
+    best_cand, best_probe = fallback
+    for cand, probe in runnable:
+        # STRICTLY greater, lexicographically. A tie keeps `sys.executable`, so
+        # the handoff only ever happens on evidence that it buys something.
+        if probe.score > best_probe.score:
+            best_cand, best_probe = cand, probe
+
+    handed_off = best_cand.key() != self_key
+    if handed_off:
+        log_.info(
+            "interpreter: %s (%s) has %d/%d of the repo's own distributions; "
+            "handing the workers off from %s",
+            best_cand.python,
+            best_cand.origin,
+            best_probe.score[0],
+            len(reqs.own),
+            sys.executable,
+        )
+        diagnostics.append(
+            f"workers will run under {best_cand.python} ({best_cand.origin}): it has "
+            f"{best_probe.score[0]}/{len(reqs.own)} of the distributions this repo "
+            f"publishes, against {fallback[1].score[0]}/{len(reqs.own)} in Vinv's own "
+            "venv. Pass --python to override."
+        )
+    for cand, probe in unrunnable:
+        # Reported, not silently dropped: "the repo's venv is too old for our
+        # worker" is a fact the human needs, and it is invisible from a run that
+        # merely stayed on the fallback.
+        diagnostics.append(
+            f"{cand.python} ({cand.origin}) has {probe.score[0]}/{len(reqs.own)} of the "
+            f"repo's own distributions but is Python "
+            f"{'.'.join(str(p) for p in probe.version)}, below exerciser's "
+            f"{'.'.join(str(p) for p in MIN_WORKER_PYTHON)} floor — it cannot host a "
+            "worker, so it was not used."
+        )
+
+    choice = _build(best_cand, best_probe, handed_off=handed_off)
+    choice.diagnostics = diagnostics
+    return choice
+
+
+@lru_cache(maxsize=32)
+def _cached(repo_key: str, explicit: str | None, timeout: float) -> InterpreterChoice:
+    return resolve_interpreter(Path(repo_key), explicit=explicit, probe_timeout_s=timeout)
+
+
+def resolve_cached(
+    repo: Path,
+    *,
+    explicit: str | None = None,
+    probe_timeout_s: float = DEFAULT_PROBE_TIMEOUT_S,
+    logger: logging.Logger | None = None,
+) -> InterpreterChoice:
+    """``resolve_interpreter`` memoised per (repo, flag).
+
+    The campaign resolves the same answer for five oracles in one run, and a
+    fan-out of probe subprocesses per oracle is pure cost — the filesystem it
+    reads does not change mid-run.
+    """
+    choice = _cached(str(repo.resolve()), explicit, probe_timeout_s)
+    if logger and choice.diagnostics:
+        for diag in choice.diagnostics:
+            logger.info("interpreter: %s", diag)
+    return choice
+
+
+def reset_cache() -> None:
+    """Drop the memo — tests build a fresh tree per case."""
+    _cached.cache_clear()

--- a/exerciser/src/exerciser/redact.py
+++ b/exerciser/src/exerciser/redact.py
@@ -48,10 +48,19 @@ PLACEHOLDER = "[redacted]"
 #: (whose value is the literal "bearer" — metadata an enum invariant legitimately
 #: learns) while still missing ``X-Api-Key`` (dash, not underscore). Over-
 #: redaction is an oracle bug, so the rule has to be tighter than "contains".
+#:
+#: ``secretkey``/``accesskey`` are listed even though ``secret`` already is:
+#: the suffix rule reads the LAST noun, and ``SECRET_KEY`` normalises to
+#: ``secretkey``, which ends in "key" rather than "secret". Django's and
+#: Flask's canonical setting name, and ``AWS_SECRET_ACCESS_KEY`` with it, were
+#: therefore not recognised at all.
 _SECRET_KEY_NOUNS = (
     "password",
     "passwd",
+    "passphrase",
     "secret",
+    "secretkey",
+    "accesskey",
     "token",
     "apikey",
     "authorization",
@@ -109,19 +118,38 @@ def is_id_shaped(value: str) -> bool:
     return not any(c in value for c in " \t\r\n/?#&=")
 
 
-#: ``key: 'value'`` / ``"key" = "value"`` / ``KEY=value`` inside FREE TEXT.
-#: The key is captured so the existing ``is_secret_key`` predicate decides —
-#: this adds a place to look, never a second vocabulary of what is secret.
-#: The bare-value branch deliberately excludes quotes and openers. Without that
-#: exclusion ``input_value={'openai_api_key': 'sk-…'}`` matched as the pair
-#: ``input_value`` → ``{'openai_api_key':`` — a non-secret key whose "value"
-#: swallowed the real one, so the credential a character later was never even
-#: looked at. The nested pair has to stay reachable.
-_TEXT_PAIR = re.compile(
-    r"""(?P<kq>['"]?)(?P<key>[A-Za-z_][A-Za-z0-9_.\- ]{0,60})(?P=kq)"""
-    r"""(?P<sep>\s*[:=]\s*)"""
-    r"""(?:(?P<vq>['"])(?P<quoted>(?:(?!(?P=vq)).)*)(?P=vq)|(?P<bare>[^\s,;:=)}\]'"{\[(]+))"""
+#: ``key:`` / ``"key" =`` / ``KEY=`` — the LEFT half of a pair in free text. The
+#: key is captured so the existing ``is_secret_key`` predicate decides; this
+#: adds a place to look, never a second vocabulary of what is secret.
+_TEXT_KEY = re.compile(
+    r"""(?P<kq>['"]?)(?P<key>[A-Za-z_][A-Za-z0-9_.\- ]{0,60})(?P=kq)(?P<sep>\s*[:=]\s*)"""
 )
+
+#: A quoted value. Same shape whoever owns the key.
+_TEXT_QUOTED = re.compile(r"""(?P<vq>['"])(?P<quoted>(?:(?!(?P=vq)).)*)(?P=vq)""")
+
+#: An unquoted value under a NON-secret key. Deliberately short: it stops at
+#: quotes, openers and ``=`` so that ``input_value={'api_key': …}`` and
+#: ``Traceback: token=sk-…`` leave the inner pair intact for the scan to reach.
+_TEXT_BARE_SHORT = re.compile(r"""[^\s,;:=)}\]'"{\[(]+""")
+
+#: An unquoted value under a SECRET key, which is a different question: ``=`` is
+#: part of the value, not a new pair. ``Set-Cookie: session=abc; Path=/`` broke
+#: under the short form — it stopped at the ``=``, redacted the cookie's NAME
+#: and left the value in the text.
+_TEXT_BARE_SECRET = re.compile(r"""[^\s\r\n,;&)}\]]+""")
+
+#: An auth SCHEME is not the credential, it introduces one. ``Authorization:
+#: Bearer eyJ…`` redacted the word "Bearer" and published the token, because a
+#: value that stops at whitespace stops one word early here — and only here, so
+#: the rest of an ordinary message ("token=… in file") keeps its prose.
+_AUTH_SCHEMES = frozenset({"bearer", "basic", "digest", "token", "jwt", "apikey", "key"})
+_TEXT_NEXT_WORD = re.compile(r"""[ \t]+(?P<word>[^\s\r\n,;&)}\]]+)""")
+
+#: A JWT with no key at all — a bearer token pasted bare into a traceback. Rule
+#: 2 of this module says the shape is enough under ANY key name, and "no key"
+#: is the limiting case of that.
+_BARE_JWT = re.compile(r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]*")
 
 
 def redact_text(text: str) -> str:
@@ -138,22 +166,57 @@ def redact_text(text: str) -> str:
     — and that message is persisted to ``.vinv/`` and printed to stdout. The
     engine has to be able to quote a target's error without becoming a way to
     exfiltrate the target's keys.
+
+    Scanned rather than ``re.sub``-ed, because a substitution consumes its whole
+    match and the value of one pair is routinely the KEY of the next. A single
+    pattern therefore let an innocent key swallow the credential behind it:
+    ``Traceback: token=sk-…`` matched as ``Traceback`` → ``token`` and the scan
+    resumed past the real pair. On a non-secret key this resumes INSIDE the
+    value, so every nested pair is examined on its own terms.
     """
     if not text:
         return text
 
-    def _sub(match: re.Match[str]) -> str:
+    out: list[str] = []
+    pos = 0
+    while pos < len(text):
+        match = _TEXT_KEY.search(text, pos)
+        if match is None:
+            break
         key = match.group("key")
-        value = match.group("quoted")
-        if value is None:
-            value = match.group("bare") or ""
-        if not (is_secret_key(key) or looks_like_jwt(value)):
-            return match.group(0)
-        quote = match.group("vq") or ""
-        kq = match.group("kq")
-        return f"{kq}{key}{kq}{match.group('sep')}{quote}{PLACEHOLDER}{quote}"
-
-    return _TEXT_PAIR.sub(_sub, text)
+        secret = is_secret_key(key)
+        value_at = match.end()
+        quoted = _TEXT_QUOTED.match(text, value_at)
+        if quoted is not None:
+            if not (secret or looks_like_jwt(quoted.group("quoted"))):
+                # Keep it verbatim and resume after it: a quoted value cannot
+                # itself be a key, so there is nothing inside to reach.
+                out.append(text[pos : quoted.end()])
+                pos = quoted.end()
+                continue
+            vq = quoted.group("vq")
+            out.append(f"{text[pos : match.end()]}{vq}{PLACEHOLDER}{vq}")
+            pos = quoted.end()
+            continue
+        bare = (_TEXT_BARE_SECRET if secret else _TEXT_BARE_SHORT).match(text, value_at)
+        if bare is None:
+            out.append(text[pos : match.end()])
+            pos = match.end()
+            continue
+        value = bare.group(0).rstrip()
+        if secret and value.casefold() in _AUTH_SCHEMES:
+            after = _TEXT_NEXT_WORD.match(text, value_at + len(value))
+            if after is not None:
+                value = text[value_at : after.end()]
+        if not (secret or looks_like_jwt(value)):
+            # Resume at the VALUE, not past it — it is the next candidate key.
+            out.append(text[pos:value_at])
+            pos = value_at
+            continue
+        out.append(f"{text[pos : match.end()]}{PLACEHOLDER}")
+        pos = value_at + len(value)
+    out.append(text[pos:])
+    return _BARE_JWT.sub(PLACEHOLDER, "".join(out))
 
 
 def redact(obj: Any, *, _key: str | None = None) -> Any:

--- a/exerciser/src/exerciser/redact.py
+++ b/exerciser/src/exerciser/redact.py
@@ -118,6 +118,59 @@ def is_id_shaped(value: str) -> bool:
     return not any(c in value for c in " \t\r\n/?#&=")
 
 
+#: ``user:password@host`` in a URL's authority. Whether or not the password is
+#: named anything, its POSITION says what it is.
+_URL_USERINFO = re.compile(r"(?P<scheme>[a-zA-Z][\w+.-]*://)(?P<user>[^/@\s:]+):[^/@\s]*@")
+
+#: Query-parameter names that mean "credential" in a URL and do NOT mean it as a
+#: field name — so this list is scoped to `redact_url` and deliberately not added
+#: to `_SECRET_KEY_NOUNS`.
+#:
+#: `key` is the case that forces the distinction. As a query parameter it is how
+#: Google authenticates (`?key=AIza…`) and is a credential essentially always; as
+#: a field name it is `sort_key`, `cache_key`, `partition_key`, `primary_key`,
+#: and redacting those would corrupt the observations the invariant oracle learns
+#: from — the over-redaction this module treats as an oracle bug. `sig` is Azure
+#: SAS, `signature` is AWS presigned. Position is the discriminator, which is the
+#: same reason `is_id_shaped` exists.
+_URL_SECRET_PARAMS = frozenset({"key", "sig", "signature", "auth"})
+
+
+def redact_url(url: str) -> str:
+    """Redact credentials carried in a URL, keeping the URL readable.
+
+    A recorded request line is one of the places a key most reliably ends up:
+    plenty of providers authenticate by query parameter (``?key=…``,
+    ``?access_token=…``) rather than by header, and a connection string carries
+    its password in the authority. ``is_id_shaped`` already refuses to SPLICE a
+    credential into a URL for exactly this reason — this is the same rule applied
+    to a URL the target built itself and the engine is about to write down.
+
+    Only values are touched: the scheme, host, path and parameter NAMES survive,
+    because what the URL was is the whole diagnostic value of recording it.
+    """
+    if not url:
+        return url
+    out = _URL_USERINFO.sub(rf"\g<scheme>\g<user>:{PLACEHOLDER}@", url)
+    head, sep, query = out.partition("?")
+    if not sep:
+        return out
+    query, frag_sep, fragment = query.partition("#")
+    pairs: list[str] = []
+    for part in query.split("&"):
+        name, eq, value = part.partition("=")
+        secret = (
+            is_secret_key(name)
+            or _normalize_key(name) in _URL_SECRET_PARAMS
+            or looks_like_jwt(value)
+        )
+        if eq and value and secret:
+            pairs.append(f"{name}={PLACEHOLDER}")
+        else:
+            pairs.append(part)
+    return f"{head}?{'&'.join(pairs)}{frag_sep}{fragment}"
+
+
 #: ``key:`` / ``"key" =`` / ``KEY=`` — the LEFT half of a pair in free text. The
 #: key is captured so the existing ``is_secret_key`` predicate decides; this
 #: adds a place to look, never a second vocabulary of what is secret.

--- a/exerciser/src/exerciser/redact.py
+++ b/exerciser/src/exerciser/redact.py
@@ -109,6 +109,53 @@ def is_id_shaped(value: str) -> bool:
     return not any(c in value for c in " \t\r\n/?#&=")
 
 
+#: ``key: 'value'`` / ``"key" = "value"`` / ``KEY=value`` inside FREE TEXT.
+#: The key is captured so the existing ``is_secret_key`` predicate decides —
+#: this adds a place to look, never a second vocabulary of what is secret.
+#: The bare-value branch deliberately excludes quotes and openers. Without that
+#: exclusion ``input_value={'openai_api_key': 'sk-…'}`` matched as the pair
+#: ``input_value`` → ``{'openai_api_key':`` — a non-secret key whose "value"
+#: swallowed the real one, so the credential a character later was never even
+#: looked at. The nested pair has to stay reachable.
+_TEXT_PAIR = re.compile(
+    r"""(?P<kq>['"]?)(?P<key>[A-Za-z_][A-Za-z0-9_.\- ]{0,60})(?P=kq)"""
+    r"""(?P<sep>\s*[:=]\s*)"""
+    r"""(?:(?P<vq>['"])(?P<quoted>(?:(?!(?P=vq)).)*)(?P=vq)|(?P<bare>[^\s,;:=)}\]'"{\[(]+))"""
+)
+
+
+def redact_text(text: str) -> str:
+    """Redact credential values embedded in a free-text blob.
+
+    ``redact`` walks a STRUCTURE and decides by field name, which is the right
+    rule and the wrong reach: an exception message is one string, and the
+    credential inside it is spelled as text. A settings object that fails
+    validation renders its whole input dict into the message —
+
+        5 validation errors for Settings ... input_value={'openai_api_key':
+        'sk-pr...54k5cA', ...}
+
+    — and that message is persisted to ``.vinv/`` and printed to stdout. The
+    engine has to be able to quote a target's error without becoming a way to
+    exfiltrate the target's keys.
+    """
+    if not text:
+        return text
+
+    def _sub(match: re.Match[str]) -> str:
+        key = match.group("key")
+        value = match.group("quoted")
+        if value is None:
+            value = match.group("bare") or ""
+        if not (is_secret_key(key) or looks_like_jwt(value)):
+            return match.group(0)
+        quote = match.group("vq") or ""
+        kq = match.group("kq")
+        return f"{kq}{key}{kq}{match.group('sep')}{quote}{PLACEHOLDER}{quote}"
+
+    return _TEXT_PAIR.sub(_sub, text)
+
+
 def redact(obj: Any, *, _key: str | None = None) -> Any:
     """Return ``obj`` with credential values replaced, shape and types intact.
 

--- a/exerciser/src/exerciser/sandbox.py
+++ b/exerciser/src/exerciser/sandbox.py
@@ -1942,6 +1942,17 @@ def _worker_main(argv: list[str]) -> int:
                     for e in service_events
                 ):
                     row["seed_dependent"] = True
+                # `substituted` belongs here too, and its absence was the whole
+                # gap. A seeded ROW is invented data the target then reads; a
+                # substituted HTTP call is an invented RESPONSE the target then
+                # reads — the same claim about the same verdict. It was left out
+                # because the other substitutes RAISE (and `mark_contained` keys
+                # on the raising module), while the HTTP double RETURNS a body:
+                # the failure surfaces later, in the target's own code, under the
+                # target's own exception type, where nothing can attribute it
+                # except this record.
+                if any(e.get("kind") == "substituted" for e in service_events):
+                    row["substitution_dependent"] = True
             rows.append(mark_contained(row, tier))
     fn._emit(rows)
     return 0

--- a/exerciser/src/exerciser/sandbox.py
+++ b/exerciser/src/exerciser/sandbox.py
@@ -927,15 +927,27 @@ def write_shim(directory: Path) -> Path:
 
     The service doubles ship alongside it as ``_vinv_service_doubles`` — a COPY
     of :mod:`exerciser.service_doubles`, not an import of it, because the worker
-    has only the standard library and the repo on its path. The module is
-    dependency-free precisely so this copy is a copy and nothing more.
+    has only the standard library and the repo on its path.
+
+    ``redact`` ships the same way, as ``_vinv_redact``. The doubles redact the
+    request lines they record — a provider URL carries the key in `?key=`/`?sig=`
+    and a connection string carries its password in the authority — and that
+    logic must not be duplicated just to satisfy the copy. Shipping the module
+    beside it keeps ONE implementation and keeps the copy free of package
+    imports, which is the constraint that makes it work at all: a relative
+    import here raises `attempted relative import with no known parent package`
+    inside the jail and takes down every double, not only the one that needed it.
     """
     directory.mkdir(parents=True, exist_ok=True)
     path = directory / "sitecustomize.py"
     path.write_text(_SITECUSTOMIZE_SOURCE, encoding="utf-8")
-    doubles = Path(__file__).with_name("service_doubles.py")
-    if doubles.is_file():
-        shutil.copy2(doubles, directory / "_vinv_service_doubles.py")
+    for source, target in (
+        ("service_doubles.py", "_vinv_service_doubles.py"),
+        ("redact.py", "_vinv_redact.py"),
+    ):
+        module = Path(__file__).with_name(source)
+        if module.is_file():
+            shutil.copy2(module, directory / target)
     return path
 
 

--- a/exerciser/src/exerciser/sandbox.py
+++ b/exerciser/src/exerciser/sandbox.py
@@ -1509,6 +1509,9 @@ def run_sandboxed_targets(
                 ),
                 encoding="utf-8",
             )
+            from .functions import distribution_cwd
+
+            module_cwd = distribution_cwd(sandbox.repo_copy, module_refusals[0].target.file)
             cmd = sandbox.mechanism.wrap(
                 [
                     python or sys.executable,
@@ -1532,7 +1535,14 @@ def run_sandboxed_targets(
                     encoding="utf-8",
                     errors="replace",
                     timeout=module_timeout_s,
-                    cwd=str(sandbox.repo_copy),
+                    # The distribution's own directory INSIDE the jail, for the
+                    # same reason the ordinary worker uses it: a repo's relative
+                    # paths resolve against the working directory, so starting
+                    # every module at the tree root silently changes what the
+                    # code under test reads. Containment is unaffected — this is
+                    # a directory within `sandbox.root`, which is what the
+                    # mechanism confines.
+                    cwd=str(module_cwd),
                     env=env,
                     preexec_fn=preexec,  # noqa: PLW1509 (POSIX rlimits, guarded)
                 )

--- a/exerciser/src/exerciser/service_doubles.py
+++ b/exerciser/src/exerciser/service_doubles.py
@@ -2135,6 +2135,24 @@ class SubstitutedResponse:
         return False
 
 
+#: Hosts that are this machine, not a remote dependency. The substitution's whole
+#: justification is that the run cannot reach a provider; none of that applies to
+#: the repo's own service, and `.localhost` is reserved for loopback by RFC 6761.
+_LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1", "0.0.0.0", "[::1]"})
+
+
+def _is_loopback(url: str) -> bool:
+    """Whether ``url`` addresses this machine rather than a remote service."""
+    host = url.partition("://")[2].partition("/")[0].partition("?")[0]
+    host = host.rpartition("@")[2]
+    if host.startswith("["):  # bracketed IPv6 keeps its brackets to the close
+        host = host[: host.find("]") + 1] if "]" in host else host
+    else:
+        host = host.partition(":")[0]
+    host = host.lower()
+    return host in _LOOPBACK_HOSTS or host.endswith(".localhost") or host.startswith("127.")
+
+
 def _serve_http(method: str, url: str) -> SubstitutedResponse:
     """Answer one request from the double, and RECORD that the double answered.
 
@@ -2151,6 +2169,16 @@ def _serve_http(method: str, url: str) -> SubstitutedResponse:
     `.env`. The ledger is a file in the user's repository; the double answering
     the call is not a reason to write the key down.
     """
+    if _is_loopback(str(url)):
+        # NOT substituted. The cut is a REMOTE dependency the run cannot reach;
+        # a call to the repo's own service on loopback is the repo talking to
+        # itself, and answering it with a vivifying body turns a call that would
+        # have failed honestly into one that proceeds on fabricated data — every
+        # assertion after it becoming a "finding". Under containment the network
+        # is denied anyway, so refusing here is the behaviour that existed before
+        # the double and the one the row is already classified for.
+        _record("substitution-declined", "http", f"{method} {redact_url(str(url))} (loopback)")
+        raise ConnectionRefusedError(f"vinv: not substituting a loopback call to {url}")
     safe = redact_url(str(url))
     _record(SUBSTITUTED, "http", f"{method} {safe}", url=safe, method=method)
     return SubstitutedResponse(url=str(url), method=method)

--- a/exerciser/src/exerciser/service_doubles.py
+++ b/exerciser/src/exerciser/service_doubles.py
@@ -1891,6 +1891,8 @@ def install(
         patchers[name] = _patch_kv
     for name in OBJECTSTORE_MODULES:
         patchers[name] = _patch_objectstore
+    for name in HTTP_MODULES:
+        patchers[name] = _HTTP_PATCHERS[name]
     patchers["sqlalchemy"] = _patch_sqlalchemy
     _pending.clear()
     _pending.update(patchers)
@@ -1972,3 +1974,288 @@ def summary() -> dict[str, Any]:
         "substitution_gaps": by_kind.get(FIDELITY_GAP, 0),
         "events": _events[:200],
     }
+
+
+# ---------------------------------------------------------------------------
+# HTTP — one seam for every remote API, including the model providers
+# ---------------------------------------------------------------------------
+#
+# Under containment the network is denied, so every target that reaches a remote
+# API lands as `contained`: correctly not a defect, and correctly not exercised.
+# That is most of the interesting surface on any repo that talks to a provider.
+#
+# The obvious substitution is a double per provider — an `openai` stand-in, an
+# `anthropic` stand-in. That does not scale and is already wrong: langchain
+# vendors sixteen partner packages in ONE repository, so the list needs sixteen
+# entries for a single target and is still wrong for the seventeenth.
+#
+# So the cut is HTTP, which is where every one of them bottoms out, and which is
+# a standard rather than a vendor — the same reasoning that makes PEP 249 the
+# right cut for databases instead of a psycopg double and a pymysql double.
+#
+# The response BODY is the part that looks like it needs per-API knowledge, and
+# does not. A client reads a body by ACCESS PATH — `r["choices"][0]["message"]
+# ["content"]` — so a body that satisfies any access path satisfies every API
+# without knowing one of them. `LenientBody` is that: it auto-vivifies on
+# lookup, indexes as a one-element sequence, and renders as a placeholder
+# string. No schema, no induction round-trip, no registry.
+#
+# What it CANNOT do is be correct. A doubled provider returns a plausibly-shaped
+# answer, never a right one, so anything asserting on model output is a
+# SUBSTITUTION GAP and never a defect in the repo. The four-value discipline the
+# rest of this module keeps — ok / rejected / defect / substitution-gap — is what
+# stops "the double answered and the target then failed" being reported as
+# "the repo is broken".
+
+#: HTTP clients worth substituting. Small and stable, unlike a vendor list:
+#: these are the transports every Python API client is built on.
+HTTP_MODULES: tuple[str, ...] = ("httpx", "requests", "aiohttp")
+
+#: Rendered where a client expects a string it will not parse further.
+_HTTP_PLACEHOLDER = "vinv-substituted"
+
+
+class LenientBody(dict):
+    """A JSON body that satisfies any access path a client happens to use.
+
+    Clients read responses positionally and by key, several levels deep, and
+    which keys depends entirely on the API. Rather than model each one, this
+    answers whatever is asked: a missing key vivifies into another
+    ``LenientBody``, indexing yields the same body back (so ``[0]`` on what the
+    caller believes is a list works), and coercion produces a placeholder.
+
+    Deliberately a ``dict`` subclass so ``isinstance(body, dict)`` — which real
+    client code branches on — stays true.
+    """
+
+    def __missing__(self, key: Any) -> LenientBody:
+        child = LenientBody()
+        self[key] = child
+        return child
+
+    def __getitem__(self, key: Any) -> Any:
+        # An integer index means the caller believes this is a sequence. Give
+        # back the body itself rather than inventing an element, so a chain like
+        # `["choices"][0]["message"]` keeps descending.
+        if isinstance(key, int):
+            return self
+        return super().__getitem__(key)
+
+    def __getattr__(self, name: str) -> Any:
+        if name.startswith("__"):
+            raise AttributeError(name)
+        return self[name]
+
+    def __iter__(self) -> Any:
+        # Iterating an unpopulated body yields ONE element, so `for choice in
+        # r["choices"]` runs its body exactly once instead of not at all. An
+        # already-populated body iterates its real keys.
+        #
+        # `super().__len__()`, NOT `not self`: `__bool__` below is always True
+        # (a response body must not read as falsy to a client guarding on it),
+        # so the truthiness test never fired and every loop over a substituted
+        # collection ran zero times — the exact "not exercised" outcome the
+        # substitution exists to remove.
+        if super().__len__() == 0:
+            return iter([self])
+        return super().__iter__()
+
+    def __len__(self) -> int:
+        return super().__len__() or 1
+
+    def __str__(self) -> str:
+        return _HTTP_PLACEHOLDER
+
+    def __contains__(self, key: Any) -> bool:
+        # A client guarding with `if "error" in body` must not be told yes —
+        # that would hand it an error path it never had a reason to take.
+        return super().__contains__(key)
+
+    def __bool__(self) -> bool:
+        return True
+
+
+class SubstitutedResponse:
+    """A response object shaped like the ones httpx/requests hand back."""
+
+    def __init__(self, url: str = "", method: str = "GET", status_code: int = 200):
+        self.status_code = status_code
+        self.status = status_code  # aiohttp's spelling
+        self.url = url
+        self.request_method = method
+        self.headers: dict[str, str] = {"content-type": "application/json"}
+        self.reason_phrase = "OK"
+        self.reason = "OK"
+        self.encoding = "utf-8"
+        self._body = LenientBody()
+
+    def json(self, **_kwargs: Any) -> LenientBody:
+        return self._body
+
+    @property
+    def text(self) -> str:
+        return _HTTP_PLACEHOLDER
+
+    @property
+    def content(self) -> bytes:
+        return _HTTP_PLACEHOLDER.encode()
+
+    def read(self) -> bytes:
+        return self.content
+
+    def iter_lines(self, *_a: Any, **_k: Any) -> Any:
+        return iter([])
+
+    def iter_content(self, *_a: Any, **_k: Any) -> Any:
+        return iter([self.content])
+
+    def raise_for_status(self) -> SubstitutedResponse:
+        return self
+
+    @property
+    def is_success(self) -> bool:
+        return True
+
+    @property
+    def ok(self) -> bool:
+        return True
+
+    def __enter__(self) -> SubstitutedResponse:
+        return self
+
+    def __exit__(self, *_exc: Any) -> bool:
+        return False
+
+    async def __aenter__(self) -> SubstitutedResponse:
+        return self
+
+    async def __aexit__(self, *_exc: Any) -> bool:
+        return False
+
+
+def _serve_http(method: str, url: str) -> SubstitutedResponse:
+    """Answer one request from the double, and RECORD that the double answered.
+
+    The recording is the load-bearing part. A parent inferring participation
+    from an error message is guessing, and a guess misattributes a genuine
+    defect — a `NameError` inside a repo's own fake-embeddings class has no
+    provider anywhere near it, and would be blamed on the substitution by any
+    rule that reads the text. Only the double knows whether the double answered.
+    """
+    _record(SUBSTITUTED, "http", f"{method} {url}", url=str(url), method=method)
+    return SubstitutedResponse(url=str(url), method=method)
+
+
+def _patch_httpx(module: types.ModuleType) -> None:
+    """Substitute httpx at the CLIENT, which is what every SDK builds on."""
+
+    def request(_self: Any, method: str, url: Any = "", *_a: Any, **_k: Any) -> SubstitutedResponse:
+        return _serve_http(str(method).upper(), url)
+
+    def verb(name: str) -> Any:
+        def call(_self: Any, url: Any = "", *_a: Any, **_k: Any) -> SubstitutedResponse:
+            return _serve_http(name, url)
+
+        return call
+
+    async def arequest(
+        _self: Any, method: str, url: Any = "", *_a: Any, **_k: Any
+    ) -> SubstitutedResponse:
+        return _serve_http(str(method).upper(), url)
+
+    async def averb_call(_self: Any, url: Any = "", *_a: Any, **_k: Any) -> SubstitutedResponse:
+        return _serve_http("GET", url)
+
+    for client_name in ("Client", "AsyncClient"):
+        client = getattr(module, client_name, None)
+        if client is None:
+            continue
+        is_async = client_name.startswith("Async")
+        client.request = arequest if is_async else request  # type: ignore[attr-defined]
+        client.send = arequest if is_async else request  # type: ignore[attr-defined]
+        for name in ("get", "post", "put", "patch", "delete", "head", "options"):
+            setattr(client, name, averb_call if is_async else verb(name.upper()))
+        # `with httpx.Client() as c:` and the async form.
+        client.__enter__ = lambda self: self  # type: ignore[attr-defined]
+        client.__exit__ = lambda self, *a: False  # type: ignore[attr-defined]
+        client.close = lambda self: None  # type: ignore[attr-defined]
+
+    for name in ("get", "post", "put", "patch", "delete", "head", "options", "request"):
+        if hasattr(module, name):
+            setattr(
+                module,
+                name,
+                (lambda n: lambda url="", *a, **k: _serve_http(n.upper(), url))(name),
+            )
+
+
+def _patch_requests(module: types.ModuleType) -> None:
+    """Substitute requests at both the module verbs and `Session`."""
+
+    def call(name: str) -> Any:
+        def outer(url: Any = "", *_a: Any, **_k: Any) -> SubstitutedResponse:
+            return _serve_http(name.upper(), url)
+
+        return outer
+
+    for name in ("get", "post", "put", "patch", "delete", "head", "options"):
+        setattr(module, name, call(name))
+    if hasattr(module, "request"):
+        module.request = lambda method="GET", url="", *a, **k: _serve_http(  # type: ignore[attr-defined]
+            str(method).upper(), url
+        )
+
+    session = getattr(module, "Session", None)
+    if session is not None:
+        session.request = lambda self, method="GET", url="", *a, **k: _serve_http(  # type: ignore[attr-defined]
+            str(method).upper(), url
+        )
+        for name in ("get", "post", "put", "patch", "delete", "head", "options"):
+            setattr(
+                session,
+                name,
+                (lambda n: lambda self, url="", *a, **k: _serve_http(n.upper(), url))(name),
+            )
+        session.__enter__ = lambda self: self  # type: ignore[attr-defined]
+        session.__exit__ = lambda self, *a: False  # type: ignore[attr-defined]
+
+
+def _patch_aiohttp(module: types.ModuleType) -> None:
+    session = getattr(module, "ClientSession", None)
+    if session is None:
+        return
+
+    def call(name: str) -> Any:
+        def outer(_self: Any, url: Any = "", *_a: Any, **_k: Any) -> SubstitutedResponse:
+            return _serve_http(name.upper(), url)
+
+        return outer
+
+    for name in ("get", "post", "put", "patch", "delete", "head", "options"):
+        setattr(session, name, call(name))
+    session.request = lambda self, method="GET", url="", *a, **k: _serve_http(  # type: ignore[attr-defined]
+        str(method).upper(), url
+    )
+    session.close = _noop_close  # type: ignore[attr-defined]
+    session.__aenter__ = _self_async  # type: ignore[attr-defined]
+    session.__aexit__ = _false_async  # type: ignore[attr-defined]
+
+
+async def _noop_close(_self: Any) -> None:
+    return None
+
+
+async def _self_async(self: Any) -> Any:
+    return self
+
+
+async def _false_async(_self: Any, *_exc: Any) -> bool:
+    return False
+
+
+#: Which patcher serves which HTTP client.
+_HTTP_PATCHERS = {
+    "httpx": _patch_httpx,
+    "requests": _patch_requests,
+    "aiohttp": _patch_aiohttp,
+}

--- a/exerciser/src/exerciser/service_doubles.py
+++ b/exerciser/src/exerciser/service_doubles.py
@@ -59,6 +59,8 @@ import sys
 import types
 from typing import Any
 
+from .redact import redact_url
+
 # ---------------------------------------------------------------------------
 # Ledger — every substitution and every fidelity gap is written down
 # ---------------------------------------------------------------------------
@@ -2141,8 +2143,16 @@ def _serve_http(method: str, url: str) -> SubstitutedResponse:
     defect — a `NameError` inside a repo's own fake-embeddings class has no
     provider anywhere near it, and would be blamed on the substitution by any
     rule that reads the text. Only the double knows whether the double answered.
+
+    The recorded URL is REDACTED and the live one is not. A provider that
+    authenticates by query parameter — ``?key=…`` is Gemini's spelling, and it is
+    not alone — puts the credential in the request line, and the target builds
+    that line from the real key `declared_env` loaded out of the repo's own
+    `.env`. The ledger is a file in the user's repository; the double answering
+    the call is not a reason to write the key down.
     """
-    _record(SUBSTITUTED, "http", f"{method} {url}", url=str(url), method=method)
+    safe = redact_url(str(url))
+    _record(SUBSTITUTED, "http", f"{method} {safe}", url=safe, method=method)
     return SubstitutedResponse(url=str(url), method=method)
 
 

--- a/exerciser/src/exerciser/service_doubles.py
+++ b/exerciser/src/exerciser/service_doubles.py
@@ -59,7 +59,10 @@ import sys
 import types
 from typing import Any
 
-from .redact import redact_url
+try:  # inside the package
+    from .redact import redact_url
+except ImportError:  # the standalone copy in the jail — see `sandbox.write_shim`
+    from _vinv_redact import redact_url  # type: ignore[no-redef]
 
 # ---------------------------------------------------------------------------
 # Ledger — every substitution and every fidelity gap is written down

--- a/exerciser/src/exerciser/services.py
+++ b/exerciser/src/exerciser/services.py
@@ -37,7 +37,12 @@ from pathlib import Path
 from typing import Any
 
 from .agent_loop import AgentChannel, Question, question_key
-from .service_doubles import KV_MODULES, OBJECTSTORE_MODULES, PEP249_DRIVERS
+from .service_doubles import (
+    HTTP_MODULES,
+    KV_MODULES,
+    OBJECTSTORE_MODULES,
+    PEP249_DRIVERS,
+)
 from .store import SKIP_DIRS
 
 log = logging.getLogger(__name__)
@@ -47,6 +52,11 @@ _MAX_SCAN_FILES = 3000
 SQL_FAMILY = "sql"
 KV_FAMILY = "kv"
 OBJECTSTORE_FAMILY = "objectstore"
+#: A remote HTTP API — a model provider, a payments gateway, any REST
+#: dependency. Its substitute is cut at the TRANSPORT (see
+#: `service_doubles.HTTP_MODULES`) rather than per vendor, so this one family
+#: covers every provider a repo talks to, including ones that do not exist yet.
+HTTP_FAMILY = "http"
 
 _FAMILY_BY_MODULE: dict[str, str] = {}
 for _name in PEP249_DRIVERS:
@@ -57,6 +67,13 @@ for _name in KV_MODULES:
     _FAMILY_BY_MODULE[_name] = KV_FAMILY
 for _name in OBJECTSTORE_MODULES + ("botocore", "aioboto3", "minio"):
     _FAMILY_BY_MODULE[_name] = OBJECTSTORE_FAMILY
+# The transports every remote-API client is built on. Listing the TRANSPORT and
+# never the vendor is the whole point: `openai`, `anthropic` and the fourteen
+# other partner packages langchain vendors all reach the network through one of
+# these, so a repo using any of them declares this family without anyone having
+# enumerated it — including providers that do not exist yet.
+for _name in HTTP_MODULES:
+    _FAMILY_BY_MODULE[_name] = HTTP_FAMILY
 
 #: A DSN in a settings file or a default argument is direct evidence that the
 #: repo expects a server at that address, even when the import is indirect.

--- a/exerciser/src/exerciser/services.py
+++ b/exerciser/src/exerciser/services.py
@@ -38,23 +38,10 @@ from typing import Any
 
 from .agent_loop import AgentChannel, Question, question_key
 from .service_doubles import KV_MODULES, OBJECTSTORE_MODULES, PEP249_DRIVERS
+from .store import SKIP_DIRS
 
 log = logging.getLogger(__name__)
 
-#: Files to skip when scanning — vendored code is not this repo's requirement.
-_SKIP_DIRS = frozenset(
-    {
-        ".git",
-        ".venv",
-        "venv",
-        "node_modules",
-        "__pycache__",
-        "site-packages",
-        ".tox",
-        "build",
-        "dist",
-    }
-)
 _MAX_SCAN_FILES = 3000
 
 SQL_FAMILY = "sql"
@@ -128,7 +115,7 @@ _scan_notes: list[str] = []
 def _python_files(repo: Path, limit: int = _MAX_SCAN_FILES) -> list[Path]:
     out: list[Path] = []
     for path in repo.rglob("*.py"):
-        if any(part in _SKIP_DIRS for part in path.parts):
+        if any(part in SKIP_DIRS for part in path.parts):
             continue
         out.append(path)
         if len(out) >= limit:
@@ -309,7 +296,7 @@ def discover_schema_sources(repo: Path) -> list[SchemaSource]:
         # Filter BEFORE bounding: 200 vendored files under .venv/ were
         # reproduced consuming the entire budget while the repo's own
         # schema.sql was never read.
-        if any(part in _SKIP_DIRS for part in path.parts):
+        if any(part in SKIP_DIRS for part in path.parts):
             continue
         sql_files.append(path)
         if len(sql_files) >= 200:

--- a/exerciser/src/exerciser/store.py
+++ b/exerciser/src/exerciser/store.py
@@ -14,6 +14,23 @@ from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
+#: Directories no scan of a repo should descend into: vendored code, build
+#: output and virtualenvs are not the repo's own source, and a match inside one
+#: is someone else's package.
+SKIP_DIRS = frozenset(
+    {
+        ".git",
+        ".venv",
+        "venv",
+        "node_modules",
+        "__pycache__",
+        "site-packages",
+        ".tox",
+        "build",
+        "dist",
+    }
+)
+
 
 def exercise_dir(repo: Path) -> Path:
     return repo / ".vinv" / "exercise"

--- a/exerciser/src/exerciser/store.py
+++ b/exerciser/src/exerciser/store.py
@@ -31,6 +31,60 @@ SKIP_DIRS = frozenset(
     }
 )
 
+#: The marker the interpreter itself writes at the root of a virtualenv. A venv
+#: is recognised by this and never by its directory NAME — the one that exposed
+#: the interpreter bug was called ``.venv-target``.
+VENV_MARKER = "pyvenv.cfg"
+
+#: Pruned during the walk but NOT name-matched as venvs: descending is the only
+#: way to find the marker, so ``.venv``/``venv`` are walked one level and then
+#: stopped by the marker instead of by their name.
+_WALK_PRUNE = (SKIP_DIRS - {".venv", "venv"}) | {".vinv"}
+
+
+def walk_source_dirs(
+    repo: Path, *, max_depth: int = 4
+) -> tuple[list[tuple[Path, frozenset[str]]], list[Path]]:
+    """One bounded, pruned walk of a repo. Returns ``(source dirs, venv roots)``.
+
+    Every scan in this engine used to be its own ``rglob``, which cannot prune:
+    the pattern is matched against the whole tree and the filter runs afterwards,
+    so each one descended through ``.venv/**/site-packages`` in full — six times
+    per run, on a tree where that is most of the files. ``os.walk`` lets the skip
+    list stop the descent instead of the match.
+
+    ``followlinks`` stays off, deliberately: ``Path.rglob`` follows directory
+    symlinks on 3.12 (``recurse_symlinks`` only arrived in 3.13), so a repo with
+    a symlink cycle hung the walk rather than being scanned.
+
+    A venv is reported separately and never descended: it is a candidate
+    INTERPRETER, and its ``site-packages`` holds every other project's manifests
+    — reading those as the repo's own measured every candidate against pandas'
+    dependency list.
+    """
+    repo = Path(repo)
+    dirs: list[tuple[Path, frozenset[str]]] = []
+    venvs: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(repo, followlinks=False):
+        here = Path(dirpath)
+        try:
+            parts = here.relative_to(repo).parts
+        except ValueError:  # pragma: no cover - os.walk cannot leave its root
+            dirnames[:] = []
+            continue
+        names = frozenset(filenames)
+        if VENV_MARKER in names:
+            venvs.append(here)
+            dirnames[:] = []
+            continue
+        if not any(p in SKIP_DIRS for p in parts):
+            dirs.append((here, names))
+        if len(parts) >= max_depth:
+            dirnames[:] = []
+            continue
+        dirnames[:] = sorted(d for d in dirnames if d not in _WALK_PRUNE)
+    return dirs, venvs
+
 
 def exercise_dir(repo: Path) -> Path:
     return repo / ".vinv" / "exercise"

--- a/exerciser/tests/test_campaign.py
+++ b/exerciser/tests/test_campaign.py
@@ -726,3 +726,53 @@ def test_the_empty_action_space_reports_the_same_keys(tmp_path: Path):
     assert result["stopped"] == "no-actions"
     assert result["interpreter"]["python"]
     assert result["own_packages_unimportable"] == []
+
+
+# ---- the run's verdict, persisted ------------------------------------------
+
+
+def test_the_campaigns_verdict_is_written_to_an_artifact(tmp_path: Path):
+    """`status` and the oracles' diagnostics existed on stdout only.
+
+    So the extension, which reads artifacts, fell back to `functions.json` — a
+    file every crash play rewrites with `only_targets=[one]`, whose `status` is
+    therefore computed over a SINGLE module. One arm's verdict, shown as the
+    run's. Writing the summary is what lets a reader ask the run.
+    """
+    from exerciser.campaign import result_path
+
+    def crash(action: Action) -> Play:
+        return Play(
+            violations=0,
+            covered=(action.target,),
+            subprocesses=1,
+            work=0,
+            status="environment",
+            diagnostics=("the repo's own package is not installed for this interpreter",),
+            detail={"own_packages_unimportable": ["acme_core"]},
+        )
+
+    result = run_campaign(
+        tmp_path, budget=3, patience=100, actions=[BARREN], runners={"crash": crash}
+    )
+
+    persisted = store.read_json(result_path(tmp_path))
+    assert persisted is not None, "the verdict was printed and not written"
+    assert persisted["status"] == result["status"] == "environment"
+    assert persisted["own_packages_unimportable"] == ["acme_core"]
+    assert any("not installed" in d for d in persisted["diagnostics"])
+    # The per-play detail is deliberately NOT in it: this file is the summary, and
+    # `plays` is what makes the campaign document large.
+    assert "plays" not in persisted
+
+
+def test_the_no_actions_branch_writes_one_too(tmp_path: Path):
+    """ "No oracle could be armed" is a verdict, and an absent file cannot say
+    whether the campaign concluded that or never finished."""
+    from exerciser.campaign import result_path
+
+    run_campaign(tmp_path, budget=4, actions=[], runners={})
+
+    persisted = store.read_json(result_path(tmp_path))
+    assert persisted is not None
+    assert persisted["stopped"] == "no-actions"

--- a/exerciser/tests/test_campaign.py
+++ b/exerciser/tests/test_campaign.py
@@ -647,3 +647,82 @@ def test_the_http_adapter_refuses_to_run_without_a_base_url(tmp_path):
 
     play = _http_runner(OracleConfig(repo=tmp_path))(HTTP)
     assert play.error == "no base_url" and play.violations == 0
+
+
+# ---- what the oracles say about the RUN ------------------------------------
+
+
+def test_an_oracles_run_level_diagnostic_reaches_the_campaigns_report(tmp_path: Path):
+    """Every oracle produced diagnostics and every runner dropped them.
+
+    So a finding about the APPARATUS — no importable target, an interpreter
+    without the repo installed, a shared unmet precondition — reached
+    `functions.json` and stopped there, while the campaign's own summary (what
+    the CLI prints and the extension's pass runs) said nothing.
+    """
+
+    def crash(action: Action) -> Play:
+        return Play(
+            violations=0,
+            covered=(action.target,),
+            subprocesses=1,
+            work=1,
+            diagnostics=("containment disabled by the caller — 3 target(s) stay refused",),
+        )
+
+    result = run_campaign(
+        tmp_path, budget=6, patience=100, actions=[BARREN], runners={"crash": crash}
+    )
+
+    assert any("stay refused" in d for d in result["diagnostics"])
+    # Six plays repeating one fact is one fact.
+    assert sum("stay refused" in d for d in result["diagnostics"]) == 1
+
+
+def test_a_campaign_that_could_not_import_the_repo_does_not_report_ok(tmp_path: Path):
+    """The headline claim, on the command that actually runs it.
+
+    `run_functions` decides this per play and used to be the only place that
+    knew: `status: "environment"` and the import canary died at the runner
+    boundary, so a campaign over a repo it could not load still answered
+    `status: "ok"` with zero findings — which is exactly what a clean repo
+    looks like, and the ambiguity the canary exists to remove.
+    """
+
+    def crash(action: Action) -> Play:
+        return Play(
+            violations=0,
+            covered=(action.target,),
+            subprocesses=1,
+            work=0,
+            status="environment",
+            detail={"own_packages_unimportable": ["acme_core"]},
+        )
+
+    result = run_campaign(
+        tmp_path, budget=4, patience=100, actions=[BARREN], runners={"crash": crash}
+    )
+
+    assert result["status"] == "environment"
+    assert result["own_packages_unimportable"] == ["acme_core"]
+    assert any("not a clean result" in d for d in result["diagnostics"])
+
+
+def test_a_healthy_campaign_is_still_ok(tmp_path: Path):
+    result = run_campaign(
+        tmp_path, budget=4, patience=100, actions=[PAYING, BARREN], runners=_runners()
+    )
+    assert result["status"] == "ok"
+    assert result["own_packages_unimportable"] == []
+
+
+def test_the_empty_action_space_reports_the_same_keys(tmp_path: Path):
+    """A caller reading `interpreter` must not have to know which branch ran.
+
+    The no-actions case is exactly when "which environment was this?" is the
+    question being asked, and it was the one return that omitted the answer.
+    """
+    result = run_campaign(tmp_path, budget=4, actions=[], runners={})
+    assert result["stopped"] == "no-actions"
+    assert result["interpreter"]["python"]
+    assert result["own_packages_unimportable"] == []

--- a/exerciser/tests/test_containment.py
+++ b/exerciser/tests/test_containment.py
@@ -430,3 +430,61 @@ def test_the_detected_mechanism_records_which_checks_it_actually_passed():
     assert "write-inside-root-allowed" in _HOST.checks
     assert _HOST.blocks_writes_outside_root is True
     assert _HOST.tool and Path(_HOST.tool).exists()
+
+
+# =========================================================================
+# A row that stood on invented data is not evidence about the repo
+# =========================================================================
+
+
+def _call_row(**over: object) -> dict:
+    row = {
+        "phase": "call",
+        "status": "error",
+        "target_id": "pkg.mod:fn",
+        "error_type": "TypeError",
+        "error": "unsupported operand",
+        "error_module": "builtins",
+        "input_class": "valid",
+    }
+    row.update(over)
+    return row
+
+
+def test_a_call_that_failed_on_a_substituted_response_is_not_a_defect() -> None:
+    """The HTTP double answers with a plausible SHAPE and never a correct value.
+
+    A target that then reads a field the real provider would have filled fails on
+    OUR value, not on its own logic. `sandbox` already drains the service ledger
+    per call and writes the evidence onto the row, under a comment saying
+    "so downstream consumers can down-weight it" — and until this, the flag had
+    exactly one write site and zero read sites, so the verdict path ran as if the
+    substitution had not happened.
+    """
+    from exerciser.functions import classify_row
+
+    assert classify_row(_call_row(substitution_dependent=True)) is None
+
+
+def test_a_call_that_failed_on_a_seeded_row_is_not_a_defect_either() -> None:
+    from exerciser.functions import classify_row
+
+    assert classify_row(_call_row(seed_dependent=True)) is None
+
+
+def test_an_ordinary_failure_is_untouched() -> None:
+    """The exemption must be narrow: no service event, no exemption."""
+    from exerciser.exception_policy import ExceptionPolicy
+    from exerciser.functions import classify_row
+
+    verdict = classify_row(_call_row(), ExceptionPolicy(), total_targets=1)
+    assert verdict != "not-a-defect-by-substitution"
+    # It travels the ordinary learned-policy path rather than being short-circuited.
+    assert verdict in (None, "function-crash")
+
+
+def test_a_substituted_call_that_SUCCEEDED_is_not_reported_at_all() -> None:
+    """Only failures are exempted; a success was never a finding."""
+    from exerciser.functions import classify_row
+
+    assert classify_row(_call_row(status="ok", substitution_dependent=True)) is None

--- a/exerciser/tests/test_declared_workdir.py
+++ b/exerciser/tests/test_declared_workdir.py
@@ -1,0 +1,325 @@
+"""Where a module runs from is settled by running it, not by reading the repo.
+
+Every oracle spawned its worker with ``cwd=repo``. A repo's relative paths
+resolve against the working directory, so that choice silently decides what the
+code under test reads — and it was never a choice, just five hardcoded call
+sites.
+
+demo-fastapi is the case that exposed it: correctly configured, ``.env`` present
+with 37 lines, settings declaring ``env_file="../.env"`` because the app runs
+from ``backend/``. Started at the repo root, ``../.env`` resolved outside the
+repo, 14 of 15 modules failed to import, and the engine reported fifteen defects
+in a clean repo.
+
+The obvious fix — parse CI files, Dockerfiles, Procfiles — is a list, and a list
+covers only the build systems someone thought of. Bazel, Nix, Earthly, a shell
+script or a README sentence are all equally valid ways to say where a project
+runs. So declarations only ORDER the candidates and the IMPORT decides, which is
+the discipline ``containment`` and ``interpreter`` already use.
+
+These tests pin both halves: the hints rank sensibly, and — the part that
+actually carries the design — a module whose hints are all WRONG still ends up
+running from the directory where it imports.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import textwrap
+from pathlib import Path
+
+from exerciser.envconfig import declared_workdirs, workdir_claims_for
+from exerciser.functions import candidate_workdirs, run_functions
+
+
+def _write(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(body).strip() + "\n", encoding="utf-8")
+
+
+def _index(repo: Path) -> None:
+    """The minimal code index ``discover_targets`` reads, built from the sources.
+
+    Same shape as ``test_functions_harness._make_repo``: the harness takes its
+    module-level function names from here, not from a fresh parse.
+    """
+    chunks = []
+    for path in sorted(repo.rglob("*.py")):
+        rel = path.relative_to(repo).as_posix()
+        if ".vinv/" in rel:
+            continue
+        body = path.read_text(encoding="utf-8")
+        for found in re.finditer(r"^(?:async )?def (\w+)", body, re.MULTILINE):
+            chunks.append(
+                {
+                    "id": f"{rel}:{found.group(1)}",
+                    "file": rel,
+                    "lang": "python",
+                    "kind": "function",
+                    "name": found.group(1),
+                    "start_line": 1,
+                    "end_line": 2,
+                    "parent": None,
+                }
+            )
+    index = repo / ".vinv" / "index"
+    index.mkdir(parents=True, exist_ok=True)
+    (index / "chunks.jsonl").write_text(
+        "".join(json.dumps(c) + "\n" for c in chunks), encoding="utf-8"
+    )
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    (repo / "backend" / "app").mkdir(parents=True)
+    (repo / "backend" / "app" / "config.py").write_text("", encoding="utf-8")
+    return repo
+
+
+def _ci(repo: Path, workdir: str, name: str = "test.yml") -> None:
+    _write(
+        repo / ".github" / "workflows" / name,
+        f"""
+        jobs:
+          test:
+            steps:
+              - run: pytest
+                working-directory: {workdir}
+        """,
+    )
+
+
+# =========================================================================
+# Hints — they order, they do not rule
+# =========================================================================
+
+
+def test_a_ci_working_directory_is_read(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    _ci(repo, "backend")
+    claims = workdir_claims_for(repo, "backend/app/config.py")
+    assert claims and claims[0].path == "backend"
+    assert claims[0].source == "ci-working-directory"
+
+
+def test_a_dockerfile_workdir_is_mapped_back_through_the_build_context(
+    tmp_path: Path,
+) -> None:
+    """``WORKDIR /app/backend`` is a path in the IMAGE, not on the host.
+
+    It names a host directory only once ``COPY . /app`` says the image root
+    corresponds to the repo root.
+    """
+    repo = _repo(tmp_path)
+    _write(repo / "Dockerfile", "FROM python:3.12\nCOPY . /app\nWORKDIR /app/backend/")
+    assert any(
+        c.path == "backend" and c.source == "dockerfile-workdir" for c in declared_workdirs(repo)
+    )
+
+
+def test_ci_outranks_a_dockerfile(tmp_path: Path) -> None:
+    """CI describes running THIS checkout; an image's layout need not mirror it."""
+    repo = _repo(tmp_path)
+    (repo / "svc").mkdir()
+    _ci(repo, "backend")
+    _write(repo / "Dockerfile", "FROM python:3.12\nCOPY . /srv\nWORKDIR /srv/svc")
+    assert workdir_claims_for(repo, "backend/app/config.py")[0].source == "ci-working-directory"
+
+
+def test_a_cd_in_a_makefile_counts(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    _write(repo / "Makefile", "run:\n\tcd backend && uvicorn app.main:app")
+    claims = workdir_claims_for(repo, "backend/app/config.py")
+    assert claims and claims[0].path == "backend"
+
+
+def test_a_claim_that_does_not_contain_the_file_says_nothing_about_it(
+    tmp_path: Path,
+) -> None:
+    """A repo may declare several. The one that applies is the one it lives under."""
+    repo = _repo(tmp_path)
+    (repo / "frontend").mkdir()
+    _ci(repo, "frontend")
+    assert workdir_claims_for(repo, "backend/app/config.py") == []
+
+
+def test_a_ci_expression_is_not_a_path(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    _ci(repo, "${{ matrix.package }}")
+    assert declared_workdirs(repo) == []
+
+
+def test_every_claim_carries_where_it_came_from(tmp_path: Path) -> None:
+    """A chosen directory must be auditable, not a silent default."""
+    repo = _repo(tmp_path)
+    _ci(repo, "backend", name="ci.yml")
+    claim = declared_workdirs(repo)[0]
+    assert claim.detail == ".github/workflows/ci.yml"
+    assert set(claim.to_json()) == {"path", "source", "detail"}
+
+
+# =========================================================================
+# Candidates — bounded, ordered, and always ending somewhere safe
+# =========================================================================
+
+
+def test_the_repo_root_is_always_a_candidate(tmp_path: Path) -> None:
+    """The historical behaviour has to remain reachable, or this is a regression.
+
+    Not necessarily LAST: when the repo root is also the distribution that owns
+    the file, trying it first is right, and that is exactly the old behaviour.
+    What must never happen is it dropping out of the search.
+    """
+    repo = _repo(tmp_path)
+    _ci(repo, "backend")
+    assert repo.resolve() in candidate_workdirs(repo, "backend/app/config.py")
+
+
+def test_a_declaration_is_tried_before_anything_inferred(tmp_path: Path) -> None:
+    """Hints exist to make the retry usually free."""
+    repo = _repo(tmp_path)
+    _ci(repo, "backend")
+    assert candidate_workdirs(repo, "backend/app/config.py")[0] == (repo / "backend").resolve()
+
+
+def test_the_search_is_bounded(tmp_path: Path) -> None:
+    """Each candidate costs a worker run, so the list cannot grow with path depth."""
+    repo = tmp_path / "repo"
+    deep = repo / "a" / "b" / "c" / "d" / "e" / "f"
+    deep.mkdir(parents=True)
+    (deep / "mod.py").write_text("", encoding="utf-8")
+
+    assert len(candidate_workdirs(repo, "a/b/c/d/e/f/mod.py")) <= 8
+
+
+def test_a_repo_that_declares_nothing_still_has_candidates(tmp_path: Path) -> None:
+    """Being unable to read a project's automation is not being unable to run it."""
+    repo = tmp_path / "repo"
+    (repo / "libs" / "core" / "acme").mkdir(parents=True)
+    (repo / "libs" / "core" / "acme" / "util.py").write_text("", encoding="utf-8")
+    _write(repo / "libs" / "core" / "pyproject.toml", '[project]\nname = "acme"\nversion = "0.1"')
+
+    assert declared_workdirs(repo) == []
+    candidates = candidate_workdirs(repo, "libs/core/acme/util.py")
+    assert candidates[0] == (repo / "libs" / "core").resolve()
+    assert candidates[-1] == repo.resolve()
+
+
+def test_candidates_are_deduplicated(tmp_path: Path) -> None:
+    """A single-distribution repo that declares its root must not try it twice."""
+    repo = tmp_path / "repo"
+    (repo / "pkg").mkdir(parents=True)
+    (repo / "pkg" / "mod.py").write_text("", encoding="utf-8")
+    _write(repo / "pyproject.toml", '[project]\nname = "solo"\nversion = "0.1"')
+
+    candidates = candidate_workdirs(repo, "pkg/mod.py")
+    assert len(candidates) == len(set(candidates))
+
+
+# =========================================================================
+# The part that carries the design: the import decides
+# =========================================================================
+
+
+def _repo_that_only_imports_from_a_subdir(tmp_path: Path) -> Path:
+    """A module whose import reads a file by RELATIVE path.
+
+    This is demo-fastapi's shape reduced to its essentials — ``env_file="../.env"``
+    is exactly "open a path relative to the process working directory during
+    import". From ``svc/`` the file resolves; from the repo root it does not.
+    """
+    repo = tmp_path / "repo"
+    (repo / "svc" / "acme").mkdir(parents=True)
+    _write(repo / "pyproject.toml", '[project]\nname = "acme"\nversion = "0.1"')
+    _write(repo / "settings.ini", "value = 1")
+    (repo / "svc" / "acme" / "__init__.py").write_text("", encoding="utf-8")
+    _write(
+        repo / "svc" / "acme" / "mod.py",
+        """
+        from pathlib import Path
+
+        # Resolvable only when the process runs from `svc/`.
+        _CONFIG = Path("../settings.ini").read_text(encoding="utf-8")
+
+
+        def double(n: int) -> int:
+            return n * 2
+        """,
+    )
+    _index(repo)
+    return repo
+
+
+def test_a_module_is_run_from_wherever_it_actually_imports(tmp_path: Path) -> None:
+    """The whole design, end to end.
+
+    Nothing in this repo declares a working directory, and the distribution is
+    the repo ROOT — so every hint points at the wrong place. The module still
+    gets driven, because the engine tried the next candidate after the import
+    failed.
+    """
+    repo = _repo_that_only_imports_from_a_subdir(tmp_path)
+
+    result = run_functions(repo, explore=False)
+
+    assert result["calls"] > 0, "the module was never successfully imported"
+    assert result["issue_clusters"] == 0, "a clean module was reported as broken"
+
+
+def test_the_directory_that_worked_is_reported(tmp_path: Path) -> None:
+    """A run must say where it decided to run each module from."""
+    repo = _repo_that_only_imports_from_a_subdir(tmp_path)
+
+    result = run_functions(repo, explore=False)
+
+    resolutions = result["workdir_resolutions"]
+    assert resolutions, "the retry happened but was never reported"
+    entry = resolutions[0]
+    assert entry["chosen"] == "svc"
+    # The failed first attempt is kept: the evidence is the point.
+    assert entry["attempts"][0]["import_blocked"] is True
+    assert entry["attempts"][-1]["import_blocked"] is False
+
+
+def test_a_module_that_imports_first_time_costs_no_retry(tmp_path: Path) -> None:
+    """The retry is paid ONLY on failure.
+
+    Every module in a healthy repo must run exactly one worker, or this feature
+    is a tax on the common case.
+    """
+    repo = tmp_path / "repo"
+    (repo / "acme").mkdir(parents=True)
+    _write(repo / "pyproject.toml", '[project]\nname = "acme"\nversion = "0.1"')
+    (repo / "acme" / "__init__.py").write_text("", encoding="utf-8")
+    _write(repo / "acme" / "mod.py", "def double(n: int) -> int:\n    return n * 2\n")
+    _index(repo)
+
+    result = run_functions(repo, explore=False)
+
+    assert result["calls"] > 0
+    assert result["workdir_resolutions"] == []
+
+
+def test_a_module_that_imports_nowhere_is_not_blamed_on_the_directory(
+    tmp_path: Path,
+) -> None:
+    """Exhausting the candidates means it is not a working-directory problem.
+
+    The run must still end with the module's real import failure, not with a
+    directory it never had a chance in.
+    """
+    repo = tmp_path / "repo"
+    (repo / "acme").mkdir(parents=True)
+    _write(repo / "pyproject.toml", '[project]\nname = "acme"\nversion = "0.1"')
+    (repo / "acme" / "__init__.py").write_text("", encoding="utf-8")
+    _write(
+        repo / "acme" / "mod.py",
+        "raise RuntimeError('broken wherever you run me')\n\n\ndef f() -> int:\n    return 1\n",
+    )
+    _index(repo)
+
+    result = run_functions(repo, explore=False)
+
+    assert result["workdir_resolutions"] == []
+    assert result["calls"] == 0

--- a/exerciser/tests/test_declared_workdir.py
+++ b/exerciser/tests/test_declared_workdir.py
@@ -29,7 +29,7 @@ import re
 import textwrap
 from pathlib import Path
 
-from exerciser.envconfig import declared_workdirs, workdir_claims_for
+from exerciser.envconfig import declared_env, declared_workdirs, workdir_claims_for
 from exerciser.functions import candidate_workdirs, run_functions
 
 
@@ -323,3 +323,78 @@ def test_a_module_that_imports_nowhere_is_not_blamed_on_the_directory(
 
     assert result["workdir_resolutions"] == []
     assert result["calls"] == 0
+
+
+# =========================================================================
+# What "the repo itself publishes" has to mean
+# =========================================================================
+
+
+def test_declared_env_never_reads_outside_the_repo(tmp_path: Path) -> None:
+    """`workdir.parent` is right for `backend/` and wrong for the repo root.
+
+    The repo root is itself a workdir candidate — it is the last one on every
+    list — and there `.parent` is the directory CONTAINING the checkout. A
+    developer whose projects sit side by side under one folder, or whose repo
+    sits in their home directory, would have had an unrelated project's `.env`
+    read and its values exported into the worker running this one.
+    """
+    outside = tmp_path / ".env"
+    outside.write_text("UNRELATED_PROJECT_TOKEN=ghp_REAL_TOKEN\n", encoding="utf-8")
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".env.example").write_text("PROJECT_NAME=demo\n", encoding="utf-8")
+
+    supplied = declared_env(repo, repo)
+
+    assert supplied == {"PROJECT_NAME": "demo"}
+    assert "UNRELATED_PROJECT_TOKEN" not in supplied
+
+
+def test_a_nested_workdir_still_reads_the_repo_root(tmp_path: Path) -> None:
+    """The bound is the REPO, not the workdir — the reason `.parent` is consulted
+    at all is a `backend/` that declares `env_file="../.env"`."""
+    repo = tmp_path / "repo"
+    (repo / "backend").mkdir(parents=True)
+    (repo / ".env").write_text("SHARED=root\n", encoding="utf-8")
+    (repo / "backend" / ".env").write_text("NEAR=backend\n", encoding="utf-8")
+
+    supplied = declared_env(repo, repo / "backend")
+
+    assert supplied == {"NEAR": "backend", "SHARED": "root"}
+
+
+def test_a_workdir_outside_the_repo_contributes_nothing(tmp_path: Path) -> None:
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    (elsewhere / ".env").write_text("STRAY=1\n", encoding="utf-8")
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    assert declared_env(repo, elsewhere) == {}
+
+
+def test_the_inductions_reason_carries_no_credential() -> None:
+    """`env_inductions` sits under a comment saying "names only, never values".
+
+    That is true of `variables` and was not of `reason`, which quotes the
+    target's own complaint — and the induction fires precisely when a settings
+    object rejects its configuration, which is when a settings object renders its
+    whole input dict into the message. The values in that dict are the ones
+    `declared_env` just loaded out of the repo's real `.env` and the ones a human
+    typed into `config_answers.json`.
+    """
+    from exerciser.redact import PLACEHOLDER, redact_text
+
+    complaint = (
+        "1 validation error for Settings\nPROJECT_NAME\n  Field required "
+        "[type=missing, input_value={'openai_api_key': 'sk-proj-EXAMPLE-NOT-REAL', "
+        "'postgres_server': 'localhost'}]"
+    )
+    cleaned = redact_text(complaint)
+
+    assert "sk-proj-EXAMPLE-NOT-REAL" not in cleaned
+    assert PLACEHOLDER in cleaned
+    # The part that makes the entry worth reporting survives.
+    assert "PROJECT_NAME" in cleaned
+    assert "'postgres_server': 'localhost'" in cleaned

--- a/exerciser/tests/test_declared_workdir.py
+++ b/exerciser/tests/test_declared_workdir.py
@@ -398,3 +398,75 @@ def test_the_inductions_reason_carries_no_credential() -> None:
     # The part that makes the entry worth reporting survives.
     assert "PROJECT_NAME" in cleaned
     assert "'postgres_server': 'localhost'" in cleaned
+
+
+def test_induction_does_not_strand_a_module_at_the_repo_root(tmp_path: Path) -> None:
+    """The two mechanisms have to compose, and they were ordered so they could not.
+
+    `candidate_workdirs` is ordered by likelihood and ends at the repo root — the
+    historical fallback — and induction fires only at that LAST entry. So a module
+    needing both a real working directory and a supplied variable resolved to
+    "repo root plus placeholders": it imported, so nothing failed, and it ran with
+    every relative path pointing at the wrong place. That is the failure
+    `candidate_workdirs` exists to remove, reached through the one path that
+    skipped it.
+
+    Here `backend/` is the right directory (it holds the data file the module
+    opens by a relative path) and `APP_TOKEN` is the missing variable. Only the
+    combination imports.
+    """
+    repo = tmp_path
+    backend = repo / "backend"
+    (backend / "app").mkdir(parents=True)
+    (repo / "pyproject.toml").write_text('[project]\nname = "app"\n', encoding="utf-8")
+    (backend / "app" / "__init__.py").write_text("", encoding="utf-8")
+    # Relative to the WORKING DIRECTORY, so it only resolves from `backend/`.
+    (backend / "settings.dat").write_text("ok\n", encoding="utf-8")
+    (backend / "app" / "mod.py").write_text(
+        textwrap.dedent("""
+            import os
+
+            if not os.environ.get("APP_TOKEN"):
+                raise RuntimeError("APP_TOKEN environment variable is required")
+            with open("settings.dat") as fh:      # relative to the run directory
+                _SETTINGS = fh.read()
+
+
+            def describe(n: int) -> str:
+                return str(n)
+            """).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    index = repo / ".vinv" / "index"
+    index.mkdir(parents=True)
+    (index / "chunks.jsonl").write_text(
+        json.dumps(
+            {
+                "id": "backend/app/mod.py:describe",
+                "file": "backend/app/mod.py",
+                "lang": "python",
+                "kind": "function",
+                "name": "describe",
+                "start_line": 1,
+                "end_line": 2,
+                "parent": None,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = run_functions(repo, max_targets=5)
+
+    inductions = result.get("env_inductions") or []
+    assert inductions, "the module's own complaint named APP_TOKEN and nothing induced it"
+    assert inductions[0]["resolved"] is True
+    assert inductions[0]["resolved_from"] == "backend"
+    resolutions = result.get("workdir_resolutions") or []
+    chosen = [r for r in resolutions if r.get("module", "").endswith("mod")]
+    assert chosen, f"no working directory was recorded: {resolutions}"
+    # The point: NOT the repo root, and reached only because the directory
+    # question was asked again once the environment answered.
+    assert chosen[0]["chosen"] == "backend", chosen[0]
+    assert any(a.get("reordered_after_induction") for a in chosen[0]["attempts"]), chosen[0]

--- a/exerciser/tests/test_differential_normalization.py
+++ b/exerciser/tests/test_differential_normalization.py
@@ -152,7 +152,13 @@ class TestTheWorkerEnvironmentIsReproducible:
         real_run = subprocess.run
 
         def _capture(cmd, **kwargs):
-            seen.append(dict(kwargs.get("env") or {}))
+            # WORKER launches only. `exerciser.differential.subprocess` is the
+            # shared module object, so patching `.run` through it intercepts
+            # every subprocess the run makes — including interpreter
+            # resolution's metadata probe, which launches no worker and pins
+            # nothing. The claim under test is about the worker's environment.
+            if "--worker" in list(cmd):
+                seen.append(dict(kwargs.get("env") or {}))
             return real_run(
                 [__import__("sys").executable, "-c", "pass"],
                 capture_output=True,

--- a/exerciser/tests/test_distribution_cwd.py
+++ b/exerciser/tests/test_distribution_cwd.py
@@ -1,0 +1,129 @@
+"""A worker's working directory is a choice, and it was being made wrongly.
+
+Every oracle spawned its worker with ``cwd=repo``. That is not neutral: a
+repo's relative paths — an ``env_file``, a data file, a template directory —
+resolve against the process working directory, so choosing it changes what the
+code under test reads.
+
+Found on demo-fastapi, a repo that was correctly configured the whole time. Its
+settings declare ``env_file="../.env"``, relative because the app runs from
+``backend/`` and the file sits at the repo root. Started from the repo root
+instead, ``../.env`` resolved OUTSIDE the repo, every required setting was
+missing, and 14 of 15 modules failed to import — reported as fifteen defects in
+someone's clean repo. Run from ``backend/``, the same code loads a 37-line
+``.env`` and imports cleanly.
+
+The rule is the one ``detect_src_roots`` already applies to imports: the
+distribution is the unit. These tests pin that, and pin the fallback — a
+single-distribution repo must keep the previous behaviour exactly.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+from exerciser.functions import detect_src_roots, distribution_cwd
+
+
+def _dist(directory: Path, name: str) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "pyproject.toml").write_text(
+        textwrap.dedent(f"""
+            [project]
+            name = "{name}"
+            version = "0.1.0"
+            """).strip(),
+        encoding="utf-8",
+    )
+
+
+def test_a_nested_distribution_runs_from_its_own_directory(tmp_path: Path) -> None:
+    """The demo-fastapi shape: one distribution one level down."""
+    repo = tmp_path / "repo"
+    _dist(repo / "backend", "demo-backend")
+    (repo / "backend" / "app").mkdir(parents=True)
+    (repo / "backend" / "app" / "config.py").write_text("", encoding="utf-8")
+
+    assert distribution_cwd(repo, "backend/app/config.py") == (repo / "backend").resolve()
+
+
+def test_the_deepest_declaring_ancestor_wins(tmp_path: Path) -> None:
+    """A monorepo root usually carries a manifest too; it must not shadow members."""
+    repo = tmp_path / "repo"
+    _dist(repo, "monorepo-root")
+    _dist(repo / "libs" / "core", "acme-core")
+    (repo / "libs" / "core" / "acme_core").mkdir(parents=True)
+    (repo / "libs" / "core" / "acme_core" / "util.py").write_text("", encoding="utf-8")
+
+    assert (
+        distribution_cwd(repo, "libs/core/acme_core/util.py") == (repo / "libs" / "core").resolve()
+    )
+
+
+def test_a_single_distribution_repo_is_unchanged(tmp_path: Path) -> None:
+    """The previous behaviour, which is correct here and must not move."""
+    repo = tmp_path / "repo"
+    _dist(repo, "solo")
+    (repo / "solo").mkdir()
+    (repo / "solo" / "mod.py").write_text("", encoding="utf-8")
+
+    assert distribution_cwd(repo, "solo/mod.py") == repo.resolve()
+
+
+def test_a_file_no_distribution_claims_falls_back_to_the_repo(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _dist(repo / "backend", "demo-backend")
+    (repo / "scripts").mkdir()
+    (repo / "scripts" / "tool.py").write_text("", encoding="utf-8")
+
+    assert distribution_cwd(repo, "scripts/tool.py") == repo.resolve()
+
+
+def test_a_repo_with_no_manifest_at_all_falls_back(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    (repo / "pkg").mkdir(parents=True)
+    (repo / "pkg" / "mod.py").write_text("", encoding="utf-8")
+
+    assert distribution_cwd(repo, "pkg/mod.py") == repo
+
+
+def test_the_cwd_and_the_import_root_agree_on_who_owns_a_file(tmp_path: Path) -> None:
+    """Both answers come from the same distribution, or the worker is incoherent.
+
+    A module imported as ``acme_core.util`` but run from the repo root reads a
+    different filesystem than the one its package expects. The two rules have to
+    be derived from the same unit.
+    """
+    repo = tmp_path / "repo"
+    _dist(repo, "monorepo-root")
+    _dist(repo / "libs" / "core", "acme-core")
+    (repo / "libs" / "core" / "acme_core").mkdir(parents=True)
+    (repo / "libs" / "core" / "acme_core" / "util.py").write_text("", encoding="utf-8")
+
+    roots = detect_src_roots(repo)
+    cwd = distribution_cwd(repo, "libs/core/acme_core/util.py")
+
+    assert "libs/core" in roots
+    assert cwd.relative_to(repo.resolve()).as_posix() == "libs/core"
+
+
+def test_a_relative_path_the_repo_declares_resolves_from_the_chosen_cwd(
+    tmp_path: Path,
+) -> None:
+    """The end-to-end shape of the bug, without needing pydantic.
+
+    `../config.ini` is reachable from the distribution directory and is NOT
+    reachable from the repo root — which is exactly what happened to
+    demo-fastapi's `env_file="../.env"`.
+    """
+    repo = tmp_path / "repo"
+    _dist(repo / "backend", "demo-backend")
+    (repo / "backend" / "app").mkdir(parents=True)
+    (repo / "backend" / "app" / "config.py").write_text("", encoding="utf-8")
+    (repo / "config.ini").write_text("[x]\ny = 1\n", encoding="utf-8")
+
+    cwd = distribution_cwd(repo, "backend/app/config.py")
+
+    assert (cwd / "../config.ini").resolve().is_file()
+    assert not (repo / "../config.ini").resolve().is_file()

--- a/exerciser/tests/test_fault_auto_arm.py
+++ b/exerciser/tests/test_fault_auto_arm.py
@@ -197,9 +197,9 @@ def test_every_derived_boundary_can_actually_reach_its_target(tmp_path: Path):
     assert len(derived) + len(skipped) == len(_ALL_TARGETS), "every target is accounted for"
     assert derived, "the gate must not be so tight that nothing arms"
     for boundary in derived:
-        assert _reaches_target(repo, boundary.target, boundary.baseline), (
-            f"{boundary.target} cannot be called with its own baseline"
-        )
+        assert _reaches_target(
+            repo, boundary.target, boundary.baseline
+        ), f"{boundary.target} cannot be called with its own baseline"
 
 
 # =========================================================================

--- a/exerciser/tests/test_fault_auto_arm.py
+++ b/exerciser/tests/test_fault_auto_arm.py
@@ -1,0 +1,86 @@
+"""The fault oracle has to arm itself, and only where it can be honest.
+
+`boundaries.json` is hand-written and `--auto-target` has to be pointed at a
+consumer by name, so on a repo nobody has prepared the oracle armed ZERO actions
+and the campaign reported the vacuum in a note that no code path acted on.
+Measured on a clone of langchain-ai/langchain: 2 of 6 oracles armed, and the
+fault oracle was never one of them.
+
+Deriving from the consumers' own annotations closes that — but only under the
+gate this file exists to pin. The first derivation had none, and it produced six
+findings that the harness caused itself: for
+`validate_hostname(hostname: str, policy: SSRFPolicy)` there is no value the
+harness can build for `policy`, so the baseline carried the string family's
+`"vinv"`, the first attribute access raised `AttributeError`, and that was
+reported as a defect in the target. `annotation_resolved` is the same honesty
+gate the function channel applies, and deriving a contract it cannot satisfy is
+worse than deriving nothing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from exerciser.faults import derive_boundaries
+
+_PKG = '''\
+from __future__ import annotations
+
+
+def all_resolvable(name: str, count: int, tags: list) -> str:
+    """Every annotation is one the harness can build a real value for."""
+    return f"{name}:{count}:{len(tags)}"
+
+
+def has_opaque_parameter(hostname: str, policy: SSRFPolicy) -> None:
+    """`policy` is a class the harness has no instance of."""
+    if policy.block_localhost:
+        raise ValueError(hostname)
+
+
+def unannotated(a, b):
+    return a
+'''
+
+
+def _repo(tmp_path: Path) -> Path:
+    pkg = tmp_path / "targetpkg"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    (pkg / "edges.py").write_text(_PKG, encoding="utf-8")
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "targetpkg"\n', encoding="utf-8")
+    return tmp_path
+
+
+def test_a_boundary_is_derived_when_every_annotation_is_satisfiable(tmp_path: Path):
+    derived = derive_boundaries(_repo(tmp_path), ["targetpkg.edges:all_resolvable"])
+    assert [b.target for b in derived] == ["targetpkg.edges:all_resolvable"]
+    boundary = derived[0]
+    assert set(boundary.contract) == {"name", "count", "tags"}
+    # A fault replaces ONE field of a WELL-FORMED payload, so every other
+    # required parameter has to be present or the call dies in the signature.
+    assert set(boundary.baseline) == {"name", "count", "tags"}
+
+
+def test_an_unsatisfiable_annotation_is_refused_not_guessed_at(tmp_path: Path):
+    """The regression: passing `"vinv"` for `policy: SSRFPolicy` makes the
+    consumer raise on the harness's own value, which is not a defect."""
+    derived = derive_boundaries(_repo(tmp_path), ["targetpkg.edges:has_opaque_parameter"])
+    assert derived == []
+
+
+def test_an_unannotated_consumer_yields_no_contract(tmp_path: Path):
+    assert derive_boundaries(_repo(tmp_path), ["targetpkg.edges:unannotated"]) == []
+
+
+def test_derivation_is_per_target_so_one_refusal_does_not_disarm_the_rest(tmp_path: Path):
+    repo = _repo(tmp_path)
+    derived = derive_boundaries(
+        repo,
+        [
+            "targetpkg.edges:has_opaque_parameter",
+            "targetpkg.edges:all_resolvable",
+            "targetpkg.edges:unannotated",
+        ],
+    )
+    assert [b.target for b in derived] == ["targetpkg.edges:all_resolvable"]

--- a/exerciser/tests/test_fault_auto_arm.py
+++ b/exerciser/tests/test_fault_auto_arm.py
@@ -7,21 +7,40 @@ Measured on a clone of langchain-ai/langchain: 2 of 6 oracles armed, and the
 fault oracle was never one of them.
 
 Deriving from the consumers' own annotations closes that — but only under the
-gate this file exists to pin. The first derivation had none, and it produced six
-findings that the harness caused itself: for
+gate this file exists to pin, which has two halves.
+
+The first: a contract the harness cannot SATISFY is worse than no contract. For
 `validate_hostname(hostname: str, policy: SSRFPolicy)` there is no value the
 harness can build for `policy`, so the baseline carried the string family's
 `"vinv"`, the first attribute access raised `AttributeError`, and that was
 reported as a defect in the target. `annotation_resolved` is the same honesty
-gate the function channel applies, and deriving a contract it cannot satisfy is
-worse than deriving nothing.
+gate the function channel applies.
+
+The second: a contract the harness cannot COMPLETE is dead rather than false,
+and dead silently, which is worse than loud. An unannotated parameter is dropped
+from the contract, so `def f(a: str, helper)` derived `{"a": "str"}` and passed
+the first gate — then every fault built on it omitted `helper`, died in the
+signature with `TypeError`, and `TypeError` is a typed rejection, i.e. recorded
+as the consumer correctly refusing the shape. Same shape as the `baseline={}`
+bug `baseline_from_contract` was written to fix, and anti-correlated with code
+quality in the same way: the less annotated the repo, the more certainly it
+reports clean. Measured on a 50-target mix, 17 boundaries were derived in that
+state and nothing said so.
 """
 
 from __future__ import annotations
 
+import json
+import subprocess
+import sys
 from pathlib import Path
 
-from exerciser.faults import derive_boundaries
+from exerciser.faults import (
+    SKIP_NO_ANNOTATION,
+    SKIP_UNDESCRIBABLE,
+    SKIP_UNSATISFIABLE,
+    derive_boundaries,
+)
 
 _PKG = '''\
 from __future__ import annotations
@@ -40,7 +59,25 @@ def has_opaque_parameter(hostname: str, policy: SSRFPolicy) -> None:
 
 def unannotated(a, b):
     return a
+
+
+def partly_annotated(name: str, helper) -> str:
+    """`helper` is REQUIRED and unannotated — no contract can supply it."""
+    return f"{name}{helper}"
+
+
+def annotated_with_optional_extra(name: str, retries=3) -> str:
+    """`retries` is unannotated but OPTIONAL, so omitting it is a legal call."""
+    return name * retries
 '''
+
+_ALL_TARGETS = [
+    "targetpkg.edges:all_resolvable",
+    "targetpkg.edges:has_opaque_parameter",
+    "targetpkg.edges:unannotated",
+    "targetpkg.edges:partly_annotated",
+    "targetpkg.edges:annotated_with_optional_extra",
+]
 
 
 def _repo(tmp_path: Path) -> Path:
@@ -52,9 +89,44 @@ def _repo(tmp_path: Path) -> Path:
     return tmp_path
 
 
+_REACHABILITY_PROBE = """\
+import importlib, json, sys
+sys.path.insert(0, sys.argv[1])
+mod, _, qual = sys.argv[2].partition(':')
+fn = getattr(importlib.import_module(mod), qual)
+try:
+    fn(**json.loads(sys.argv[3]))
+except TypeError as exc:
+    # The one failure this asks about: the call died in the SIGNATURE, so the
+    # target's own first line never ran. Any other exception means the harness
+    # reached the code, which is all a boundary has to promise.
+    if 'required positional argument' in str(exc) or 'required keyword-only' in str(exc):
+        print('UNREACHABLE')
+        raise SystemExit(0)
+except BaseException:
+    pass
+print('REACHED')
+"""
+
+
+def _reaches_target(repo: Path, target: str, payload: dict) -> bool:
+    proc = subprocess.run(
+        [sys.executable, "-c", _REACHABILITY_PROBE, str(repo), target, json.dumps(payload)],
+        capture_output=True,
+        text=True,
+    )
+    return proc.stdout.strip() == "REACHED"
+
+
+# =========================================================================
+# Gate one: a contract the harness cannot satisfy
+# =========================================================================
+
+
 def test_a_boundary_is_derived_when_every_annotation_is_satisfiable(tmp_path: Path):
-    derived = derive_boundaries(_repo(tmp_path), ["targetpkg.edges:all_resolvable"])
+    derived, skipped = derive_boundaries(_repo(tmp_path), ["targetpkg.edges:all_resolvable"])
     assert [b.target for b in derived] == ["targetpkg.edges:all_resolvable"]
+    assert skipped == {}
     boundary = derived[0]
     assert set(boundary.contract) == {"name", "count", "tags"}
     # A fault replaces ONE field of a WELL-FORMED payload, so every other
@@ -65,17 +137,79 @@ def test_a_boundary_is_derived_when_every_annotation_is_satisfiable(tmp_path: Pa
 def test_an_unsatisfiable_annotation_is_refused_not_guessed_at(tmp_path: Path):
     """The regression: passing `"vinv"` for `policy: SSRFPolicy` makes the
     consumer raise on the harness's own value, which is not a defect."""
-    derived = derive_boundaries(_repo(tmp_path), ["targetpkg.edges:has_opaque_parameter"])
+    derived, skipped = derive_boundaries(_repo(tmp_path), ["targetpkg.edges:has_opaque_parameter"])
     assert derived == []
+    assert skipped == {"targetpkg.edges:has_opaque_parameter": SKIP_UNSATISFIABLE}
 
 
 def test_an_unannotated_consumer_yields_no_contract(tmp_path: Path):
-    assert derive_boundaries(_repo(tmp_path), ["targetpkg.edges:unannotated"]) == []
+    derived, skipped = derive_boundaries(_repo(tmp_path), ["targetpkg.edges:unannotated"])
+    assert derived == []
+    assert skipped == {"targetpkg.edges:unannotated": SKIP_NO_ANNOTATION}
+
+
+# =========================================================================
+# Gate two: a contract the harness cannot complete
+# =========================================================================
+
+
+def test_a_required_unannotated_parameter_refuses_the_whole_boundary(tmp_path: Path):
+    """`partly_annotated(name: str, helper)` PASSES the first gate.
+
+    Its one annotation is satisfiable, so `annotation_resolved` says yes. But a
+    payload built from the contract alone omits `helper`, every fault raises
+    `TypeError` in the signature, and `TypeError` is a typed rejection — so the
+    boundary can never fire and never says so.
+    """
+    repo = _repo(tmp_path)
+    derived, skipped = derive_boundaries(repo, ["targetpkg.edges:partly_annotated"])
+    assert derived == []
+    assert skipped == {"targetpkg.edges:partly_annotated": SKIP_UNDESCRIBABLE}
+    # And the reason is measured, not asserted: the payload the ungated version
+    # would have armed does not reach the target.
+    assert not _reaches_target(repo, "targetpkg.edges:partly_annotated", {"name": "vinv"})
+
+
+def test_an_unannotated_parameter_with_a_default_is_not_a_blocker(tmp_path: Path):
+    """Only REQUIRED ones are.
+
+    Omitting an optional parameter is a legal call, so refusing here would cost
+    coverage for nothing.
+    """
+    repo = _repo(tmp_path)
+    derived, skipped = derive_boundaries(repo, ["targetpkg.edges:annotated_with_optional_extra"])
+    assert [b.target for b in derived] == ["targetpkg.edges:annotated_with_optional_extra"]
+    assert set(derived[0].baseline) == {"name"}
+    assert skipped == {}
+    assert _reaches_target(repo, derived[0].target, derived[0].baseline)
+
+
+def test_every_derived_boundary_can_actually_reach_its_target(tmp_path: Path):
+    """The property, stated once over the whole fixture.
+
+    A boundary whose baseline cannot be passed to its own target is not a
+    boundary — it is budget the campaign spends on a call that dies before the
+    target's first line, recorded as the consumer correctly refusing a shape.
+    """
+    repo = _repo(tmp_path)
+    derived, skipped = derive_boundaries(repo, _ALL_TARGETS)
+
+    assert len(derived) + len(skipped) == len(_ALL_TARGETS), "every target is accounted for"
+    assert derived, "the gate must not be so tight that nothing arms"
+    for boundary in derived:
+        assert _reaches_target(repo, boundary.target, boundary.baseline), (
+            f"{boundary.target} cannot be called with its own baseline"
+        )
+
+
+# =========================================================================
+# Per-target, and once
+# =========================================================================
 
 
 def test_derivation_is_per_target_so_one_refusal_does_not_disarm_the_rest(tmp_path: Path):
     repo = _repo(tmp_path)
-    derived = derive_boundaries(
+    derived, skipped = derive_boundaries(
         repo,
         [
             "targetpkg.edges:has_opaque_parameter",
@@ -84,3 +218,31 @@ def test_derivation_is_per_target_so_one_refusal_does_not_disarm_the_rest(tmp_pa
         ],
     )
     assert [b.target for b in derived] == ["targetpkg.edges:all_resolvable"]
+    assert set(skipped) == {
+        "targetpkg.edges:has_opaque_parameter",
+        "targetpkg.edges:unannotated",
+    }
+
+
+def test_the_whole_catalogue_is_read_in_one_subprocess(tmp_path: Path, monkeypatch):
+    """Reading a signature IMPORTS the module that defines it.
+
+    One subprocess per target cost 0.35s each on a trivial module — 17s for a
+    campaign's 50 — and re-imported the same modules 50 times over, all of it
+    inside `enumerate_actions`, before a single unit of budget was spent.
+    """
+    from exerciser import faults as faults_module
+
+    calls = 0
+    real = faults_module.subprocess.run
+
+    def counting(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(faults_module.subprocess, "run", counting)
+    derived, skipped = derive_boundaries(_repo(tmp_path), _ALL_TARGETS)
+
+    assert len(derived) + len(skipped) == len(_ALL_TARGETS)
+    assert calls == 1, f"{calls} subprocesses to read one catalogue"

--- a/exerciser/tests/test_functions_harness.py
+++ b/exerciser/tests/test_functions_harness.py
@@ -1541,3 +1541,69 @@ def test_blocking_needs_a_majority_of_modules_not_a_single_one():
 
     assert import_canary([row("acme_core.a")], 10)["blocking"] is False
     assert import_canary([row(f"acme_core.{c}") for c in "abcdef"], 10)["blocking"] is True
+
+
+# ---- the published surface claims the target budget first -------------------
+
+
+def test_the_public_api_is_not_crowded_out_by_private_helpers(tmp_path: Path):
+    """`_add` stops at `max_targets`, and the walk is alphabetical by file.
+
+    A single pass therefore spent the budget in FILE order — and with private
+    functions now eligible they are the majority of a real repo's module-level
+    definitions (851 of langchain's 1,365), so `_helper` in `a.py` took the slot
+    that the public API in `z.py` never got. Which functions are driven must not
+    depend on their filename.
+    """
+    body_a = "\n".join(f"def _helper_{n}(x: int) -> int:\n    return x\n" for n in range(6))
+    body_z = "\n".join(f"def public_{n}(x: int) -> int:\n    return x\n" for n in range(6))
+    repo = _make_repo(tmp_path, pkg={"a_mod.py": body_a, "z_mod.py": body_z})
+
+    targets, _skipped = discover_targets(repo, max_targets=6)
+    kinds = {t.kind for t in targets}
+
+    assert len(targets) == 6
+    assert kinds == {"exported"}, f"private helpers took the budget: {sorted(kinds)}"
+    assert all(t.qualname.startswith("public_") for t in targets)
+
+
+def test_internals_are_still_driven_when_there_is_room(tmp_path: Path):
+    """Ordering is a priority, not a filter — the whole point of driving them."""
+    body_a = "def _helper(x: int) -> int:\n    return x\n"
+    body_z = "def public(x: int) -> int:\n    return x\n"
+    repo = _make_repo(tmp_path, pkg={"a_mod.py": body_a, "z_mod.py": body_z})
+
+    targets, _skipped = discover_targets(repo, max_targets=50)
+
+    assert {t.qualname: t.kind for t in targets} == {"_helper": "internal", "public": "exported"}
+
+
+# ---- one redaction chokepoint, upstream of every consumer -------------------
+
+
+def test_a_credential_in_an_import_error_never_reaches_a_cluster(tmp_path: Path):
+    """The message that motivated `redact_text` is quoted into FOUR artifacts.
+
+    `function_results.jsonl`, the cluster title, the cluster exemplar and
+    `issues.json` all carry a target's exception verbatim, and a settings object
+    that fails validation renders its whole input dict — API keys included — into
+    that exception. Redacting one report field left the credential in every other
+    copy, so the redaction has to happen to the ROWS, before anything reads them.
+    """
+    leaked = "sk-proj-EXAMPLE-NOT-A-REAL-KEY"
+    body = (
+        "raise ValueError(\n"
+        f"    \"1 validation error for Settings [input_value={{'openai_api_key': '{leaked}'}}]\"\n"
+        ")\n"
+        "def unreachable(x: int) -> int:\n"
+        "    return x\n"
+    )
+    repo = _make_repo(tmp_path, pkg={"boom.py": body})
+
+    result = run_functions(repo, max_targets=10)
+
+    persisted = (store.exercise_dir(repo) / "function_results.jsonl").read_text(encoding="utf-8")
+    assert leaked not in persisted, "the credential reached the persisted rows"
+    assert leaked not in json.dumps(result), "and the run summary the CLI prints"
+    # The diagnostic value of the message survives — only the value is gone.
+    assert "validation error for Settings" in persisted

--- a/exerciser/tests/test_functions_harness.py
+++ b/exerciser/tests/test_functions_harness.py
@@ -24,8 +24,10 @@ from exerciser.functions import (
     call_verdict,
     classify_row,
     denial_reason,
+    detect_src_roots,
     discover_targets,
     discover_with_refusals,
+    import_canary,
     impurities_in_source,
     is_denied,
     is_test_scaffolding,
@@ -895,12 +897,17 @@ def test_argument_sets_cover_the_input_classes():
     assert value_for(None, "boundary") == ""
 
 
-def test_discovery_skips_private_and_destructive(tmp_path: Path):
+def test_discovery_drives_internals_but_never_destructive(tmp_path: Path):
     repo = _make_repo(tmp_path)
     targets, skipped = discover_targets(repo)
     names = {t.qualname for t in targets}
     assert {"add", "halve", "greet", "untyped"} <= names
-    assert "_private" not in names, "private by convention"
+    # A leading underscore is an API-stability marker, not a safety one, and the
+    # helpers it hides are where input-shaped defects concentrate. It is driven,
+    # and labelled so a reader can tell it from the published surface.
+    assert "_private" in names
+    assert {t.kind for t in targets if t.qualname == "_private"} == {"internal"}
+    # Safety is still decided by the guards, and they are unaffected.
     assert "delete_everything" not in names
     assert any(s["reason"].startswith("destructive-name") for s in skipped)
     assert all(t.module == "targetpkg.calc" for t in targets)
@@ -1441,3 +1448,96 @@ def test_a_suppressed_signature_is_re_examinable_from_a_real_run(tmp_path: Path)
     assert explored is not None, "a suppressed signature must be re-examinable"
     assert explored["issue_clusters"] > 0, "and reported, so it can be labelled"
     assert any(c["kind"] == "function-crash" for c in explored["clusters"])
+
+
+# ---- the canary and the source roots are load-bearing for each other --------
+
+
+def _monorepo(tmp_path: Path) -> Path:
+    """Two distributions under libs/, the shape a single-root scan gets wrong."""
+    for dist, pkg in (("core", "acme_core"), ("api", "acme_api")):
+        src = tmp_path / "libs" / dist / pkg
+        src.mkdir(parents=True)
+        (src / "__init__.py").write_text("", encoding="utf-8")
+        (tmp_path / "libs" / dist / "pyproject.toml").write_text(
+            f'[project]\nname = "{pkg}"\n', encoding="utf-8"
+        )
+    return tmp_path
+
+
+def test_each_distribution_resolves_to_its_installed_import_name(tmp_path: Path):
+    repo = _monorepo(tmp_path)
+    roots = detect_src_roots(repo)
+    # Not `libs.core.acme_core`: that name is importable only as a namespace
+    # package, and importing it loads a SECOND copy beside the installed one.
+    assert module_name_for("libs/core/acme_core/__init__.py", roots) == "acme_core"
+    assert module_name_for("libs/api/acme_api/__init__.py", roots) == "acme_api"
+
+
+def test_the_canary_fires_because_the_roots_named_the_package_correctly():
+    """The ownership gate reads `repo_packages`, which comes from the resolved
+    module names. Collapse the roots and every package looks third-party, so the
+    canary goes silent on exactly the run that motivated it — these two fixes
+    cannot be changed independently.
+    """
+    resolved = [
+        {
+            "module": "acme_core.util",
+            "phase": "import",
+            "status": "error",
+            "error": "No module named 'acme_core'",
+            "repo_packages": ["acme_core"],
+        }
+    ]
+    assert import_canary(resolved, 1)["own_packages_unimportable"] == ["acme_core"]
+
+    # The pre-fix world: modules resolved to `libs.…`, so `repo_packages` was
+    # `{"libs"}` and the missing package never matched.
+    collapsed = [{**resolved[0], "module": "libs.core.acme_core.util", "repo_packages": ["libs"]}]
+    assert import_canary(collapsed, 1)["own_packages_unimportable"] == []
+
+
+def test_a_stale_install_counts_as_unimportable_too():
+    """A package present but too old to carry the name the source expects is not
+    a defect in the source — it is the same wrong-interpreter problem wearing a
+    different exception message.
+    """
+    rows = [
+        {
+            "module": "acme_core.util",
+            "phase": "import",
+            "status": "error",
+            "error": "cannot import name 'Widget' from 'acme_core.models'",
+            "repo_packages": ["acme_core"],
+        }
+    ]
+    assert import_canary(rows, 1)["own_packages_unimportable"] == ["acme_core"]
+
+
+def test_a_missing_third_party_extra_is_not_an_environment_failure():
+    rows = [
+        {
+            "module": "acme_core.vectors",
+            "phase": "import",
+            "status": "error",
+            "error": "No module named 'qdrant_client'",
+            "repo_packages": ["acme_core"],
+        }
+    ]
+    canary = import_canary(rows, 4)
+    assert canary["own_packages_unimportable"] == []
+    assert canary["blocking"] is False
+
+
+def test_blocking_needs_a_majority_of_modules_not_a_single_one():
+    def row(mod: str) -> dict:
+        return {
+            "module": mod,
+            "phase": "import",
+            "status": "error",
+            "error": "No module named 'acme_core'",
+            "repo_packages": ["acme_core"],
+        }
+
+    assert import_canary([row("acme_core.a")], 10)["blocking"] is False
+    assert import_canary([row(f"acme_core.{c}") for c in "abcdef"], 10)["blocking"] is True

--- a/exerciser/tests/test_http_double.py
+++ b/exerciser/tests/test_http_double.py
@@ -1,0 +1,144 @@
+"""One seam for every remote API, including the model providers.
+
+Under containment the network is denied, so every target that reaches a remote
+API lands as ``contained`` — correctly not a defect, and correctly not
+exercised. On a repo that talks to a provider that is most of the interesting
+surface.
+
+The obvious substitution is one double per provider. It does not scale and is
+already wrong: langchain vendors SIXTEEN partner packages in one repository, so
+that list needs sixteen entries for a single target and is still wrong for the
+seventeenth. So the cut is HTTP — where all of them bottom out, and a standard
+rather than a vendor, exactly as PEP 249 is the right cut for databases.
+
+The response body looks like it needs per-API knowledge and does not: a client
+reads by ACCESS PATH, so a body that satisfies any path satisfies every API
+without knowing one of them.
+
+What this cannot do is be correct, and the tests say so: a doubled provider
+returns a plausibly-SHAPED answer, never a right one.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from exerciser.service_doubles import HTTP_MODULES, LenientBody, SubstitutedResponse
+
+
+@pytest.mark.parametrize(
+    ("path", "label"),
+    [
+        (("choices", 0, "message", "content"), "openai chat"),
+        (("content", 0, "text"), "anthropic messages"),
+        (("generations", 0, "text"), "cohere generate"),
+        (("data", 0, "embedding"), "openai embeddings"),
+        (("candidates", 0, "content", "parts", 0, "text"), "gemini"),
+        (("results", 0, "outputs", 0, "data"), "an api nobody has written yet"),
+    ],
+)
+def test_any_access_path_is_satisfied(path: tuple, label: str) -> None:
+    """The whole argument for cutting at HTTP instead of per provider."""
+    body: object = LenientBody()
+    for key in path:
+        body = body[key]  # type: ignore[index]
+    assert str(body) == "vinv-substituted", label
+
+
+def test_a_body_is_a_dict_because_client_code_branches_on_that() -> None:
+    assert isinstance(LenientBody(), dict)
+
+
+def test_a_loop_over_a_substituted_collection_runs_once() -> None:
+    """Zero iterations is the "not exercised" outcome this exists to remove.
+
+    An earlier version defined ``__bool__`` as always True — a response body
+    must not read as falsy to a client guarding on it — which made the
+    emptiness test never fire, so every ``for choice in r["choices"]`` ran zero
+    times while appearing to work.
+    """
+    assert len([c for c in LenientBody()["choices"]]) == 1
+    assert [str(c["message"]["content"]) for c in LenientBody()["choices"]] == ["vinv-substituted"]
+
+
+def test_a_populated_body_iterates_its_real_keys() -> None:
+    body = LenientBody()
+    body["a"] = 1
+    body["b"] = 2
+    assert sorted(body) == ["a", "b"]
+
+
+def test_a_guard_on_a_missing_key_is_not_told_yes() -> None:
+    """`if "error" in body` must not hand the client an error path.
+
+    Vivifying on ``in`` would send every caller down its failure branch, and
+    those branches would then be reported as the repo's behaviour.
+    """
+    assert "error" not in LenientBody()
+
+
+def test_a_body_is_truthy() -> None:
+    assert bool(LenientBody()) is True
+
+
+def test_the_response_looks_like_the_real_ones() -> None:
+    response = SubstitutedResponse(url="https://api.example.invalid/v1/chat", method="POST")
+    assert response.status_code == 200
+    assert response.status == 200  # aiohttp's spelling
+    assert response.ok is True
+    assert response.is_success is True
+    assert response.raise_for_status() is response
+    assert response.text == "vinv-substituted"
+    assert response.content == b"vinv-substituted"
+    assert response.headers["content-type"] == "application/json"
+
+
+def test_the_response_supports_the_context_manager_spellings() -> None:
+    response = SubstitutedResponse()
+    with response as opened:
+        assert opened is response
+
+
+def test_streaming_readers_do_not_hang_or_raise() -> None:
+    response = SubstitutedResponse()
+    assert list(response.iter_lines()) == []
+    assert list(response.iter_content()) == [b"vinv-substituted"]
+
+
+def test_the_clients_substituted_are_transports_not_vendors() -> None:
+    """A vendor list goes stale; the transport list is the standard."""
+    assert set(HTTP_MODULES) == {"httpx", "requests", "aiohttp"}
+
+
+def test_the_double_records_that_it_answered(monkeypatch) -> None:
+    """Participation is recorded by the double, never inferred by the parent.
+
+    A parent reading an error message to decide whether the substitution was
+    involved is guessing, and the guess misattributes real defects: a
+    ``NameError`` inside a repo's own fake-embeddings class has no provider
+    anywhere near it and would be blamed on the substitution by any text rule.
+    Only the double knows whether the double answered.
+    """
+    from exerciser import service_doubles
+
+    seen: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        service_doubles,
+        "_record",
+        lambda kind, service, detail, **extra: seen.append((kind, service)),
+    )
+    service_doubles._serve_http("POST", "https://api.example.invalid/v1/chat")
+
+    assert seen == [(service_doubles.SUBSTITUTED, "http")]
+
+
+def test_a_substituted_answer_is_shaped_not_correct() -> None:
+    """The honest ceiling, pinned so nobody reads more into this than it gives.
+
+    Two different questions return the same placeholder. The substitution buys
+    REACHABILITY — the code path runs — and never the correctness of anything
+    downstream of the model's content.
+    """
+    first = LenientBody()["choices"][0]["message"]["content"]
+    second = LenientBody()["choices"][0]["message"]["content"]
+    assert str(first) == str(second) == "vinv-substituted"

--- a/exerciser/tests/test_http_double.py
+++ b/exerciser/tests/test_http_double.py
@@ -142,3 +142,57 @@ def test_a_substituted_answer_is_shaped_not_correct() -> None:
     first = LenientBody()["choices"][0]["message"]["content"]
     second = LenientBody()["choices"][0]["message"]["content"]
     assert str(first) == str(second) == "vinv-substituted"
+
+
+# =========================================================================
+# Reachability — the half that was dead on arrival
+# =========================================================================
+
+
+def test_an_http_client_declares_a_service_requirement() -> None:
+    """Without this the whole double is unreachable, and silently so.
+
+    `install()` is gated on the service plan carrying REQUIREMENTS, which come
+    from `discover_requirements` recognising a client library. No HTTP module
+    mapped to a family, so a repo whose only external dependency was a provider
+    produced no requirement, the doubles never installed, and every patcher in
+    this module was dead code — on exactly the repos it was written for.
+
+    Both ends reported success the whole time: the double had tests that passed
+    and the run had a plan that looked fine.
+    """
+    from exerciser.services import _FAMILY_BY_MODULE, HTTP_FAMILY
+
+    for module in HTTP_MODULES:
+        assert (
+            _FAMILY_BY_MODULE.get(module) == HTTP_FAMILY
+        ), f"{module} produces no requirement, so the double never installs"
+
+
+def test_the_family_is_keyed_on_the_transport_not_the_vendor() -> None:
+    """A vendor list needs sixteen entries for langchain alone.
+
+    `openai`/`anthropic`/the rest are NOT listed and must not be: they reach the
+    network through one of the transports, so they are covered without anyone
+    enumerating them — including providers that do not exist yet.
+    """
+    from exerciser.services import _FAMILY_BY_MODULE
+
+    for vendor in ("openai", "anthropic", "cohere", "mistralai", "groq"):
+        assert vendor not in _FAMILY_BY_MODULE
+
+
+def test_a_repo_that_calls_a_provider_is_recognised(tmp_path) -> None:
+    """End to end over discovery: source that imports httpx wants the http family."""
+    from exerciser.services import HTTP_FAMILY, discover_requirements
+
+    pkg = tmp_path / "provider"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    (pkg / "client.py").write_text(
+        "import httpx\n\n\ndef ask(t):\n    return httpx.Client().post('https://x/y').json()\n",
+        encoding="utf-8",
+    )
+
+    families = {r.family for r in discover_requirements(tmp_path)}
+    assert HTTP_FAMILY in families

--- a/exerciser/tests/test_http_double.py
+++ b/exerciser/tests/test_http_double.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import pytest
 
+from exerciser import service_doubles
 from exerciser.service_doubles import HTTP_MODULES, LenientBody, SubstitutedResponse
 
 
@@ -196,3 +197,52 @@ def test_a_repo_that_calls_a_provider_is_recognised(tmp_path) -> None:
 
     families = {r.family for r in discover_requirements(tmp_path)}
     assert HTTP_FAMILY in families
+
+
+# =========================================================================
+# The cut is a REMOTE dependency
+# =========================================================================
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1:8000/items",
+        "http://localhost:3000/api",
+        "https://[::1]:8443/x",
+        "http://api.localhost/v1",
+        "http://127.0.0.53/x",
+    ],
+)
+def test_a_loopback_call_is_not_substituted(url: str) -> None:
+    """The repo talking to its own service is not a provider it cannot reach.
+
+    Answering it with a vivifying body turns a call that would have failed
+    honestly into one that proceeds on fabricated data, and every assertion after
+    it becomes a "finding". Under containment the network is denied anyway, so
+    refusing is the behaviour that existed before the double.
+    """
+    service_doubles.reset()
+    with pytest.raises(ConnectionRefusedError):
+        service_doubles._serve_http("GET", url)
+    kinds = [e.get("kind") for e in service_doubles.events()]
+    assert "substituted" not in kinds
+    assert "substitution-declined" in kinds
+    service_doubles.reset()
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://api.openai.com/v1/chat/completions",
+        "https://generativelanguage.googleapis.com/v1beta/models/x",
+        "http://localhost.evil.com/x",
+    ],
+)
+def test_a_remote_call_still_is(url: str) -> None:
+    """Including a host that merely CONTAINS 'localhost' — the check is on the
+    host, not on the string."""
+    service_doubles.reset()
+    assert service_doubles._serve_http("POST", url).status_code == 200
+    assert [e.get("kind") for e in service_doubles.events()] == ["substituted"]
+    service_doubles.reset()

--- a/exerciser/tests/test_import_preconditions.py
+++ b/exerciser/tests/test_import_preconditions.py
@@ -1,0 +1,212 @@
+"""One unmet precondition is one finding, not one per module it blocked.
+
+``classify_row`` exempts the two import failures that say nothing about the
+code under test: a dependency this machine lacks (the ``ImportError`` family)
+and an exception the repo defines about itself. A third shape reached a verdict
+and should not have, and it went from rare to common the moment the workers
+started running under the TARGET's own interpreter — before that, a service
+whose settings are unset never got far enough to raise, because the import died
+on ``ModuleNotFoundError`` first and was exempt.
+
+Measured on demo-fastapi: 14 of the 15 modules that attempted an import raised
+the same ``pydantic_core.ValidationError`` — required settings were not
+configured — and the run reported 15 separate defect clusters on a repo whose
+only problem was an unset environment variable. Provenance cannot separate
+that: the exception belongs to pydantic, so "the repo stating its own
+precondition" does not apply.
+
+Dispersion can, and it is a fact about the run rather than a vocabulary. These
+tests pin both directions — the shared precondition is withheld and described,
+and a genuine defect that happens to occur during import is NOT.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from exerciser.functions import cluster_function_failures, shared_import_preconditions
+from exerciser.issues import FailureCluster
+
+
+def _import_row(module: str, error_type: str, error_module: str, message: str) -> dict[str, Any]:
+    return {
+        "module": module,
+        "target_id": module,
+        "phase": "import",
+        "status": "error",
+        "error_type": error_type,
+        "error_module": error_module,
+        "error": message,
+        "error_mro": [error_type, "ValueError", "Exception", "BaseException", "object"],
+        "repo_packages": ["app"],
+    }
+
+
+def _clusters(rows: list[dict[str, Any]]):
+    """The real clustering path, so these tests bind to production behaviour."""
+    return cluster_function_failures(rows)
+
+
+#: Realistic module names. NOT ``mod0``/``mod1``: cluster signatures are
+#: digit-normalised, so numbered fixtures collapse into a single cluster and
+#: every count in these tests would be measuring the fixture instead of the
+#: code. The repo that exposed this had ``app.core.config``, ``app.api.routes``…
+_MODULES = [
+    "app.core.config",
+    "app.core.db",
+    "app.core.security",
+    "app.crud",
+    "app.main",
+    "app.utils",
+    "app.api.routes.items",
+    "app.api.routes.login",
+    "app.api.routes.users",
+    "app.api.routes.utils",
+    "app.backend_pre_start",
+    "app.initial_data",
+    "app.tests_pre_start",
+    "app.models",
+]
+
+
+def _settings_failure(module: str) -> dict[str, Any]:
+    return _import_row(
+        module,
+        "ValidationError",
+        "pydantic_core._pydantic_core",
+        "5 validation errors for Settings\nPROJECT_NAME\n  Field required",
+    )
+
+
+# =========================================================================
+# The shared precondition
+# =========================================================================
+
+
+def test_one_error_across_every_module_is_withheld_and_described() -> None:
+    rows = [_settings_failure(m) for m in _MODULES]
+    kept, preconditions = shared_import_preconditions(rows, _clusters(rows))
+
+    assert kept == []
+    assert len(preconditions) == 1
+    found = preconditions[0]
+    assert found["error_type"] == "ValidationError"
+    assert found["modules_blocked"] == 14
+    assert found["modules_attempted"] == 14
+    assert found["clusters_withheld"] == 14
+    # Withheld is not discarded: the cause has to be readable from the summary.
+    assert "PROJECT_NAME" in found["detail"]
+
+
+def test_the_reported_detail_carries_no_credential() -> None:
+    """The message that motivated this rendered the settings dict verbatim."""
+    rows = [
+        _import_row(
+            m,
+            "ValidationError",
+            "pydantic_core._pydantic_core",
+            "Field required [input_value={'openai_api_key': 'sk-proj-LEAKED-VALUE-HERE'}]",
+        )
+        for m in _MODULES[:5]
+    ]
+    _, preconditions = shared_import_preconditions(rows, _clusters(rows))
+    assert "sk-proj-LEAKED-VALUE-HERE" not in preconditions[0]["detail"]
+
+
+def test_a_defect_in_one_module_is_still_a_defect() -> None:
+    """The direction that matters most: this must not become a way to hide bugs."""
+    rows = [_settings_failure(m) for m in _MODULES[:10]]
+    # A THIRD-PARTY error module: an exception the repo defines about itself is
+    # already exempt, so a repo-provenance fixture would pass for the wrong
+    # reason and prove nothing about this rule.
+    rows.append(_import_row("app.broken", "TypeError", "somelib.core", "unsupported operand"))
+
+    kept, preconditions = shared_import_preconditions(rows, _clusters(rows))
+
+    assert len(preconditions) == 1
+    assert [c.to_json()["endpoint_id"] for c in kept] == ["app.broken"]
+
+
+def test_a_minority_of_modules_is_not_a_precondition() -> None:
+    """Below the share threshold the errors stay defects.
+
+    Three modules out of twenty failing the same way is a bug with a shared
+    cause, not an environment that was never configured.
+    """
+    rows = [_settings_failure(m) for m in _MODULES[:3]]
+    rows += [
+        {"module": f"app.ok.{n}", "target_id": f"app.ok.{n}", "phase": "import", "status": "ok"}
+        for n in "abcdefghijklmnopq"
+    ]
+    kept, preconditions = shared_import_preconditions(rows, _clusters(rows))
+
+    assert preconditions == []
+    assert len(kept) == 3
+
+
+def test_a_tiny_repo_is_never_called_dispersed() -> None:
+    """ "Both of my two modules raised the same thing" is not dispersion."""
+    rows = [_settings_failure("app.alpha"), _settings_failure("app.beta")]
+    kept, preconditions = shared_import_preconditions(rows, _clusters(rows))
+
+    assert preconditions == []
+    assert len(kept) == 2
+
+
+def test_two_distinct_preconditions_are_reported_separately() -> None:
+    rows = [_settings_failure(m) for m in _MODULES[:6]]
+    rows += [
+        _import_row(m, "OperationalError", "sqlalchemy.exc", "could not connect")
+        for m in _MODULES[6:12]
+    ]
+    kept, preconditions = shared_import_preconditions(rows, _clusters(rows))
+
+    assert kept == []
+    assert {p["error_type"] for p in preconditions} == {"ValidationError", "OperationalError"}
+    assert all(p["clusters_withheld"] == 6 for p in preconditions)
+
+
+def test_a_clean_run_is_untouched() -> None:
+    rows = [
+        {"module": f"app.m.{n}", "target_id": f"app.m.{n}", "phase": "import", "status": "ok"}
+        for n in "abcdefgh"
+    ]
+    kept, preconditions = shared_import_preconditions(rows, [])
+    assert kept == []
+    assert preconditions == []
+
+
+@pytest.mark.parametrize("rows", [[], [{"phase": "call", "status": "ok"}]])
+def test_no_import_rows_is_not_an_error(rows: list[dict[str, Any]]) -> None:
+    kept, preconditions = shared_import_preconditions(rows, [])
+    assert preconditions == []
+    assert kept == []
+
+
+def test_only_import_error_clusters_are_ever_withheld() -> None:
+    """The rule is scoped to IMPORT.
+
+    A crash cluster is built here directly rather than through
+    ``cluster_function_failures``: whether a given call row reaches a defect
+    verdict is the learned policy's business, and this test is about the
+    withholding filter, not about the policy. The crash is deliberately given
+    the SAME module and the SAME exception as the precondition, so kind is the
+    only thing that can be separating them.
+    """
+    rows = [_settings_failure(m) for m in _MODULES[:6]]
+    crash = FailureCluster(
+        signature="deadbeef",
+        kind="function-crash",
+        title="app.core.config — ValidationError",
+        endpoint_id="app.core.config",
+        method="CALL",
+        path="app.core.config",
+        exemplar={},
+    )
+
+    kept, preconditions = shared_import_preconditions(rows, [*_clusters(rows), crash])
+
+    assert preconditions and preconditions[0]["modules_blocked"] == 6
+    assert [c.kind for c in kept] == ["function-crash"]

--- a/exerciser/tests/test_import_preconditions.py
+++ b/exerciser/tests/test_import_preconditions.py
@@ -15,9 +15,15 @@ only problem was an unset environment variable. Provenance cannot separate
 that: the exception belongs to pydantic, so "the repo stating its own
 precondition" does not apply.
 
-Dispersion can, and it is a fact about the run rather than a vocabulary. These
-tests pin both directions — the shared precondition is withheld and described,
-and a genuine defect that happens to occur during import is NOT.
+Dispersion can, and it is a fact about the run rather than a vocabulary. What it
+establishes is that the group has ONE cause — not that the cause is harmless — so
+the group collapses to a single REPRESENTATIVE cluster rather than to none: a
+broken shared ``__init__`` blocks every module that imports it and is a real
+defect, and trading fifteen fabricated findings for one missed one is not a fix.
+
+These tests pin all three directions — the group is collapsed to one, the
+collapse is described, and a genuine defect that happens to occur during import
+keeps its own cluster.
 """
 
 from __future__ import annotations
@@ -85,19 +91,42 @@ def _settings_failure(module: str) -> dict[str, Any]:
 # =========================================================================
 
 
-def test_one_error_across_every_module_is_withheld_and_described() -> None:
+def test_one_error_across_every_module_is_reported_once_not_fourteen_times() -> None:
     rows = [_settings_failure(m) for m in _MODULES]
     kept, preconditions = shared_import_preconditions(rows, _clusters(rows))
 
-    assert kept == []
+    # ONE cluster, not fourteen and not zero. `clusters` is what reaches
+    # issues.json and the dispatch path, so a group that leaves nothing behind
+    # here is a finding the extension can never show or act on.
+    assert len(kept) == 1
+    assert kept[0].to_json()["kind"] == "import-error"
     assert len(preconditions) == 1
     found = preconditions[0]
     assert found["error_type"] == "ValidationError"
     assert found["modules_blocked"] == 14
     assert found["modules_attempted"] == 14
-    assert found["clusters_withheld"] == 14
-    # Withheld is not discarded: the cause has to be readable from the summary.
+    assert found["clusters_withheld"] == 13
+    assert found["reported_as"] == kept[0].to_json()["endpoint_id"]
+    # Folded is not discarded: the cause has to be readable from the summary.
     assert "PROJECT_NAME" in found["detail"]
+
+
+def test_a_shared_cause_is_still_reachable_by_the_dispatch_path() -> None:
+    """The regression this guards against.
+
+    An earlier form withheld the whole group. On a repo whose every module fails
+    to import because ONE shared module is broken — a real defect, and the most
+    consequential kind — the run then reported it in a summary field the
+    extension does not read, and dispatched nothing.
+    """
+    rows = [
+        _import_row(m, "TypeError", "somelib.core", "unsupported operand type(s)")
+        for m in _MODULES
+    ]
+    kept, preconditions = shared_import_preconditions(rows, _clusters(rows))
+
+    assert [c.to_json()["kind"] for c in kept] == ["import-error"]
+    assert preconditions[0]["clusters_withheld"] == 13
 
 
 def test_the_reported_detail_carries_no_credential() -> None:
@@ -126,7 +155,11 @@ def test_a_defect_in_one_module_is_still_a_defect() -> None:
     kept, preconditions = shared_import_preconditions(rows, _clusters(rows))
 
     assert len(preconditions) == 1
-    assert [c.to_json()["endpoint_id"] for c in kept] == ["app.broken"]
+    # The lone defect keeps its own cluster, and the shared group keeps exactly
+    # one — they are separate findings and both are reportable.
+    endpoints = [c.to_json()["endpoint_id"] for c in kept]
+    assert "app.broken" in endpoints
+    assert len(endpoints) == 2
 
 
 def test_a_minority_of_modules_is_not_a_precondition() -> None:
@@ -163,9 +196,13 @@ def test_two_distinct_preconditions_are_reported_separately() -> None:
     ]
     kept, preconditions = shared_import_preconditions(rows, _clusters(rows))
 
-    assert kept == []
+    # One representative EACH: two causes are two findings.
+    assert len(kept) == 2
     assert {p["error_type"] for p in preconditions} == {"ValidationError", "OperationalError"}
-    assert all(p["clusters_withheld"] == 6 for p in preconditions)
+    assert all(p["clusters_withheld"] == 5 for p in preconditions)
+    assert {p["reported_as"] for p in preconditions} == {
+        c.to_json()["endpoint_id"] for c in kept
+    }
 
 
 def test_a_clean_run_is_untouched() -> None:
@@ -185,7 +222,7 @@ def test_no_import_rows_is_not_an_error(rows: list[dict[str, Any]]) -> None:
     assert kept == []
 
 
-def test_only_import_error_clusters_are_ever_withheld() -> None:
+def test_only_import_error_clusters_are_ever_folded() -> None:
     """The rule is scoped to IMPORT.
 
     A crash cluster is built here directly rather than through
@@ -209,4 +246,5 @@ def test_only_import_error_clusters_are_ever_withheld() -> None:
     kept, preconditions = shared_import_preconditions(rows, [*_clusters(rows), crash])
 
     assert preconditions and preconditions[0]["modules_blocked"] == 6
-    assert [c.kind for c in kept] == ["function-crash"]
+    # The crash is untouched; the import group contributed its one representative.
+    assert sorted(c.kind for c in kept) == ["function-crash", "import-error"]

--- a/exerciser/tests/test_import_preconditions.py
+++ b/exerciser/tests/test_import_preconditions.py
@@ -120,8 +120,7 @@ def test_a_shared_cause_is_still_reachable_by_the_dispatch_path() -> None:
     extension does not read, and dispatched nothing.
     """
     rows = [
-        _import_row(m, "TypeError", "somelib.core", "unsupported operand type(s)")
-        for m in _MODULES
+        _import_row(m, "TypeError", "somelib.core", "unsupported operand type(s)") for m in _MODULES
     ]
     kept, preconditions = shared_import_preconditions(rows, _clusters(rows))
 
@@ -200,9 +199,7 @@ def test_two_distinct_preconditions_are_reported_separately() -> None:
     assert len(kept) == 2
     assert {p["error_type"] for p in preconditions} == {"ValidationError", "OperationalError"}
     assert all(p["clusters_withheld"] == 5 for p in preconditions)
-    assert {p["reported_as"] for p in preconditions} == {
-        c.to_json()["endpoint_id"] for c in kept
-    }
+    assert {p["reported_as"] for p in preconditions} == {c.to_json()["endpoint_id"] for c in kept}
 
 
 def test_a_clean_run_is_untouched() -> None:

--- a/exerciser/tests/test_integration_end_to_end.py
+++ b/exerciser/tests/test_integration_end_to_end.py
@@ -1,0 +1,393 @@
+"""End to end, through the REAL pipeline, asserting the CONTRACT with the extension.
+
+Companion to `test_integration_reachability.py`, which drives the CLI as a
+subprocess and asserts that each feature is on a path the engine takes. This one
+drives the same pipeline in-process and asserts the other half: that what a run
+LEAVES BEHIND carries what the reader on the far side needs, and that the stages
+between discovery and the verdict did what they claim.
+
+The contract assertions are the point. This branch has now hit the same defect five times:
+a producer whose output nothing consumes, with both ends reporting success. A
+unit test on the writing end passes whether or not a reading end exists, and a
+unit test on the reading end passes against a fixture the writer never produced.
+The only thing that catches it is one test that spans the boundary, so the
+contract assertions here name the fields by the reader's expectations rather
+than by the writer's.
+
+The fixture repo is built to make each stage do real work:
+
+===========================  ==================================================
+``src/`` layout              `detect_src_roots` must resolve `src`, not `.`
+`[project] name`             the interpreter probe's OWN-distribution signal
+a module needing `$DEMO_TOKEN`   the environment induction ladder
+a module needing `service/`  the working-directory search (a relative open())
+a genuine ZeroDivisionError  a real defect the verdict path must find
+a `_private` helper          internal targets are driven, exported ones first
+a filesystem writer          the purity guard refuses it; containment drives it
+a `requests.post` to a host  the HTTP double substitutes it
+a settings dump with a key   nothing may copy the credential into an artifact
+===========================  ==================================================
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+import sys
+import textwrap
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from exerciser import store
+from exerciser.campaign import result_path, run_campaign
+from exerciser.functions import detect_src_roots, discover_with_refusals, run_functions
+
+# A credential that must never appear in anything the engine writes. Fabricated;
+# the shape is what matters, because `redact_text` decides by key name.
+FAKE_KEY = "sk-proj-INTEGRATION-NOT-A-REAL-KEY"
+
+_MODULES: dict[str, str] = {
+    "pure.py": '''
+        """Verified-pure functions: the crash oracle's ordinary path."""
+
+
+        def add(a: int, b: int) -> int:
+            return a + b
+
+
+        def divide(a: int, b: int) -> float:
+            """A REAL defect: the harness's boundary class includes 0."""
+            return a / b
+
+
+        def _scale(n: int) -> int:
+            """Private by convention, driven anyway — API stability is not safety."""
+            return n * 2
+    ''',
+    "needs_env.py": '''
+        """Import fails until the environment names what it wants."""
+        import os
+
+        if not os.environ.get("DEMO_TOKEN"):
+            raise RuntimeError("DEMO_TOKEN environment variable is required")
+
+
+        def token_length(n: int) -> int:
+            return n
+    ''',
+    "impure.py": '''
+        """Writes a file, so the purity guard refuses it and containment drives it."""
+        from pathlib import Path
+
+
+        def record(name: str) -> str:
+            Path("side-effect.txt").write_text(name, encoding="utf-8")
+            return name
+    ''',
+    "provider.py": '''
+        """Reaches a remote API — the substitution's whole reason to exist."""
+        import requests
+
+
+        def ask(prompt: str) -> str:
+            reply = requests.post(
+                "https://api.example-provider.com/v1/chat?key=SECRETKEYVALUE",
+                json={"prompt": prompt},
+            )
+            return reply.json()["choices"][0]["message"]["content"]
+    ''',
+    "settings_dump.py": '''
+        """Renders its whole input dict when it rejects one field, as pydantic does."""
+        import os
+
+        _SEEN = {k: v for k, v in os.environ.items() if k.startswith("DEMO_")}
+        if not os.environ.get("DEMO_REGION"):
+            raise ValueError(
+                "1 validation error for Settings\\nDEMO_REGION\\n  Field required "
+                "[type=missing, input_value=" + repr(_SEEN) + "]"
+            )
+
+
+        def region(n: int) -> int:
+            return n
+    ''',
+}
+
+
+def _write_index(repo: Path, files: dict[str, str]) -> None:
+    """A code index over the fixture, derived from its own AST.
+
+    Written rather than shelled out to the Rust indexer: this suite is about the
+    exerciser, and depending on a second engine's binary would make it skip on
+    any machine that has not built one.
+    """
+    chunks: list[dict[str, Any]] = []
+    for rel, source in files.items():
+        tree = ast.parse(source)
+        for node in tree.body:
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                chunks.append(
+                    {
+                        "id": f"{rel}:{node.name}",
+                        "file": rel,
+                        "lang": "python",
+                        "kind": "function",
+                        "name": node.name,
+                        "start_line": node.lineno,
+                        "end_line": getattr(node, "end_lineno", node.lineno),
+                        "parent": None,
+                    }
+                )
+    index = repo / ".vinv" / "index"
+    index.mkdir(parents=True, exist_ok=True)
+    (index / "chunks.jsonl").write_text(
+        "".join(json.dumps(c) + "\n" for c in chunks), encoding="utf-8"
+    )
+
+
+@pytest.fixture(scope="module")
+def demo_repo(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """The fixture repo. Module-scoped: building it costs real subprocesses."""
+    repo = tmp_path_factory.mktemp("demo-repo")
+    pkg = repo / "src" / "demo"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+
+    written: dict[str, str] = {}
+    for name, body in _MODULES.items():
+        source = textwrap.dedent(body).strip() + "\n"
+        (pkg / name).write_text(source, encoding="utf-8")
+        written[f"src/demo/{name}"] = source
+
+    (repo / "pyproject.toml").write_text(
+        '[project]\nname = "demo-app"\nversion = "0.1.0"\ndependencies = ["requests"]\n',
+        encoding="utf-8",
+    )
+    # What the repo PUBLISHES about its environment, including a credential that
+    # must reach the worker and no artifact.
+    (repo / ".env").write_text(
+        f"DEMO_REGION=eu-west-1\nOPENAI_API_KEY={FAKE_KEY}\n", encoding="utf-8"
+    )
+    # A directory the code must run FROM for a relative path to resolve.
+    (repo / "service").mkdir()
+    (repo / "service" / "fixture.dat").write_text("present\n", encoding="utf-8")
+
+    _write_index(repo, written)
+    return repo
+
+
+@pytest.fixture(scope="module")
+def functions_result(demo_repo: Path) -> dict[str, Any]:
+    """One real run of the function channel, shared by the assertions below."""
+    from exerciser import interpreter
+
+    interpreter.reset_cache()
+    env_before = dict(os.environ)
+    try:
+        return run_functions(demo_repo, max_targets=40)
+    finally:
+        os.environ.clear()
+        os.environ.update(env_before)
+
+
+# =========================================================================
+# Stage 1 — which interpreter, and is it reported
+# =========================================================================
+
+
+def test_the_run_records_the_interpreter_it_used(functions_result: dict[str, Any]) -> None:
+    """Without this a run is unreproducible: the single most important input to
+    the result was chosen and never written down."""
+    chosen = functions_result["interpreter"]
+    assert chosen["python"] == sys.executable, "the fixture has no better candidate"
+    assert chosen["handed_off"] is False
+    assert chosen["repo_distributions"]["declared"] == 1  # demo-app
+    assert isinstance(chosen["considered"], list) and chosen["considered"]
+
+
+# =========================================================================
+# Stage 2 — import roots and target discovery
+# =========================================================================
+
+
+def test_a_src_layout_resolves_to_the_src_root(demo_repo: Path) -> None:
+    roots = detect_src_roots(demo_repo)
+    assert roots[0] == "src"
+    assert roots.count(".") == 1, f"the repo root is listed twice: {roots}"
+
+
+def test_discovery_drives_internals_but_claims_the_public_surface_first(
+    demo_repo: Path,
+) -> None:
+    targets, skipped, refusals = discover_with_refusals(demo_repo, max_targets=40)
+    kinds = [t.kind for t in targets]
+    names = {t.qualname for t in targets}
+
+    assert "add" in names and "divide" in names
+    assert "_scale" in names, "a leading underscore is API stability, not safety"
+    # Exported before internal: with a cap, filename order must not decide which
+    # functions get driven.
+    assert kinds.index("exported") < kinds.index("internal")
+    # The filesystem writer is refused by the purity guard and kept for the
+    # SANDBOX rather than dropped — a refusal is a recoverable decision.
+    refused = {r.target.qualname for r in refusals}
+    assert "record" in refused, skipped
+    # And the provider call, whose impurity is the network reach itself.
+    assert "ask" in refused, skipped
+
+
+# =========================================================================
+# Stage 3 — configuration the repo did not supply
+# =========================================================================
+
+
+def test_the_missing_variable_is_induced_from_the_modules_own_complaint(
+    functions_result: dict[str, Any],
+) -> None:
+    """`needs_env` names DEMO_TOKEN in its exception and nothing else knows it."""
+    inductions = functions_result["env_inductions"]
+    supplied = {v for entry in inductions for v in entry["variables"]}
+    assert "DEMO_TOKEN" in supplied, inductions
+    resolved = [e for e in inductions if e["module"].endswith("needs_env")]
+    assert resolved and resolved[0]["resolved"] is True, resolved
+
+
+def test_a_variable_the_repo_already_declares_is_not_induced(
+    functions_result: dict[str, Any],
+) -> None:
+    """`.env` gives DEMO_REGION, so `settings_dump` imports without a ladder."""
+    supplied = {v for e in functions_result["env_inductions"] for v in e["variables"]}
+    assert "DEMO_REGION" not in supplied
+
+
+# =========================================================================
+# Stage 4 — the verdict path
+# =========================================================================
+
+
+def test_a_real_defect_is_found_and_a_correct_function_is_not(
+    functions_result: dict[str, Any],
+) -> None:
+    verdicts = functions_result["verdicts"]
+    assert functions_result["calls"] > 0
+    assert verdicts.get("ok", 0) > 0, "nothing was driven successfully"
+    targets_with_clusters = {c["endpoint_id"] for c in functions_result["clusters"]}
+    assert any("divide" in t for t in targets_with_clusters), functions_result["clusters"]
+    assert not any("demo.pure:add" == t for t in targets_with_clusters)
+
+
+def test_containment_drove_the_target_the_purity_guard_refused(
+    functions_result: dict[str, Any],
+) -> None:
+    sandbox = functions_result["sandbox"]
+    assert sandbox["enabled"] is True
+    assert sandbox.get("tier"), sandbox
+    # `effects` is the per-row list; `effect_totals` is the tally.
+    assert sandbox["effect_totals"].get("filesystem", 0) >= 1, sandbox["effect_totals"]
+    assert any(e.get("kind") == "filesystem" for e in sandbox["effects"]), sandbox["effects"][:3]
+
+
+# =========================================================================
+# Stage 5 — service substitution
+# =========================================================================
+
+
+def test_the_provider_call_was_substituted_rather_than_left_unreachable(
+    functions_result: dict[str, Any],
+) -> None:
+    """Under containment the network is denied, so without the double this target
+    lands as `contained` and is never exercised."""
+    services = functions_result["sandbox"].get("services") or {}
+    families = {r.get("family") for r in (services.get("requirements") or [])}
+    assert "http" in families, services
+    assert services.get("enabled") is True
+    # The doubles must actually have INSTALLED. A relative import in the copied
+    # module made this silently false for every family at once.
+    assert not services.get("error"), services.get("error")
+
+
+def test_a_failure_caused_by_the_double_is_not_blamed_on_the_repo(
+    functions_result: dict[str, Any],
+) -> None:
+    """The double answers with a plausible SHAPE and never a correct value, so a
+    target that chokes on the fabricated body failed on OUR value."""
+    for gap in functions_result["substitution_gaps"]:
+        assert gap["target_id"] not in {c["endpoint_id"] for c in functions_result["clusters"]}
+
+
+# =========================================================================
+# Stage 6 — nothing the engine writes carries a credential
+# =========================================================================
+
+
+def test_no_artifact_contains_the_repos_credential(
+    demo_repo: Path, functions_result: dict[str, Any]
+) -> None:
+    """`.env` is loaded into the worker on purpose. Every artifact is written
+    inside the user's repository, one `git add .` from a public push.
+    """
+    assert FAKE_KEY not in json.dumps(functions_result), "the run summary carries it"
+    for artifact in sorted(store.exercise_dir(demo_repo).rglob("*")):
+        if not artifact.is_file():
+            continue
+        text = artifact.read_text(encoding="utf-8", errors="replace")
+        assert FAKE_KEY not in text, f"{artifact.name} carries the credential"
+
+
+# =========================================================================
+# Stage 7 — the artifact contract with the extension
+# =========================================================================
+
+#: Exactly the fields `extension/src/harness/exerciseRunner.ts` reads. Named from
+#: the READER's side deliberately: a writer-side test passes whether or not the
+#: reader exists, which is how five producer/consumer breaks reached this branch.
+_ENGINE_VERDICT_FIELDS = ("status", "diagnostics")
+_ISSUES_CLUSTER_FIELDS = ("signature", "kind", "title", "endpoint_id")
+
+
+def test_functions_json_carries_what_the_extension_reads(
+    demo_repo: Path, functions_result: dict[str, Any]
+) -> None:
+    doc = store.read_json(store.exercise_dir(demo_repo) / "functions.json")
+    assert doc is not None, "functions.json was never written"
+    for field in _ENGINE_VERDICT_FIELDS:
+        assert field in doc, f"`engineVerdict` reads `{field}` and it is absent"
+    assert isinstance(doc["diagnostics"], list)
+    assert doc["status"] in ("ok", "environment")
+
+
+def test_the_campaign_writes_the_artifact_the_extension_reads(demo_repo: Path) -> None:
+    """`campaign_result.json` is the RUN's verdict.
+
+    `functions.json` is rewritten by every crash play with `only_targets=[one]`,
+    so reading it gives one arm's verdict presented as the run's. This is the
+    file that fixes that, and this asserts the campaign actually produces it.
+    """
+    from exerciser import interpreter
+
+    interpreter.reset_cache()
+    result = run_campaign(demo_repo, budget=4, patience=100, max_targets=6)
+
+    persisted = store.read_json(result_path(demo_repo))
+    assert persisted is not None, "the campaign's verdict was printed and not written"
+    for field in _ENGINE_VERDICT_FIELDS:
+        assert field in persisted
+    assert persisted["status"] == result["status"]
+    assert "own_packages_unimportable" in persisted
+
+    issues = store.read_json(store.issues_path(demo_repo))
+    if issues and issues.get("clusters"):
+        for cluster in issues["clusters"]:
+            for field in _ISSUES_CLUSTER_FIELDS:
+                assert field in cluster, f"the dispatch path reads `{field}`"
+
+
+def test_every_artifact_the_engine_writes_is_json_serialisable(demo_repo: Path) -> None:
+    """They are written with `default=str`, so a non-serialisable value degrades
+    to a string rather than failing — and then the extension reads a string where
+    it expected a number. Reading each one back is the check."""
+    for artifact in sorted(store.exercise_dir(demo_repo).glob("*.json")):
+        assert store.read_json(artifact) is not None, f"{artifact.name} is not readable JSON"

--- a/exerciser/tests/test_integration_end_to_end.py
+++ b/exerciser/tests/test_integration_end_to_end.py
@@ -391,3 +391,139 @@ def test_every_artifact_the_engine_writes_is_json_serialisable(demo_repo: Path) 
     it expected a number. Reading each one back is the check."""
     for artifact in sorted(store.exercise_dir(demo_repo).glob("*.json")):
         assert store.read_json(artifact) is not None, f"{artifact.name} is not readable JSON"
+
+
+# =========================================================================
+# The handshake: artifacts the extension's tests consume
+# =========================================================================
+
+#: Where the extension's `exercisePassEndToEnd.test.ts` looks for real artifacts.
+#: Committed, so the TypeScript side reads documents THIS engine produced rather
+#: than objects a TypeScript file invented — which is the failure mode a
+#: reader-side test cannot see: it passes against a shape the writer never emits.
+_FIXTURE_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "extension"
+    / "src"
+    / "test"
+    / "fixtures"
+    / "engine-artifacts"
+)
+
+#: The artifacts that cross the boundary. Anything the extension reads belongs
+#: here; anything here that the engine stops writing fails on the far side.
+_HANDSHAKE_ARTIFACTS = ("issues.json", "campaign_result.json", "functions.json")
+
+
+def test_the_artifacts_the_extension_reads_are_published_for_its_tests(
+    demo_repo: Path, functions_result: dict[str, Any]
+) -> None:
+    """Emit real artifacts into the extension's fixture directory.
+
+    Not a fixture written by hand on either side: this run produced them, and the
+    extension's suite consumes exactly these bytes. A field the engine stops
+    emitting therefore fails a TypeScript test, in CI, without anyone thinking to
+    look — which is the only mechanism that catches a producer/consumer break,
+    because both sides pass in isolation by construction.
+
+    A credential check runs first: these files are COMMITTED, so publishing one
+    that carries a secret would put it in the repository permanently.
+    """
+    from exerciser import interpreter
+
+    interpreter.reset_cache()
+    run_campaign(demo_repo, budget=4, patience=100, max_targets=6)
+
+    _FIXTURE_DIR.mkdir(parents=True, exist_ok=True)
+    published: list[str] = []
+    for name in _HANDSHAKE_ARTIFACTS:
+        source = store.exercise_dir(demo_repo) / name
+        if not source.is_file():
+            continue
+        text = source.read_text(encoding="utf-8")
+        assert FAKE_KEY not in text, f"{name} carries a credential and must not be committed"
+        (_FIXTURE_DIR / name).write_text(text, encoding="utf-8")
+        published.append(name)
+
+    assert "issues.json" in published, published
+    assert "campaign_result.json" in published, published
+
+    # And the contract, asserted on what was just published rather than on what
+    # the writer intended: these are the fields the extension takes.
+    issues = json.loads((_FIXTURE_DIR / "issues.json").read_text(encoding="utf-8"))
+    assert "cluster_count" in issues, "`exerciseStateFromArtifacts` reads `cluster_count`"
+    assert isinstance(issues.get("clusters"), list)
+    verdict = json.loads((_FIXTURE_DIR / "campaign_result.json").read_text(encoding="utf-8"))
+    assert "status" in verdict and "diagnostics" in verdict, "`engineVerdict` reads both"
+
+
+# =========================================================================
+# The oracles the campaign allocates across
+# =========================================================================
+
+
+def test_the_differential_oracle_runs_against_the_real_repo(demo_repo: Path) -> None:
+    """Only `crash` and `campaign` had integration coverage; four oracles were
+    unit-tested only, so a break in how one is INVOKED was invisible."""
+    from exerciser.differential import run_differential
+
+    result = run_differential(demo_repo, timeout_s=60.0)
+
+    assert result["status"] in ("ok", "environment"), result.get("error")
+    assert "comparisons" in result
+    assert isinstance(result.get("clusters"), list)
+
+
+def test_the_concurrency_oracle_runs_against_a_real_target(demo_repo: Path) -> None:
+    from exerciser.concurrency import run_concurrency
+
+    result = run_concurrency(demo_repo, target="demo.pure:add", workers=2, repeats=2)
+
+    assert result["status"] in ("ok", "environment"), result.get("error")
+    assert isinstance(result.get("clusters"), list)
+    # `add` is deterministic and pure, so a divergence here would be the oracle's.
+    assert not [c for c in result["clusters"] if "divergence" in str(c.get("kind"))], result
+
+
+def test_the_fault_oracle_runs_from_a_derived_boundary(demo_repo: Path) -> None:
+    """Derivation and injection are separate halves and only the first had cover."""
+    from exerciser.faults import derive_boundaries, run_faults
+
+    derived, skipped = derive_boundaries(demo_repo, ["demo.pure:divide"])
+    assert derived, f"nothing derivable from an annotated target: {skipped}"
+
+    boundary = derived[0]
+    result = run_faults(
+        demo_repo,
+        target=boundary.target,
+        contract=dict(boundary.contract),
+        baseline=dict(boundary.baseline),
+        timeout_s=60.0,
+    )
+
+    assert result["status"] in ("ok", "environment"), result.get("error")
+    assert result.get("faults_injected", 0) > 0, "a derived boundary produced no faults"
+
+
+def test_the_environment_oracle_runs(demo_repo: Path) -> None:
+    from exerciser.environment import run_environment
+
+    result = run_environment(demo_repo, timeout_s=120.0)
+    assert result["status"] in ("ok", "skipped"), result
+
+
+def test_every_oracle_the_campaign_can_draw_has_a_runner(demo_repo: Path) -> None:
+    """The action space and the runner map must not drift apart.
+
+    An armed oracle with no runner drains budget into a no-op — the campaign
+    handles it, but only by dropping the actions and saying so, which is a
+    recovery rather than a design.
+    """
+    from exerciser.campaign import OracleConfig, default_runners, enumerate_actions
+
+    space = enumerate_actions(demo_repo, max_targets=6)
+    runners = default_runners(OracleConfig(repo=demo_repo))
+    armed = {a.oracle for a in space.actions}
+
+    assert armed, f"nothing armed on a repo with real targets: {space.notes}"
+    assert armed <= set(runners), f"armed with no runner: {armed - set(runners)}"

--- a/exerciser/tests/test_integration_end_to_end.py
+++ b/exerciser/tests/test_integration_end_to_end.py
@@ -415,6 +415,31 @@ _FIXTURE_DIR = (
 _HANDSHAKE_ARTIFACTS = ("issues.json", "campaign_result.json", "functions.json")
 
 
+def _machine_independent(text: str, repo: Path) -> str:
+    """Replace this machine's absolute paths with stable placeholders.
+
+    These files are COMMITTED, and an engine artifact records where it ran: the
+    repo it drove and the interpreter it drove it with. Left verbatim that
+    publishes the developer's home directory and username into the repository,
+    and makes regenerating on any other machine a diff of pure noise — which is
+    how a golden fixture stops being maintained and starts being reverted.
+
+    Only paths are touched. Every field the extension reads — `status`,
+    `diagnostics`, `cluster_count`, `clusters` — stays exactly as the engine
+    emitted it, because the point is to hold the READER to what the WRITER
+    really produces.
+    """
+    for actual, placeholder in (
+        (str(repo.resolve()), "<repo>"),
+        (str(Path(sys.executable).resolve()), "<python>"),
+        (str(Path(sys.executable).parent.parent.resolve()), "<venv>"),
+    ):
+        # Both spellings: raw, and JSON-escaped as it appears in the file.
+        text = text.replace(actual.replace("\\", "\\\\"), placeholder)
+        text = text.replace(actual, placeholder)
+    return text
+
+
 def test_the_artifacts_the_extension_reads_are_published_for_its_tests(
     demo_repo: Path, functions_result: dict[str, Any]
 ) -> None:
@@ -440,7 +465,7 @@ def test_the_artifacts_the_extension_reads_are_published_for_its_tests(
         source = store.exercise_dir(demo_repo) / name
         if not source.is_file():
             continue
-        text = source.read_text(encoding="utf-8")
+        text = _machine_independent(source.read_text(encoding="utf-8"), demo_repo)
         assert FAKE_KEY not in text, f"{name} carries a credential and must not be committed"
         (_FIXTURE_DIR / name).write_text(text, encoding="utf-8")
         published.append(name)
@@ -455,6 +480,12 @@ def test_the_artifacts_the_extension_reads_are_published_for_its_tests(
     assert isinstance(issues.get("clusters"), list)
     verdict = json.loads((_FIXTURE_DIR / "campaign_result.json").read_text(encoding="utf-8"))
     assert "status" in verdict and "diagnostics" in verdict, "`engineVerdict` reads both"
+
+    # And nothing machine-specific survived into a committed file.
+    for name in published:
+        published_text = (_FIXTURE_DIR / name).read_text(encoding="utf-8")
+        assert str(Path.home()) not in published_text, f"{name} carries a home directory"
+        assert str(demo_repo) not in published_text, f"{name} carries a temp path"
 
 
 # =========================================================================

--- a/exerciser/tests/test_integration_reachability.py
+++ b/exerciser/tests/test_integration_reachability.py
@@ -1,0 +1,537 @@
+"""Does anything actually REACH the thing that was built?
+
+Every failure this branch shipped had the same shape, and unit tests could not
+see any of them:
+
+* the HTTP double worked perfectly against its own classes and was never
+  installed, because no HTTP module produced a service requirement and
+  ``install()`` is gated on requirements;
+* the agent channel was written to disk and no consumer existed;
+* the fault oracle's contract questions were queued in memory and never saved;
+* ``evidenceFileForKind`` had no case for the kinds that fire most.
+
+In each case the component's own tests passed, because the component worked.
+What was missing was any test that the component is on a path the engine takes.
+
+So these tests drive the REAL CLI as a subprocess against synthetic repos and
+assert on the artifacts a run leaves behind. They are slower than unit tests and
+they are the only kind that can fail when a feature becomes unreachable — which
+is the failure mode this branch actually had, four times.
+
+Deliberately NOT asserting on defect counts or cluster contents: those belong to
+the oracles' own tests and would make this file fail for reasons that have
+nothing to do with reachability.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+#: The engine is driven exactly as a user drives it. `-m exerciser.cli` rather
+#: than the console script so the test does not depend on an install layout.
+_CLI = [sys.executable, "-m", "exerciser.cli"]
+
+_RUN_TIMEOUT_S = 300.0
+
+
+def _write(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(body).strip() + "\n", encoding="utf-8")
+
+
+def _index(repo: Path) -> None:
+    """The minimal code index discovery reads, built from the sources."""
+    chunks = []
+    for path in sorted(repo.rglob("*.py")):
+        rel = path.relative_to(repo).as_posix()
+        if ".vinv/" in rel:
+            continue
+        for found in re.finditer(r"^def (\w+)", path.read_text(encoding="utf-8"), re.M):
+            chunks.append(
+                {
+                    "id": f"{rel}:{found.group(1)}",
+                    "file": rel,
+                    "lang": "python",
+                    "kind": "function",
+                    "name": found.group(1),
+                    "start_line": 1,
+                    "end_line": 2,
+                    "parent": None,
+                }
+            )
+    index = repo / ".vinv" / "index"
+    index.mkdir(parents=True, exist_ok=True)
+    (index / "chunks.jsonl").write_text(
+        "".join(json.dumps(c) + "\n" for c in chunks), encoding="utf-8"
+    )
+
+
+def _run(repo: Path, *args: str) -> dict:
+    """Run the real CLI and return its parsed summary."""
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(
+        [p for p in (env.get("PYTHONPATH"), str(Path(__file__).parents[1] / "src")) if p]
+    )
+    proc = subprocess.run(
+        [*_CLI, "functions", str(repo), *args],
+        capture_output=True,
+        text=True,
+        timeout=_RUN_TIMEOUT_S,
+        env=env,
+    )
+    start = proc.stdout.find("{")
+    assert start >= 0, f"the CLI produced no JSON:\n{proc.stdout}\n{proc.stderr}"
+    return json.loads(proc.stdout[start:])
+
+
+def _artifact(repo: Path, name: str) -> dict:
+    return json.loads((repo / ".vinv" / "exercise" / name).read_text(encoding="utf-8"))
+
+
+# =========================================================================
+# Fixtures — repos shaped like the failures that motivated each layer
+# =========================================================================
+
+
+@pytest.fixture
+def plain_repo(tmp_path: Path) -> Path:
+    """A repo that needs nothing: no config, no services, no venv."""
+    repo = tmp_path / "plain"
+    _write(repo / "pyproject.toml", '[project]\nname = "plain"\nversion = "0.1.0"')
+    _write(repo / "plain" / "__init__.py", "")
+    _write(repo / "plain" / "calc.py", "def double(n: int) -> int:\n    return n * 2")
+    _index(repo)
+    return repo
+
+
+@pytest.fixture
+def provider_repo(tmp_path: Path) -> Path:
+    """A repo whose only external dependency is a remote API.
+
+    The exact shape that made the HTTP double unreachable: nothing here is a
+    database, a cache or an object store, so before `HTTP_FAMILY` existed this
+    repo produced no service requirement at all.
+    """
+    repo = tmp_path / "provider"
+    _write(repo / "pyproject.toml", '[project]\nname = "prov"\nversion = "0.1.0"')
+    _write(repo / "prov" / "__init__.py", "")
+    _write(
+        repo / "prov" / "client.py",
+        """
+        import httpx
+
+
+        def summarize(text: str) -> str:
+            reply = httpx.Client().post(
+                "https://api.openai.com/v1/chat/completions",
+                json={"model": "gpt-4", "messages": [{"role": "user", "content": text}]},
+                headers={"Authorization": "Bearer sk-not-a-real-key"},
+            )
+            return str(reply.json()["choices"][0]["message"]["content"])
+        """,
+    )
+    _index(repo)
+    return repo
+
+
+@pytest.fixture
+def unconfigured_repo(tmp_path: Path) -> Path:
+    """A repo whose import needs an environment variable nothing supplies."""
+    repo = tmp_path / "unconfigured"
+    _write(repo / "pyproject.toml", '[project]\nname = "unconf"\nversion = "0.1.0"')
+    _write(repo / "unconf" / "__init__.py", "")
+    _write(
+        repo / "unconf" / "settings.py",
+        """
+        import os
+
+        PROJECT_SLUG = os.environ["VINV_TEST_SLUG"]
+
+
+        def slug() -> str:
+            return PROJECT_SLUG
+        """,
+    )
+    _index(repo)
+    return repo
+
+
+# =========================================================================
+# Every layer, asserted to have actually run
+# =========================================================================
+
+
+def test_interpreter_resolution_runs_and_is_reported(plain_repo: Path) -> None:
+    """The choice must be in the summary, or the run is unreproducible."""
+    result = _run(plain_repo)
+    interpreter = result["interpreter"]
+    assert interpreter["python"], "no interpreter was recorded"
+    assert interpreter["considered"], "no candidates were probed"
+
+
+def test_the_run_records_where_it_looked_for_configuration(plain_repo: Path) -> None:
+    """These fields exist so a run says what it did. Absent, nothing is auditable."""
+    result = _run(plain_repo)
+    for field in ("interpreter", "import_preconditions", "env_inductions", "config_requests"):
+        assert field in result, f"{field} missing from the run summary"
+
+
+def test_a_repo_needing_nothing_escalates_nothing(plain_repo: Path) -> None:
+    """The ladder must cost nothing when it is not needed."""
+    result = _run(plain_repo)
+    assert result["calls"] > 0, "a trivial pure function was never called"
+    assert result["config_requests"] == []
+    assert result["env_inductions"] == []
+
+
+def test_config_requests_is_written_even_when_empty(plain_repo: Path) -> None:
+    """The UI must distinguish "nothing is asked" from "no run got this far".
+
+    Written every run, so a stale prompt for a variable that is now satisfied
+    cannot persist in the panel.
+    """
+    _run(plain_repo)
+    doc = _artifact(plain_repo, "config_requests.json")
+    assert doc["requests"] == []
+    assert doc["answers_path"].endswith("config_answers.json")
+
+
+# ---- the layer that shipped unreachable ---------------------------------
+
+
+def test_a_provider_repo_declares_a_service_requirement(provider_repo: Path) -> None:
+    """The gate that made the HTTP double dead code.
+
+    `install()` runs only when the plan carries requirements. This repo has no
+    database, cache or object store — if an HTTP client does not produce a
+    requirement, the doubles never install and every patcher is unreachable.
+    """
+    from exerciser.services import HTTP_FAMILY, discover_requirements
+
+    families = {r.family for r in discover_requirements(provider_repo)}
+    assert HTTP_FAMILY in families
+
+
+def test_the_http_double_actually_serves_a_provider_call(provider_repo: Path) -> None:
+    """The end-to-end assertion that unit tests could not make.
+
+    No API key, no network. The call must COMPLETE — not land as `contained`,
+    which is what happened before the substitution existed, and not fail, which
+    is what happened while the double was unreachable.
+    """
+    result = _run(provider_repo)
+
+    assert result["calls"] > 0, "the provider-backed function was never called"
+    assert (
+        result["verdicts"].get("ok", 0) > 0
+    ), f"no call succeeded — the double did not serve: {result['verdicts']}"
+
+    events = result["sandbox"]["services"]["events"]
+    served = [e for e in events if e.get("kind") == "substituted" and e.get("service") == "http"]
+    assert served, f"the HTTP double recorded no participation: {events[:3]}"
+    assert "api.openai.com" in served[0]["detail"]
+
+
+def test_the_substituted_value_reaches_the_target(provider_repo: Path) -> None:
+    """The body has to satisfy the access path, or the call completes with junk."""
+    _run(provider_repo)
+    rows = [
+        json.loads(line)
+        for line in (provider_repo / ".vinv/exercise/function_results.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+        if line.strip()
+    ]
+    returned = [str(r.get("result")) for r in rows if r.get("phase") == "call"]
+    assert returned, "no call rows were recorded"
+    assert any(
+        "vinv-substituted" in value for value in returned
+    ), f"the target did not receive the substituted body: {returned[:3]}"
+
+
+# ---- configuration, all the way to the escalation ------------------------
+
+
+def test_a_missing_variable_is_induced_rather_than_reported_as_a_defect(
+    unconfigured_repo: Path,
+) -> None:
+    """The induction has to actually run, not merely exist."""
+    result = _run(unconfigured_repo)
+
+    induced = result["env_inductions"]
+    assert induced, "nothing was induced for a module that names a missing variable"
+    assert any("VINV_TEST_SLUG" in entry["variables"] for entry in induced)
+    assert any(
+        entry["resolved"] for entry in induced
+    ), "the variable was named and supplied but the module still did not import"
+
+
+def test_an_induced_run_calls_the_code_it_unblocked(unconfigured_repo: Path) -> None:
+    """Supplying a value is worthless unless the target then runs."""
+    result = _run(unconfigured_repo)
+    assert result["calls"] > 0
+
+
+def test_a_user_answer_is_read_back_on_the_next_run(unconfigured_repo: Path) -> None:
+    """The write-back contract the panel depends on.
+
+    The panel writes this file; if the engine does not read it, every answer a
+    person gives is discarded and they are asked again forever.
+    """
+    answers = unconfigured_repo / ".vinv" / "exercise" / "config_answers.json"
+    answers.parent.mkdir(parents=True, exist_ok=True)
+    answers.write_text(
+        json.dumps({"version": 1, "answers": {"VINV_TEST_SLUG": "from-the-user"}}),
+        encoding="utf-8",
+    )
+
+    result = _run(unconfigured_repo)
+
+    assert result["calls"] > 0
+    # The value came from the answers file, so nothing had to be induced for it.
+    induced_names = {n for entry in result["env_inductions"] for n in entry["variables"]}
+    assert "VINV_TEST_SLUG" not in induced_names
+
+
+def test_the_working_directory_search_is_reported(tmp_path: Path) -> None:
+    """A module that only imports from a subdirectory must still be driven."""
+    repo = tmp_path / "cwd"
+    _write(repo / "pyproject.toml", '[project]\nname = "cwd"\nversion = "0.1.0"')
+    _write(repo / "settings.ini", "value = 1")
+    _write(repo / "svc" / "pkg" / "__init__.py", "")
+    _write(
+        repo / "svc" / "pkg" / "mod.py",
+        """
+        from pathlib import Path
+
+        _CONFIG = Path("../settings.ini").read_text(encoding="utf-8")
+
+
+        def double(n: int) -> int:
+            return n * 2
+        """,
+    )
+    _index(repo)
+
+    result = _run(repo)
+
+    assert result["calls"] > 0, "the module never imported from any candidate directory"
+    assert result["workdir_resolutions"], "the retry happened but was not reported"
+    assert result["workdir_resolutions"][0]["chosen"] == "svc"
+
+
+# ---- the contract that keeps the doubles installable ---------------------
+
+
+def test_the_doubles_install_at_all(provider_repo: Path) -> None:
+    """Any failure here silently disables EVERY double, not just one.
+
+    `service_doubles` is copied into the jail as a standalone module beside a
+    generated `sitecustomize`, so a package-relative import inside it raises
+    `attempted relative import with no known parent package` and `install()`
+    aborts — taking sql, kv, objectstore and http down together while each
+    target merely looks like it could not connect.
+
+    That happened: a `from .redact import redact_url` added for a real leak
+    disabled every substitution in the engine, and the only visible symptom was
+    calls landing as `contained`.
+    """
+    result = _run(provider_repo)
+    services = result["sandbox"]["services"]
+    assert services.get("error") is None, f"the doubles did not install: {services.get('error')}"
+
+
+def test_the_copied_modules_import_standalone(tmp_path: Path) -> None:
+    """Load the shim's copies the way the jail does: no package, no parent.
+
+    Asserted by IMPORTING them rather than by grepping for `from .`, because the
+    failure is an import failure and only an import can prove the absence of
+    one.
+    """
+    from exerciser.sandbox import write_shim
+
+    write_shim(tmp_path)
+    assert (tmp_path / "_vinv_service_doubles.py").is_file()
+
+    probe = subprocess.run(
+        [sys.executable, "-c", "import _vinv_service_doubles as d; print(bool(d.install))"],
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+        timeout=60,
+    )
+    assert probe.returncode == 0, f"the standalone copy does not import: {probe.stderr}"
+
+
+def test_a_recorded_request_line_carries_no_credential(tmp_path: Path) -> None:
+    """The ledger records the URL the double answered, and URLs carry keys.
+
+    Gemini authenticates with `?key=`, Azure SAS with `?sig=`, AWS presigns with
+    `?signature=`. The client still gets the real URL; only what is written down
+    is redacted.
+    """
+    repo = tmp_path / "keyed"
+    _write(repo / "pyproject.toml", '[project]\nname = "keyed"\nversion = "0.1.0"')
+    _write(repo / "keyed" / "__init__.py", "")
+    _write(
+        repo / "keyed" / "client.py",
+        """
+        import httpx
+
+
+        def fetch() -> str:
+            reply = httpx.Client().get(
+                "https://generativelanguage.googleapis.com/v1/models?key=AIzaSyREALKEYVALUE"
+            )
+            return str(reply.json()["candidates"][0]["content"])
+        """,
+    )
+    _index(repo)
+
+    result = _run(repo)
+    recorded = json.dumps(result["sandbox"]["services"].get("events", []))
+    assert "AIzaSyREALKEYVALUE" not in recorded, "the double wrote a live key into the ledger"
+
+
+# ---- the agentic fallback, for what no pattern can read -------------------
+
+
+def test_an_unreadable_failure_is_handed_to_the_harness(tmp_path: Path) -> None:
+    """The gap that made the ladder a pattern match and nothing else.
+
+    ``missing_env_names`` reads the shapes in which a program says a variable is
+    missing, and that set is finite while the ways to say it are not. A repo
+    raising its own ``NeedsSetup("the widget registry has not been provisioned")``
+    names nothing in any recognisable form — so nothing was induced, nothing was
+    unsatisfied, and nothing escalated. The module stayed blocked and no one was
+    asked, which is the pattern silently being the only path.
+    """
+    repo = tmp_path / "weird"
+    _write(repo / "pyproject.toml", '[project]\nname = "weird"\nversion = "0.1.0"')
+    _write(repo / "weird" / "__init__.py", "")
+    _write(
+        repo / "weird" / "mod.py",
+        """
+        class NeedsSetup(Exception):
+            pass
+
+
+        def _bootstrap():
+            raise NeedsSetup("cannot start: the widget registry has not been provisioned")
+
+
+        _bootstrap()
+
+
+        def go() -> int:
+            return 1
+        """,
+    )
+    _index(repo)
+
+    result = _run(repo)
+
+    asked = result["blocked_imports_asked"]
+    assert asked, "an unreadable import failure was dropped instead of asked about"
+    assert asked[0]["module"] == "weird.mod"
+    assert "widget registry" in asked[0]["reason"]
+    doc = _artifact(repo, "agent_blocked-import.json")
+    assert doc["questions"], "the question was reported but never persisted"
+
+
+def test_a_readable_failure_does_not_bother_the_harness(tmp_path: Path) -> None:
+    """The patterns stay because they are free.
+
+    A ``KeyError`` from ``os.environ[...]`` is settled by induction with no model
+    call at all, and must not also raise a question.
+    """
+    repo = tmp_path / "readable"
+    _write(repo / "pyproject.toml", '[project]\nname = "readable"\nversion = "0.1.0"')
+    _write(repo / "readable" / "__init__.py", "")
+    _write(
+        repo / "readable" / "mod.py",
+        """
+        import os
+
+        SLUG = os.environ["VINV_READABLE_SLUG"]
+
+
+        def slug() -> str:
+            return SLUG
+        """,
+    )
+    _index(repo)
+
+    result = _run(repo)
+
+    assert result["blocked_imports_asked"] == []
+    assert any(e["resolved"] for e in result["env_inductions"])
+
+
+def test_a_harness_answer_for_a_blocked_module_is_read_back(tmp_path: Path) -> None:
+    """The loop has to close, or asking was theatre."""
+    repo = tmp_path / "answered"
+    _write(repo / "pyproject.toml", '[project]\nname = "answered"\nversion = "0.1.0"')
+    _write(repo / "answered" / "__init__.py", "")
+    _write(
+        repo / "answered" / "mod.py",
+        """
+        import os
+
+        if "VINV_ODD_GATE" not in os.environ:
+            raise SystemError("the gate is shut")
+
+        VALUE = os.environ["VINV_ODD_GATE"]
+
+
+        def value() -> str:
+            return VALUE
+        """,
+    )
+    _index(repo)
+    _run(repo)
+
+    channel_path = repo / ".vinv" / "exercise" / "agent_blocked-import.json"
+    doc = json.loads(channel_path.read_text(encoding="utf-8"))
+    for entry in doc["questions"].values():
+        entry["answer"] = {"variables": {"VINV_ODD_GATE": "open"}, "blocker": None}
+    channel_path.write_text(json.dumps(doc), encoding="utf-8")
+
+    result = _run(repo)
+    assert result["calls"] > 0, "the harness answered and the module still was not driven"
+
+
+def test_a_credential_never_returns_through_the_blocked_channel(tmp_path: Path) -> None:
+    """A model that helpfully hallucinates an API key must not get it used."""
+    from exerciser.envconfig import blocked_module_answers
+
+    exercise = tmp_path / ".vinv" / "exercise"
+    exercise.mkdir(parents=True)
+    (exercise / "agent_blocked-import.json").write_text(
+        json.dumps(
+            {
+                "topic": "blocked-import",
+                "questions": {
+                    "k": {
+                        "answer": {
+                            "variables": {"OPENAI_API_KEY": "sk-hallucinated", "REGION": "eu"},
+                            "blocker": None,
+                        }
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    answers = blocked_module_answers(tmp_path)
+    assert "OPENAI_API_KEY" not in answers
+    assert answers == {"REGION": "eu"}

--- a/exerciser/tests/test_interpreter_discovery.py
+++ b/exerciser/tests/test_interpreter_discovery.py
@@ -77,9 +77,27 @@ def _make_venv(root: Path, dists: list[str]) -> str:
         (info / "METADATA").write_text(
             f"Metadata-Version: 2.1\nName: {dist}\nVersion: 1.0\n", encoding="utf-8"
         )
-    exe = next((p for p in (root / "bin/python3", root / "Scripts/python.exe") if p.exists()), None)
-    assert exe is not None, "venv produced no interpreter"
-    return str(exe)
+    return str(_venv_exe(root))
+
+
+def _site_packages(root: Path) -> Path:
+    """This venv's ``site-packages``, on either platform layout.
+
+    POSIX is ``lib/python3.X/site-packages`` and Windows is ``Lib/site-packages``
+    — hardcoding the first is how a test that has nothing to do with platforms
+    fails on one of them.
+    """
+    found = next(root.glob("lib/python*/site-packages"), None) or (root / "Lib/site-packages")
+    assert found.is_dir(), f"no site-packages under {root}"
+    return found
+
+
+def _venv_exe(root: Path) -> Path:
+    """This venv's interpreter, on either platform layout."""
+    layouts = (root / "bin/python3", root / "Scripts/python.exe")
+    found = next((p for p in layouts if p.exists()), None)
+    assert found is not None, f"no interpreter under {root}"
+    return found
 
 
 def _pyproject(directory: Path, name: str, deps: list[str]) -> None:
@@ -261,20 +279,38 @@ def test_two_venvs_built_from_one_base_python_are_not_one_candidate(
     same Python into a single entry. The target's venv and Vinv's own venv then
     look like one candidate — with entirely different ``site-packages`` — and
     whichever was discovered first silently won.
+
+    The symlink, and therefore the trap, is POSIX-only: Windows COPIES the
+    interpreter into the venv, so ``realpath`` separates them there for a reason
+    that has nothing to do with the fix. Asserting the shared base
+    unconditionally made this fail on Windows for the fixture's reasons rather
+    than the code's. The key must separate the two either way, which is the
+    claim; the trap is pinned only where it exists.
     """
     monkeypatch.delenv("VIRTUAL_ENV", raising=False)
     a = _make_venv(tmp_path / "a", [])
     b = _make_venv(tmp_path / "b", [])
 
-    assert Path(a).resolve() == Path(b).resolve(), "fixture assumes a shared base interpreter"
-    assert Candidate(a, "test").key() != Candidate(b, "test").key()
+    shared_base = Path(a).resolve() == Path(b).resolve()
+    why = " — off ONE base interpreter, which is what realpath keying gets wrong"
+    assert Candidate(a, "test").key() != Candidate(b, "test").key(), (
+        "two venvs collapsed into one candidate" + (why if shared_base else "")
+    )
 
 
 def test_the_two_names_for_one_venvs_interpreter_collapse(tmp_path: Path) -> None:
+    """``python`` and ``python3`` in one venv are one candidate.
+
+    Both spellings are asked for by their real directory, so this says something
+    on Windows (``Scripts/``) as well as on POSIX (``bin/``) — naming the POSIX
+    layout unconditionally made both sides fall through to the venv-prefix
+    branch and the test passed without testing anything.
+    """
     root = tmp_path / "env"
     _make_venv(root, [])
-    assert Candidate(str(root / "bin" / "python"), "x").key() == (
-        Candidate(str(root / "bin" / "python3"), "x").key()
+    bin_dir = _venv_exe(root).parent
+    assert Candidate(str(bin_dir / "python"), "x").key() == (
+        Candidate(str(bin_dir / "python3"), "x").key()
     )
 
 
@@ -336,7 +372,7 @@ def test_the_probe_does_not_import_the_target(tmp_path: Path) -> None:
     whose import would raise, hang, or write to disk is still counted correctly.
     """
     exe = _make_venv(tmp_path / "env", ["demo-core"])
-    site = next((tmp_path / "env").glob("lib/python*/site-packages"))
+    site = _site_packages(tmp_path / "env")
     (site / "demo_core.py").write_text("raise SystemExit('imported!')\n", encoding="utf-8")
 
     probe = probe_candidate(Candidate(exe, "test"), Requirements(own=("demo-core",)))
@@ -585,3 +621,139 @@ def test_the_report_is_json_serialisable(monorepo: Path) -> None:
     """It lands in the run summary, which is written to disk and printed."""
     _make_venv(monorepo / ".venv-target", ["demo-root"])
     json.dumps(resolve_interpreter(monorepo).to_json())
+
+
+# =========================================================================
+# The fallback keeps a reserved slot
+# =========================================================================
+
+
+def _stub_venv(root: Path) -> None:
+    """A venv-SHAPED directory. Never executed — only the discovery walk sees it."""
+    (root / "Scripts").mkdir(parents=True)
+    (root / "bin").mkdir(parents=True)
+    (root / "pyvenv.cfg").write_text("home = /nowhere\n", encoding="utf-8")
+    for rel in ("Scripts/python.exe", "bin/python3"):
+        exe = root / rel
+        exe.write_text("", encoding="utf-8")
+        exe.chmod(0o755)
+
+
+def test_the_fallback_survives_a_repo_with_more_venvs_than_the_cap(tmp_path: Path) -> None:
+    """The cap truncates the TAIL, and the fallback is last.
+
+    A monorepo with a venv per package therefore dropped ``sys.executable`` off
+    the end of its own candidate list — after which ``resolve_interpreter``
+    scored it (0, 0) WITHOUT PROBING IT, which both fabricates the baseline the
+    handoff diagnostic quotes and lets a candidate with one third-party package
+    beat an interpreter that may have the whole repo installed.
+    """
+    repo = tmp_path / "repo"
+    _pyproject(repo, "demo", [])
+    for n in range(interpreter.MAX_CANDIDATES + 2):
+        _stub_venv(repo / f"pkg{n:02d}" / ".venv")
+
+    candidates = discover_candidates(repo)
+    self_key = Candidate(sys.executable, "").key()
+
+    assert len(candidates) == interpreter.MAX_CANDIDATES
+    assert any(c.key() == self_key for c in candidates), "the fallback was truncated away"
+    assert candidates[-1].key() == self_key, "and it is still last"
+
+
+def test_an_explicit_flag_survives_the_cap_too(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _pyproject(repo, "demo", [])
+    for n in range(interpreter.MAX_CANDIDATES + 2):
+        _stub_venv(repo / f"pkg{n:02d}" / ".venv")
+
+    candidates = discover_candidates(repo, explicit="/somewhere/python")
+    assert candidates[0].origin == "--python"
+
+
+# =========================================================================
+# setup.cfg
+# =========================================================================
+
+
+def test_a_setuptools_repo_declares_its_own_distribution(tmp_path: Path) -> None:
+    """``setup.cfg`` was in ``_MANIFESTS`` from the start and nothing parsed it.
+
+    So a setuptools-configured repo declared no OWN distribution, and the
+    ranking fell back to the flat third-party count that this module exists to
+    say is too weak to trust.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "setup.cfg").write_text(
+        textwrap.dedent("""
+            [metadata]
+            name = Demo_Pkg
+
+            [options]
+            install_requires =
+                requests>=2
+                pydantic
+            """).strip(),
+        encoding="utf-8",
+    )
+    reqs = declared_requirements(repo)
+    assert reqs.own == ("demo-pkg",)
+    assert set(reqs.third_party) == {"requests", "pydantic"}
+
+
+# =========================================================================
+# An answer handed back is not a flag
+# =========================================================================
+
+
+def test_the_campaigns_own_answer_is_not_re_probed_as_an_explicit_flag(
+    monorepo: Path, monkeypatch
+) -> None:
+    """The campaign resolves once and passes the ANSWER to every oracle.
+
+    Each oracle then offers it here as ``explicit`` — a different cache key, so
+    it re-probed, and worse took the explicit branch and reported ``--python
+    <path> has NONE of the distributions this repo publishes`` about a flag
+    nobody passed.
+    """
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    _make_venv(monorepo / ".venv-target", ["demo-root", "demo-core"])
+
+    first = interpreter.resolve_cached(monorepo)
+    calls: list[list[str]] = []
+    real = interpreter.probe_candidate
+    monkeypatch.setattr(
+        interpreter,
+        "probe_candidate",
+        lambda cand, reqs, **kw: (calls.append([cand.python]), real(cand, reqs, **kw))[1],
+    )
+
+    again = interpreter.resolve_cached(monorepo, explicit=first.python)
+
+    assert again is first, "the repo's own answer coming back round is the same answer"
+    assert calls == [], "and it is not re-probed"
+    # No diagnostic ACCUSING a flag. The handoff notice legitimately mentions
+    # `--python` as the override; what must not appear is the explicit branch's
+    # "--python <path> has NONE of …", which leads with the flag it is blaming.
+    assert not any(d.startswith("--python") for d in again.diagnostics)
+
+
+def test_a_different_explicit_flag_still_resolves(monorepo: Path, monkeypatch) -> None:
+    """The short-circuit must not swallow a flag that names something else.
+
+    The prior answer here is the repo's venv (it has the repo installed), so
+    pointing the flag back at Vinv's own interpreter is the case that has to get
+    through: it disagrees with what resolution chose, which is exactly when a
+    human's flag matters most.
+    """
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    venv = _make_venv(monorepo / ".venv-target", ["demo-root", "demo-core"])
+
+    first = interpreter.resolve_cached(monorepo)
+    assert first.python == venv, "fixture assumes resolution prefers the repo's venv"
+
+    chosen = interpreter.resolve_cached(monorepo, explicit=sys.executable)
+
+    assert chosen.python == sys.executable
+    assert chosen.origin == "--python"

--- a/exerciser/tests/test_interpreter_discovery.py
+++ b/exerciser/tests/test_interpreter_discovery.py
@@ -1,0 +1,587 @@
+"""Choosing the interpreter that can actually import the target.
+
+The bug these tests pin came from a real run, not a fixture. Against a clone of
+langchain-ai/langchain the engine reported ``status: "ok"``, ``issue_clusters:
+0``, ``diagnostics: []`` — while 185 of 288 outcomes were
+``ModuleNotFoundError: No module named 'langchain_core'``, because the workers
+ran under Vinv's own venv. The same command with ``--python`` pointed at the
+repo's venv produced 642 calls and 5 defect clusters.
+
+So the tests are built around the ways the choice could go wrong:
+
+* the repo's venv is not called ``.venv`` (the real one was ``.venv-target``),
+  so any name-based discovery misses it;
+* Vinv's own venv shares enough ordinary libraries (pydantic, requests, PyYAML)
+  with the target that a flat "how many dependencies do you have" count nearly
+  ties — 20 against 15 on the real repo — and would invert on a repo with more
+  common dependencies still;
+* an active ``VIRTUAL_ENV`` is ALWAYS Vinv's own when the CLI runs, so trusting
+  it re-elects exactly the interpreter this module exists to stop electing;
+* the manifests inside a venv's ``site-packages`` are other projects', and
+  reading them measures every candidate against pandas' dependency list;
+* a repo's venv can be older than the worker's own ``requires-python`` floor,
+  which must be reported rather than crashed into;
+* an explicit ``--python`` must never be second-guessed, however bad it looks.
+
+The fake environments here are REAL venvs (``python -m venv``) with synthetic
+``.dist-info`` directories dropped in, so the probe subprocess is exercised for
+real rather than mocked out.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from exerciser import interpreter
+from exerciser.interpreter import (
+    MIN_WORKER_PYTHON,
+    Candidate,
+    Probe,
+    Requirements,
+    _requirement_name,
+    declared_requirements,
+    discover_candidates,
+    normalize_dist,
+    probe_candidate,
+    resolve_interpreter,
+)
+
+# =========================================================================
+# Fixtures — real venvs, synthetic metadata
+# =========================================================================
+
+
+def _make_venv(root: Path, dists: list[str]) -> str:
+    """A real venv at ``root``, reporting ``dists`` as installed.
+
+    ``--without-pip`` keeps it to roughly a quarter of a second; the metadata is
+    written by hand because what the probe reads is ``.dist-info``, not an
+    actual package. Nothing is downloaded and nothing is imported.
+    """
+    subprocess.run(
+        [sys.executable, "-m", "venv", "--without-pip", str(root)],
+        check=True,
+        capture_output=True,
+    )
+    site = next(root.glob("lib/python*/site-packages"), None) or (root / "Lib/site-packages")
+    site.mkdir(parents=True, exist_ok=True)
+    for dist in dists:
+        info = site / f"{dist.replace('-', '_')}-1.0.dist-info"
+        info.mkdir(exist_ok=True)
+        (info / "METADATA").write_text(
+            f"Metadata-Version: 2.1\nName: {dist}\nVersion: 1.0\n", encoding="utf-8"
+        )
+    exe = next((p for p in (root / "bin/python3", root / "Scripts/python.exe") if p.exists()), None)
+    assert exe is not None, "venv produced no interpreter"
+    return str(exe)
+
+
+def _pyproject(directory: Path, name: str, deps: list[str]) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    rendered = ", ".join(f'"{d}"' for d in deps)
+    (directory / "pyproject.toml").write_text(
+        textwrap.dedent(f"""
+            [project]
+            name = "{name}"
+            version = "0.1.0"
+            dependencies = [{rendered}]
+            """).strip(),
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    interpreter.reset_cache()
+    yield
+    interpreter.reset_cache()
+
+
+@pytest.fixture
+def monorepo(tmp_path: Path) -> Path:
+    """A two-package monorepo, shaped like the repo that exposed this."""
+    repo = tmp_path / "repo"
+    _pyproject(repo, "demo-root", ["demo-core", "requests"])
+    _pyproject(repo / "libs" / "core", "demo-core", ["pydantic"])
+    return repo
+
+
+# =========================================================================
+# Requirement parsing
+# =========================================================================
+
+
+@pytest.mark.parametrize(
+    ("spec", "expected"),
+    [
+        ("langchain-core", "langchain-core"),
+        ("langchain_core>=0.3.0,<0.4", "langchain-core"),
+        ("Foo.Bar_baz==1.0", "foo-bar-baz"),
+        ("pydantic[email]>=2", "pydantic"),
+        ('httpx ; python_version < "3.12"', "httpx"),
+        ("requests @ https://example.invalid/requests.whl", "requests"),
+        ("  tenacity  ", "tenacity"),
+        # Not names: flags, comments, paths, URLs, the marker variable itself.
+        ("-r other.txt", None),
+        ("-e ./libs/core", None),
+        ("# a comment", None),
+        ("./local/pkg", None),
+        ("python", None),
+        ("", None),
+    ],
+)
+def test_requirement_names_survive_the_shapes_a_manifest_actually_carries(
+    spec: str, expected: str | None
+) -> None:
+    assert _requirement_name(spec) == expected
+
+
+def test_normalisation_collapses_the_pep503_separators() -> None:
+    assert normalize_dist("Foo_Bar.Baz") == normalize_dist("foo-bar-baz") == "foo-bar-baz"
+
+
+def test_a_monorepo_declares_its_own_packages_separately_from_its_dependencies(
+    monorepo: Path,
+) -> None:
+    reqs = declared_requirements(monorepo)
+    assert set(reqs.own) == {"demo-root", "demo-core"}
+    # `demo-core` is declared as a dependency of the root too. It belongs to the
+    # repo, so it is counted once — on the side that discriminates.
+    assert "demo-core" not in reqs.third_party
+    assert set(reqs.third_party) == {"requests", "pydantic"}
+
+
+def test_manifests_inside_a_venv_are_not_read_as_the_repos_own(monorepo: Path) -> None:
+    """A venv's site-packages is full of other projects' manifests.
+
+    Reading them would measure every candidate against some vendored library's
+    dependency list — and, worse, would add that library's name to the repo's
+    "own" set, which is the number the whole ranking turns on.
+    """
+    vendored = monorepo / ".venv-target" / "lib" / "python3.12" / "site-packages" / "alien"
+    _pyproject(vendored, "alien-package", ["numpy"])
+    (monorepo / ".venv-target" / "pyvenv.cfg").parent.mkdir(parents=True, exist_ok=True)
+    (monorepo / ".venv-target" / "pyvenv.cfg").write_text("version_info = 3.12\n", encoding="utf-8")
+
+    reqs = declared_requirements(monorepo)
+    assert "alien-package" not in reqs.own
+    assert "numpy" not in reqs.third_party
+
+
+# =========================================================================
+# Candidate discovery
+# =========================================================================
+
+
+def test_a_venv_is_found_by_its_marker_not_by_its_name(tmp_path: Path, monkeypatch) -> None:
+    """The venv that exposed this bug was called ``.venv-target``.
+
+    Any list of blessed directory names — ``.venv``, ``venv``, ``env`` — misses
+    it. ``pyvenv.cfg`` is written by the interpreter itself, so it is the marker
+    that cannot be renamed out of existence.
+    """
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    repo = tmp_path / "repo"
+    _pyproject(repo, "demo", [])
+    exe = _make_venv(repo / "kitchen-sink", [])
+
+    origins = {c.python: c.origin for c in discover_candidates(repo)}
+    assert exe in origins
+    assert origins[exe] == "in-repo venv"
+
+
+def test_the_fallback_is_always_present_and_always_last(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _pyproject(repo, "demo", [])
+    candidates = discover_candidates(repo)
+    assert candidates[-1].python == sys.executable
+    assert candidates[-1].origin == "vinv's own interpreter"
+
+
+def test_an_active_virtualenv_outside_the_repo_is_ignored(tmp_path: Path, monkeypatch) -> None:
+    """Vinv's own venv is active on every CLI invocation.
+
+    Treating ``VIRTUAL_ENV`` as a signal would nominate the interpreter this
+    module exists to move off, and would do it with a confident-looking origin.
+    """
+    repo = tmp_path / "repo"
+    _pyproject(repo, "demo", [])
+    outside = tmp_path / "elsewhere"
+    outside_exe = _make_venv(outside, [])
+    monkeypatch.setenv("VIRTUAL_ENV", str(outside))
+
+    assert all(c.origin != "VIRTUAL_ENV" for c in discover_candidates(repo))
+    assert outside_exe not in {c.python for c in discover_candidates(repo)}
+
+
+def test_an_active_virtualenv_inside_the_repo_is_offered(tmp_path: Path, monkeypatch) -> None:
+    repo = tmp_path / "repo"
+    _pyproject(repo, "demo", [])
+    _make_venv(repo / ".venv", [])
+    monkeypatch.setenv("VIRTUAL_ENV", str(repo / ".venv"))
+
+    assert any(c.origin == "VIRTUAL_ENV" for c in discover_candidates(repo))
+
+
+def test_the_explicit_flag_leads_the_list(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _pyproject(repo, "demo", [])
+    candidates = discover_candidates(repo, explicit="/opt/somewhere/bin/python")
+    assert candidates[0].origin == "--python"
+    assert candidates[0].python == "/opt/somewhere/bin/python"
+
+
+def test_one_venv_named_twice_is_one_candidate(tmp_path: Path, monkeypatch) -> None:
+    """The same environment reached by three routes must be probed once."""
+    repo = tmp_path / "repo"
+    _pyproject(repo, "demo", [])
+    exe = _make_venv(repo / ".venv", [])
+    monkeypatch.setenv("VINV_TARGET_PYTHON", exe)
+    monkeypatch.setenv("VIRTUAL_ENV", str(repo / ".venv"))
+
+    keys = [c.key() for c in discover_candidates(repo)]
+    assert len(keys) == len(set(keys))
+    # The venv, and Vinv's own interpreter. Nothing counted twice.
+    assert len(keys) == 2
+
+
+def test_two_venvs_built_from_one_base_python_are_not_one_candidate(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The dedup trap that made every fixture in this file pass wrongly.
+
+    A venv's ``bin/python3`` is a SYMLINK to the base interpreter, so keying
+    candidates on ``os.path.realpath`` collapses every venv created from the
+    same Python into a single entry. The target's venv and Vinv's own venv then
+    look like one candidate — with entirely different ``site-packages`` — and
+    whichever was discovered first silently won.
+    """
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    a = _make_venv(tmp_path / "a", [])
+    b = _make_venv(tmp_path / "b", [])
+
+    assert Path(a).resolve() == Path(b).resolve(), "fixture assumes a shared base interpreter"
+    assert Candidate(a, "test").key() != Candidate(b, "test").key()
+
+
+def test_the_two_names_for_one_venvs_interpreter_collapse(tmp_path: Path) -> None:
+    root = tmp_path / "env"
+    _make_venv(root, [])
+    assert Candidate(str(root / "bin" / "python"), "x").key() == (
+        Candidate(str(root / "bin" / "python3"), "x").key()
+    )
+
+
+def test_a_tool_environment_is_not_queried_for_a_repo_that_only_has_a_pyproject(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """``pyproject.toml`` alone is not evidence that a repo uses poetry.
+
+    Nearly every Python repo has one, and ``poetry env info --path`` reports the
+    ACTIVATED virtualenv — which is always Vinv's own while the CLI runs. Gating
+    on the bare manifest re-nominated exactly the interpreter this module exists
+    to move off, labelled "poetry environment" so it read as corroboration.
+    """
+    repo = tmp_path / "repo"
+    _pyproject(repo, "demo", [])
+    outside = tmp_path / "elsewhere"
+    outside_exe = _make_venv(outside, [])
+    monkeypatch.setenv("VIRTUAL_ENV", str(outside))
+
+    assert outside_exe not in {c.python for c in discover_candidates(repo)}
+
+
+# =========================================================================
+# The probe
+# =========================================================================
+
+
+def test_the_probe_reports_what_is_installed_and_what_is_not(tmp_path: Path) -> None:
+    exe = _make_venv(tmp_path / "env", ["demo-core", "requests"])
+    reqs = Requirements(own=("demo-core",), third_party=("requests", "absent-thing"))
+
+    probe = probe_candidate(Candidate(exe, "test"), reqs)
+
+    assert probe.ok
+    assert probe.own_present == ("demo-core",)
+    assert probe.third_present == ("requests",)
+    assert "absent-thing" in probe.missing
+    assert probe.score == (1, 1)
+
+
+def test_the_probe_normalises_names_the_way_packaging_does(tmp_path: Path) -> None:
+    """``Demo_Core`` in METADATA and ``demo-core`` in a manifest are one name."""
+    exe = _make_venv(tmp_path / "env", ["Demo_Core"])
+    probe = probe_candidate(Candidate(exe, "test"), Requirements(own=("demo-core",)))
+    assert probe.own_present == ("demo-core",)
+
+
+def test_a_candidate_that_cannot_be_executed_is_an_answer_not_a_crash(tmp_path: Path) -> None:
+    probe = probe_candidate(Candidate(str(tmp_path / "nope"), "test"), Requirements(own=("x",)))
+    assert not probe.ok
+    assert probe.error
+    assert probe.score == (0, 0)
+
+
+def test_the_probe_does_not_import_the_target(tmp_path: Path) -> None:
+    """Measuring a candidate must not execute the repo.
+
+    ``importlib.metadata`` reads ``.dist-info`` off the filesystem, so a package
+    whose import would raise, hang, or write to disk is still counted correctly.
+    """
+    exe = _make_venv(tmp_path / "env", ["demo-core"])
+    site = next((tmp_path / "env").glob("lib/python*/site-packages"))
+    (site / "demo_core.py").write_text("raise SystemExit('imported!')\n", encoding="utf-8")
+
+    probe = probe_candidate(Candidate(exe, "test"), Requirements(own=("demo-core",)))
+    assert probe.ok
+    assert probe.own_present == ("demo-core",)
+
+
+def test_the_probe_is_isolated_from_a_shadowing_module_in_the_repo(tmp_path: Path) -> None:
+    """A repo with its own ``json.py`` must not break the probe's own imports."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "json.py").write_text("raise RuntimeError('shadowed')\n", encoding="utf-8")
+    exe = _make_venv(tmp_path / "env", ["demo-core"])
+
+    probe = probe_candidate(Candidate(exe, "test"), Requirements(own=("demo-core",)), cwd=repo)
+    assert probe.ok
+    assert probe.own_present == ("demo-core",)
+
+
+# =========================================================================
+# The choice
+# =========================================================================
+
+
+def test_the_interpreter_with_the_repo_installed_wins(monorepo: Path, monkeypatch) -> None:
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    target = _make_venv(monorepo / ".venv-target", ["demo-root", "demo-core"])
+
+    choice = resolve_interpreter(monorepo)
+
+    assert choice.python == target
+    assert choice.handed_off
+    assert choice.target_installed
+    assert choice.own_present == 2
+
+
+def test_shared_third_party_libraries_do_not_outvote_the_repos_own_packages(
+    monorepo: Path, monkeypatch
+) -> None:
+    """The real failure mode, in miniature.
+
+    On langchain the two candidates scored 20 and 15 on a flat dependency count
+    — Vinv's own venv genuinely has requests, pydantic and a dozen others — and
+    4 against 0 on the repo's own distributions. A flat count is one common
+    dependency away from picking the wrong interpreter; this pins the ordering
+    that is not.
+    """
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    # Has the repo, and none of its third-party dependencies.
+    target = _make_venv(monorepo / ".venv-target", ["demo-root", "demo-core"])
+    # Has every third-party dependency, and nothing of the repo.
+    _make_venv(monorepo / ".venv-decoy", ["requests", "pydantic"])
+
+    choice = resolve_interpreter(monorepo)
+
+    assert choice.python == target
+    assert choice.own_present == 2
+    assert choice.third_present == 0
+
+
+def test_a_tie_keeps_vinvs_own_interpreter(tmp_path: Path, monkeypatch) -> None:
+    """The handoff is paid for by evidence or it does not happen.
+
+    A repo that declares nothing, or one already installed into Vinv's venv,
+    must behave exactly as it did before this module existed — otherwise every
+    existing test in this suite is running somewhere new.
+    """
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    repo = tmp_path / "repo"
+    _pyproject(repo, "demo", [])
+    _make_venv(repo / ".venv", [])
+
+    choice = resolve_interpreter(repo)
+
+    assert choice.python == sys.executable
+    assert not choice.handed_off
+    assert choice.diagnostics == []
+
+
+def test_a_repo_that_declares_nothing_changes_nothing(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    choice = resolve_interpreter(repo)
+    assert choice.python == sys.executable
+    assert not choice.handed_off
+
+
+def test_every_candidate_considered_is_reported(monorepo: Path, monkeypatch) -> None:
+    """A wrong choice must be debuggable from the run summary alone."""
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    _make_venv(monorepo / ".venv-target", ["demo-root", "demo-core"])
+
+    doc = resolve_interpreter(monorepo).to_json()
+
+    assert len(doc["considered"]) >= 2
+    origins = {c["origin"] for c in doc["considered"]}
+    assert {"in-repo venv", "vinv's own interpreter"} <= origins
+    for entry in doc["considered"]:
+        assert entry["repo_distributions_present"].endswith("/2")
+
+
+def test_the_handoff_is_announced(monorepo: Path, monkeypatch) -> None:
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    _make_venv(monorepo / ".venv-target", ["demo-root", "demo-core"])
+
+    choice = resolve_interpreter(monorepo)
+
+    assert choice.diagnostics
+    assert "workers will run under" in choice.diagnostics[0]
+    assert "--python" in choice.diagnostics[0]
+
+
+# =========================================================================
+# The explicit flag is not second-guessed
+# =========================================================================
+
+
+def test_an_explicit_python_is_used_even_when_a_better_one_exists(
+    monorepo: Path, tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    _make_venv(monorepo / ".venv-target", ["demo-root", "demo-core"])
+    barren = _make_venv(tmp_path / "barren", [])
+
+    choice = resolve_interpreter(monorepo, explicit=barren)
+
+    assert choice.python == barren
+    assert choice.origin == "--python"
+
+
+def test_an_explicit_python_without_the_target_is_called_out(
+    monorepo: Path, tmp_path: Path
+) -> None:
+    """Pointing the flag at the wrong venv used to produce the same silent zero."""
+    barren = _make_venv(tmp_path / "barren", [])
+
+    choice = resolve_interpreter(monorepo, explicit=barren)
+
+    assert choice.diagnostics
+    assert "NONE of the" in choice.diagnostics[0]
+    assert not choice.target_installed
+
+
+def test_an_unprobeable_explicit_python_is_still_honoured(monorepo: Path, tmp_path: Path) -> None:
+    missing = str(tmp_path / "not-a-python")
+    choice = resolve_interpreter(monorepo, explicit=missing)
+    assert choice.python == missing
+    assert any("could not be probed" in d for d in choice.diagnostics)
+
+
+def test_the_explicit_flag_short_circuits_the_fan_out(monorepo: Path, tmp_path: Path) -> None:
+    """Probing candidates that cannot win is pure cost."""
+    _make_venv(monorepo / ".venv-target", ["demo-root"])
+    barren = _make_venv(tmp_path / "barren", [])
+
+    choice = resolve_interpreter(monorepo, explicit=barren)
+
+    assert len(choice.considered) == 1
+
+
+# =========================================================================
+# The worker's own floor
+# =========================================================================
+
+
+def test_an_interpreter_below_the_worker_floor_is_not_runnable() -> None:
+    old = Probe(ok=True, version=(3, 9, 18), own_present=("demo-core",))
+    assert not old.runnable
+    assert Probe(ok=True, version=MIN_WORKER_PYTHON, own_present=()).runnable
+
+
+def test_a_too_old_venv_is_reported_rather_than_silently_skipped(
+    monorepo: Path, monkeypatch
+) -> None:
+    """ "The repo's venv is older than our worker" is a fact the human needs.
+
+    Handing an exerciser worker to a 3.9 interpreter reports OUR SyntaxError as
+    the repo's defect; staying on the fallback without saying why looks like a
+    clean run under a well-chosen interpreter. Neither is acceptable.
+    """
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    exe = _make_venv(monorepo / ".venv-old", ["demo-root", "demo-core"])
+    real = interpreter.probe_candidate
+
+    def _aged(candidate, reqs, **kwargs):
+        probe = real(candidate, reqs, **kwargs)
+        if candidate.python == exe:
+            probe.version = (3, 9, 18)
+        return probe
+
+    monkeypatch.setattr(interpreter, "probe_candidate", _aged)
+
+    choice = resolve_interpreter(monorepo)
+
+    assert choice.python == sys.executable
+    assert not choice.handed_off
+    assert any("below exerciser's" in d and "3.9.18" in d for d in choice.diagnostics)
+
+
+# =========================================================================
+# Caching
+# =========================================================================
+
+
+def test_the_choice_is_memoised_per_repo_and_flag(monorepo: Path, monkeypatch) -> None:
+    """The campaign resolves the same answer for five oracles in one run."""
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    _make_venv(monorepo / ".venv-target", ["demo-root", "demo-core"])
+    calls = 0
+    real = interpreter.probe_candidate
+
+    def _counted(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(interpreter, "probe_candidate", _counted)
+
+    first = interpreter.resolve_cached(monorepo)
+    after_first = calls
+    second = interpreter.resolve_cached(monorepo)
+
+    assert first.python == second.python
+    assert calls == after_first, "a second resolve re-probed every candidate"
+
+
+# =========================================================================
+# End to end, against this repo
+# =========================================================================
+
+
+def test_exerciser_itself_resolves_to_the_interpreter_running_these_tests() -> None:
+    """The suite's own repo IS installed into the interpreter running it.
+
+    So the correct answer is "change nothing" — and this is the guard that the
+    default path of every other test in the suite has not moved.
+    """
+    repo = Path(__file__).resolve().parents[1]
+    choice = resolve_interpreter(repo)
+    assert choice.python == sys.executable
+    assert not choice.handed_off
+
+
+def test_the_report_is_json_serialisable(monorepo: Path) -> None:
+    """It lands in the run summary, which is written to disk and printed."""
+    _make_venv(monorepo / ".venv-target", ["demo-root"])
+    json.dumps(resolve_interpreter(monorepo).to_json())

--- a/exerciser/tests/test_redact.py
+++ b/exerciser/tests/test_redact.py
@@ -221,3 +221,85 @@ class TestLedgerHarvest:
         # The non-secret scalars are still harvested — teardown depends on them.
         assert "user@example.com" in harvested
         assert "bearer" in harvested
+
+
+# =========================================================================
+# SEC-3: a credential rendered INSIDE an exception message
+# =========================================================================
+
+
+class TestSecretsInsideFreeText:
+    """``redact`` decides by field name, which cannot reach inside one string.
+
+    Found in a real run against demo-fastapi once the workers started using the
+    target's own interpreter: every module failed to import because required
+    settings were unset, and pydantic renders the whole input dict into the
+    validation message — API key included. That message was persisted to
+    ``.vinv/exercise/functions.json`` and printed to stdout.
+    """
+
+    def test_a_credential_in_a_rendered_dict_is_removed(self) -> None:
+        from exerciser.redact import redact_text
+
+        # Wholly fabricated. A fixture for a redaction test is the LAST place a
+        # real credential should be pasted from a run's output, however dead the
+        # key is believed to be — the test file is the artifact that gets pushed.
+        message = (
+            "5 validation errors for Settings\nPROJECT_NAME\n  Field required "
+            "[type=missing, input_value={'openai_api_key': 'sk-proj-EXAMPLE-NOT-A-REAL-KEY', "
+            "'project': 'demo'}, input_type=dict]"
+        )
+        cleaned = redact_text(message)
+        assert "sk-proj-EXAMPLE-NOT-A-REAL-KEY" not in cleaned
+        # The surrounding diagnostic is what makes the message useful.
+        assert "PROJECT_NAME" in cleaned
+        assert "'project': 'demo'" in cleaned
+
+    def test_a_non_secret_key_does_not_swallow_the_secret_after_it(self) -> None:
+        """The bug the first version of the pattern had.
+
+        ``input_value={'openai_api_key': …}`` matched as the pair
+        ``input_value`` → ``{'openai_api_key':`` — an innocent key whose "value"
+        consumed the real credential, so it was never examined.
+        """
+        from exerciser.redact import redact_text
+
+        cleaned = redact_text("input_value={'api_key': 'AKIAsecretsecret'}")
+        assert "AKIAsecretsecret" not in cleaned
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "POSTGRES_PASSWORD=s3cr3tvalue",
+            '{"Authorization": "Bearer abc.def"}',
+            "client_secret: 'shhh'",
+            "X-Api-Key = 'abcdef123456'",
+        ],
+    )
+    def test_the_credential_spellings_a_message_actually_carries(self, text: str) -> None:
+        from exerciser.redact import redact_text
+
+        cleaned = redact_text(text)
+        assert PLACEHOLDER in cleaned
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "token_type: bearer",
+            "count: 5",
+            "PROJECT_NAME=demo",
+            "no credentials in this sentence",
+            "",
+        ],
+    )
+    def test_ordinary_text_is_left_alone(self, text: str) -> None:
+        """Over-redaction is an oracle bug, exactly as it is for ``redact``."""
+        from exerciser.redact import redact_text
+
+        assert redact_text(text) == text
+
+    def test_the_separator_and_quoting_survive(self) -> None:
+        from exerciser.redact import redact_text
+
+        assert redact_text("PASSWORD=x") == f"PASSWORD={PLACEHOLDER}"
+        assert redact_text("'password': 'x'") == f"'password': '{PLACEHOLDER}'"

--- a/exerciser/tests/test_redact.py
+++ b/exerciser/tests/test_redact.py
@@ -303,3 +303,65 @@ class TestSecretsInsideFreeText:
 
         assert redact_text("PASSWORD=x") == f"PASSWORD={PLACEHOLDER}"
         assert redact_text("'password': 'x'") == f"'password': '{PLACEHOLDER}'"
+
+
+# =========================================================================
+# SEC-4: a credential carried in a URL the engine writes down
+# =========================================================================
+
+
+class TestSecretsInsideUrls:
+    """`is_id_shaped` already refuses to SPLICE a credential into a URL.
+
+    The same credential arrives the other way round once the HTTP double records
+    the request line it answered: plenty of providers authenticate by query
+    parameter rather than by header (`?key=` is Gemini's spelling), and the
+    target builds that URL from the real key `declared_env` loaded out of the
+    repo's own `.env`. The ledger is a file inside the user's repository.
+    """
+
+    def test_a_key_in_a_query_parameter_is_removed(self) -> None:
+        from exerciser.redact import redact_url
+
+        cleaned = redact_url(
+            "https://generativelanguage.googleapis.com/v1beta/models/x:go?key=AIzaSyREAL&alt=sse"
+        )
+        assert "AIzaSyREAL" not in cleaned
+        # What the request WAS is the whole point of recording it.
+        assert "generativelanguage.googleapis.com" in cleaned
+        assert "alt=sse" in cleaned
+        assert "key=" in cleaned
+
+    def test_a_password_in_the_authority_is_removed(self) -> None:
+        from exerciser.redact import redact_url
+
+        cleaned = redact_url("postgresql://admin:hunter2@db.internal:5432/app")
+        assert "hunter2" not in cleaned
+        assert "admin" in cleaned and "db.internal:5432/app" in cleaned
+
+    def test_a_jwt_under_any_parameter_name_is_removed(self) -> None:
+        from exerciser.redact import redact_url
+
+        jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.sig"
+        assert jwt not in redact_url(f"https://api.example.com/v1/x?t={jwt}")
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://api.openai.com/v1/chat/completions",
+            "https://example.com/items?page=2&sort=name",
+            "https://example.com/a/b#frag",
+            "",
+        ],
+    )
+    def test_an_ordinary_url_is_untouched(self, url: str) -> None:
+        from exerciser.redact import redact_url
+
+        assert redact_url(url) == url
+
+    def test_the_fragment_survives(self) -> None:
+        from exerciser.redact import redact_url
+
+        cleaned = redact_url("https://h/p?api_key=SECRET#section")
+        assert "SECRET" not in cleaned
+        assert cleaned.endswith("#section")

--- a/extension/package.json
+++ b/extension/package.json
@@ -587,7 +587,8 @@
 		"pretest": "npm run compile && npm run lint",
 		"lint": "eslint src",
 		"test": "vscode-test",
-		"test:packaged": "npm run bundle && node scripts/test-packaged.mjs"
+		"test:packaged": "npm run bundle && node scripts/test-packaged.mjs",
+		"test:e2e": "node scripts/e2e-vsix-run.mjs"
 	},
 	"devDependencies": {
 		"@types/mocha": "^10.0.10",

--- a/extension/scripts/e2e-vsix-run.mjs
+++ b/extension/scripts/e2e-vsix-run.mjs
@@ -1,0 +1,238 @@
+/**
+ * The acceptance test: package the VSIX, install it into a real VS Code, open a
+ * real project, run the pipeline, and check what landed on disk.
+ *
+ * Everything else in this repo tests a seam. `npm test` loads the extension from
+ * SOURCE into a VS Code instance; `test:packaged` proves the VSIX installs and
+ * its MCP server answers. Neither runs the product: neither packages the code a
+ * user installs, points it at a project, presses the button, and looks at the
+ * result. So the failures that only exist in the assembled whole — an engine the
+ * extension cannot find, a command that never activates, a stage that stops
+ * before the one that matters — had nowhere to show up.
+ *
+ * What this does, in order:
+ *
+ *   1. `vsce package`                  the artifact a user actually installs
+ *   2. `--install-extension`           into a clean profile, no dev path
+ *   3. build a fixture project         real Python, pre-seeded discovery state
+ *   4. launch VS Code on it            the installed extension, no source
+ *   5. run `vinv-vs.autoPilot`         the product's own entry point
+ *   6. assert `.vinv/exercise/*`       written by the REAL engine
+ *
+ * The engine is real: `vinv.enginesPath` points at this checkout, so the
+ * extension resolves `<repo>/.venv/bin/exerciser` exactly as it would resolve a
+ * user's. Nothing here is stubbed except the discovery state, which is seeded so
+ * the run is deterministic and does not depend on the index engine having been
+ * built — that is a different engine's acceptance test, not this one's.
+ *
+ * Run with `npm run test:e2e`. Skips with a clear message, rather than failing,
+ * when the engines venv is absent — a machine that has not run `uv sync` cannot
+ * run the product either, and a red test would be reporting the wrong thing.
+ */
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { runTests, runVSCodeCommand } from '@vscode/test-electron';
+
+const extensionRoot = path.resolve(import.meta.dirname, '..');
+const repoRoot = path.resolve(extensionRoot, '..');
+const temporary = fs.mkdtempSync(path.join(os.tmpdir(), 'vinv-e2e-vsix-'));
+
+// `vscode:prepublish` STAMPS the engine ref into a tracked source file. Correct
+// for a release build and unacceptable as a test's residue: running the suite
+// must not leave the checkout dirty, or the next `git status` blames the test.
+const pinnedFile = path.join(extensionRoot, 'src', 'engines', 'pinned.ts');
+const pinnedBefore = fs.readFileSync(pinnedFile, 'utf8');
+
+const vsix = path.join(temporary, 'vinv.vsix');
+const profile = path.join(temporary, 'profile');
+const extensions = path.join(temporary, 'extensions');
+const workspace = path.join(temporary, 'project');
+
+/** The engine console scripts the extension resolves, per platform. */
+function enginesVenvBin(name) {
+	return process.platform === 'win32'
+		? path.join(repoRoot, '.venv', 'Scripts', `${name}.exe`)
+		: path.join(repoRoot, '.venv', 'bin', name);
+}
+
+async function main() {
+	if (!fs.existsSync(enginesVenvBin('exerciser'))) {
+		process.stdout.write(
+			'SKIP: no engines venv at <repo>/.venv — run `uv sync` at the repo root first.\n',
+		);
+		return;
+	}
+
+	buildFixtureProject(workspace);
+
+	// 1 + 2: the artifact a user installs, into a profile that has nothing else.
+	run(path.join(extensionRoot, 'node_modules', '.bin', 'vsce'), [
+		'package',
+		'--no-rewrite-relative-links',
+		'--out',
+		vsix,
+	]);
+	await runVSCodeCommand([
+		'--install-extension',
+		vsix,
+		'--force',
+		'--user-data-dir',
+		profile,
+		'--extensions-dir',
+		extensions,
+	]);
+	// AFTER packaging, deliberately. `vscode:prepublish` runs the bundler, and
+	// the bundler starts from a clean `out/` — so anything compiled before this
+	// point is deleted by the very step that builds the VSIX. Compiling the
+	// in-editor half here is the only ordering that survives it.
+	run(path.join(extensionRoot, 'node_modules', '.bin', 'tsc'), ['-p', '.']);
+	assert.ok(
+		fs.existsSync(path.resolve(extensionRoot, 'out', 'e2e', 'index.js')),
+		'the in-editor half did not compile',
+	);
+
+	const installed = fs
+		.readdirSync(extensions, { withFileTypes: true })
+		.filter((e) => e.isDirectory() && e.name.toLowerCase().startsWith('vinvai.vinvai-'));
+	assert.equal(installed.length, 1, 'the VSIX did not install into the clean profile');
+	process.stdout.write(`installed ${installed[0].name}\n`);
+
+	// 3 + 4 + 5: drive the INSTALLED extension against the fixture. No
+	// `--extensionDevelopmentPath`: the code under test is the packaged code.
+	const code = await runTests({
+		extensionTestsPath: path.resolve(extensionRoot, 'out', 'e2e', 'index.js'),
+		// Points at the installed VSIX rather than this checkout's source.
+		extensionTestsEnv: {
+			VINV_E2E_WORKSPACE: workspace,
+			VINV_E2E_ENGINES: repoRoot,
+		},
+		launchArgs: [
+			workspace,
+			'--user-data-dir',
+			profile,
+			'--extensions-dir',
+			extensions,
+			'--disable-workspace-trust',
+			'--skip-welcome',
+			'--skip-release-notes',
+		],
+	});
+	assert.equal(code, 0, 'the in-editor acceptance run failed');
+	process.stdout.write('packaged VSIX end-to-end run passed\n');
+}
+
+/**
+ * A real Python project, plus the discovery state the pipeline gates on.
+ *
+ * `isProjectDiscovered` wants an index (`meta.json` + `vectors.f32`), a handbook
+ * and a services list. Those are three other engines' output; seeding them keeps
+ * this test about the exercise path rather than about whether the Rust indexer
+ * was built on this machine. `chunks.jsonl` is real, because the exerciser reads
+ * it to find targets, and the whole point is that the engine does real work.
+ */
+function buildFixtureProject(root) {
+	const pkg = path.join(root, 'src', 'acceptance_demo');
+	fs.mkdirSync(pkg, { recursive: true });
+	fs.writeFileSync(path.join(pkg, '__init__.py'), '', 'utf8');
+
+	const module = [
+		'"""A library: nothing to serve, which is the case this pipeline added."""',
+		'',
+		'',
+		'def add(a: int, b: int) -> int:',
+		'    return a + b',
+		'',
+		'',
+		'def divide(a: int, b: int) -> float:',
+		'    """The boundary input class includes 0, so this is a real defect."""',
+		'    return a / b',
+		'',
+	].join('\n');
+	fs.writeFileSync(path.join(pkg, 'calc.py'), module, 'utf8');
+	fs.writeFileSync(
+		path.join(root, 'pyproject.toml'),
+		'[project]\nname = "acceptance-demo"\nversion = "0.1.0"\n',
+		'utf8',
+	);
+
+	const vinv = path.join(root, '.vinv');
+	fs.mkdirSync(path.join(vinv, 'index'), { recursive: true });
+	const chunks = ['add', 'divide'].map((name, i) =>
+		JSON.stringify({
+			id: `src/acceptance_demo/calc.py:${name}`,
+			file: 'src/acceptance_demo/calc.py',
+			lang: 'python',
+			kind: 'function',
+			name,
+			start_line: 4 + i * 5,
+			end_line: 6 + i * 5,
+			parent: null,
+		}),
+	);
+	fs.writeFileSync(path.join(vinv, 'index', 'chunks.jsonl'), `${chunks.join('\n')}\n`, 'utf8');
+	// Enough for `isProjectIndexed`; the exerciser never reads these two.
+	fs.writeFileSync(
+		path.join(vinv, 'index', 'meta.json'),
+		JSON.stringify({ version: 5, chunks: chunks.length }),
+		'utf8',
+	);
+	fs.writeFileSync(path.join(vinv, 'index', 'vectors.f32'), Buffer.alloc(4));
+	fs.writeFileSync(path.join(vinv, 'vinv.md'), '# acceptance-demo\n\nA library.\n', 'utf8');
+	// A library: no service, which is exactly the workspace that used to do
+	// nothing at all after discovery.
+	fs.writeFileSync(
+		path.join(vinv, 'services.json'),
+		JSON.stringify({ services: [] }, null, 2),
+		'utf8',
+	);
+
+	fs.mkdirSync(path.join(root, '.vscode'), { recursive: true });
+	fs.writeFileSync(
+		path.join(root, '.vscode', 'settings.json'),
+		JSON.stringify(
+			{
+				// The REAL engines, resolved the way a user's are.
+				'vinv.enginesPath': repoRoot,
+				// No coding-harness dispatch: this asserts the pipeline reaches the
+				// findings, not that an agent is signed in.
+				'vinv.autoEpisodes': false,
+			},
+			null,
+			2,
+		),
+		'utf8',
+	);
+}
+
+function run(command, args) {
+	const result = spawnSync(command, args, {
+		cwd: extensionRoot,
+		encoding: 'utf8',
+		shell: process.platform === 'win32',
+		env: {
+			...process.env,
+			// `vscode:prepublish` refuses to stamp an engine ref that is not
+			// reachable from origin/main, because a published VSIX pinned to an
+			// unmerged commit cannot fetch its engines. Correct for a release and
+			// wrong for this: the VSIX built here is installed into a throwaway
+			// profile, asserted on, and deleted. The guard's own documented escape.
+			VINV_ENGINE_ALLOW_UNREACHABLE: '1',
+		},
+	});
+	if (result.status !== 0) {
+		throw new Error(`${command} failed:\n${result.stdout}\n${result.stderr}`);
+	}
+}
+
+try {
+	await main();
+} finally {
+	// Restored unconditionally: a failed run must not dirty the tree either.
+	if (fs.readFileSync(pinnedFile, 'utf8') !== pinnedBefore) {
+		fs.writeFileSync(pinnedFile, pinnedBefore, 'utf8');
+	}
+	fs.rmSync(temporary, { recursive: true, force: true });
+}

--- a/extension/src/e2e/index.ts
+++ b/extension/src/e2e/index.ts
@@ -1,0 +1,170 @@
+/**
+ * The in-editor half of the packaged acceptance run.
+ *
+ * VS Code loads this file in the extension host via `--extensionTestsPath`. The
+ * extension under test is the one INSTALLED FROM THE VSIX in the profile the
+ * driver prepared — there is no `--extensionDevelopmentPath`, so nothing here
+ * can accidentally exercise the source tree.
+ *
+ * Deliberately not mocha: this is one scenario with a long wall clock (the real
+ * engine spawns real workers), and a runner's default timeouts and reporters buy
+ * nothing at a single test. `run()` resolving is the pass.
+ */
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+const EXTENSION_ID = 'VinvAI.VinvAI';
+
+/** How long the real pipeline gets. Engine workers are real subprocesses. */
+const PIPELINE_DEADLINE_MS = 10 * 60 * 1000;
+
+export async function run(): Promise<void> {
+	const workspace = process.env.VINV_E2E_WORKSPACE;
+	assert.ok(workspace, 'VINV_E2E_WORKSPACE was not passed to the editor');
+
+	await assertTheInstalledExtensionActivates();
+	await assertThePipelineRunsTheRealEngine(workspace);
+	log('acceptance run passed');
+}
+
+/**
+ * The packaged extension is present, is the one from the VSIX, and activates.
+ *
+ * A VSIX that installs but never activates is the failure `test:packaged` cannot
+ * see: it inspects the archive's contents and never boots an editor on it.
+ */
+async function assertTheInstalledExtensionActivates(): Promise<void> {
+	const extension = vscode.extensions.getExtension(EXTENSION_ID);
+	assert.ok(extension, `${EXTENSION_ID} is not installed in this profile`);
+	assert.ok(
+		!extension.extensionPath.includes(path.join('extension', 'src')),
+		`the SOURCE tree activated, not the VSIX: ${extension.extensionPath}`,
+	);
+
+	await extension.activate();
+	assert.ok(extension.isActive, 'the extension did not activate');
+
+	// The product's entry point has to be reachable by the id the UI uses; a
+	// command that fails to register is invisible to everything except a user.
+	const commands = await vscode.commands.getCommands(true);
+	assert.ok(
+		commands.includes('vinv-vs.autoPilot'),
+		'vinv-vs.autoPilot was never registered by the packaged build',
+	);
+	log(`activated ${EXTENSION_ID} from ${extension.extensionPath}`);
+}
+
+/**
+ * Press the button, then look at what the ENGINE left on disk.
+ *
+ * The assertions are about artifacts rather than about UI state on purpose: the
+ * artifacts are the product's output, they are what the next run and the coding
+ * agent read, and they are the only evidence that the extension found the
+ * engine, spawned it, and that it did real work on this project.
+ */
+async function assertThePipelineRunsTheRealEngine(workspace: string): Promise<void> {
+	const exerciseDir = path.join(workspace, '.vinv', 'exercise');
+	assert.ok(
+		!fs.existsSync(path.join(exerciseDir, 'functions.json')),
+		'the fixture already had engine output — the run would prove nothing',
+	);
+
+	log('running vinv-vs.autoPilot…');
+	// Started, NOT awaited. Auto-Pilot resolves when every stage settles, and one
+	// of them drains the agent channels through a coding harness that is not
+	// signed in here — so awaiting it would make this test's runtime depend on
+	// something it is not asserting. What is being asserted is that the engine
+	// ran, and the artifacts are the evidence of that, so the artifacts are what
+	// this waits for.
+	const pipeline = Promise.resolve(
+		vscode.commands.executeCommand('vinv-vs.autoPilot'),
+	).catch((err) => log(`auto-pilot reported: ${err instanceof Error ? err.message : String(err)}`));
+	const produced = await waitForAny(
+		exerciseDir,
+		['functions.json', 'campaign_result.json', 'issues.json'],
+		PIPELINE_DEADLINE_MS,
+	);
+	assert.ok(
+		produced.length > 0,
+		`the pipeline produced no engine artifacts in ${exerciseDir} — ` +
+			`present: ${safeList(exerciseDir).join(', ') || '(nothing)'}`,
+	);
+	log(`engine wrote: ${produced.join(', ')}`);
+	// Give the stage a moment to finish writing the rest, but never wait on it.
+	await Promise.race([pipeline, new Promise((resolve) => setTimeout(resolve, 30_000))]);
+
+	// The campaign's own summary, which is the run's verdict rather than one
+	// play's. Its absence means the exercise stage never reached `campaign`.
+	const verdictFile = path.join(exerciseDir, 'campaign_result.json');
+	if (fs.existsSync(verdictFile)) {
+		const verdict = readJson(verdictFile);
+		assert.ok(
+			typeof verdict.status === 'string',
+			'campaign_result.json carries no status for the extension to read',
+		);
+		assert.ok(Array.isArray(verdict.diagnostics), 'campaign_result.json carries no diagnostics');
+		// The interpreter is the single most important input to the result, and a
+		// run that does not record it is not reproducible.
+		assert.ok(verdict.interpreter?.python, 'the run did not record which interpreter it used');
+		log(`verdict: status=${verdict.status} interpreter=${verdict.interpreter.python}`);
+	}
+
+	// Proof the engine did WORK on this project rather than merely starting: the
+	// fixture's two functions are the only targets it could have found.
+	const functionsFile = path.join(exerciseDir, 'functions.json');
+	if (fs.existsSync(functionsFile)) {
+		const doc = readJson(functionsFile);
+		assert.ok(
+			(doc.targets ?? 0) > 0,
+			`the engine ran and discovered nothing: ${JSON.stringify(doc.diagnostics ?? [])}`,
+		);
+		log(`targets=${doc.targets} calls=${doc.calls} clusters=${doc.issue_clusters}`);
+	}
+}
+
+// =========================================================================
+
+function safeList(directory: string): string[] {
+	try {
+		return fs.readdirSync(directory);
+	} catch {
+		return [];
+	}
+}
+
+/** An engine artifact, read for the handful of fields this asserts on. */
+interface EngineArtifact {
+	status?: unknown;
+	diagnostics?: unknown;
+	interpreter?: { python?: string };
+	targets?: number;
+	calls?: number;
+	issue_clusters?: number;
+}
+
+function readJson(file: string): EngineArtifact {
+	return JSON.parse(fs.readFileSync(file, 'utf8')) as EngineArtifact;
+}
+
+/** Poll for whichever of `names` the engine produces, up to `deadlineMs`. */
+async function waitForAny(
+	directory: string,
+	names: string[],
+	deadlineMs: number,
+): Promise<string[]> {
+	const until = Date.now() + deadlineMs;
+	for (;;) {
+		const present = names.filter((n) => fs.existsSync(path.join(directory, n)));
+		if (present.length > 0 || Date.now() > until) {
+			return present;
+		}
+		await new Promise((resolve) => setTimeout(resolve, 1000));
+	}
+}
+
+function log(message: string): void {
+	// Goes to the driver's stdout, which is where a failing CI run is read from.
+	process.stdout.write(`[vinv-e2e] ${message}\n`);
+}

--- a/extension/src/harness/agentChannel.ts
+++ b/extension/src/harness/agentChannel.ts
@@ -1,0 +1,300 @@
+/**
+ * Drain the engine's agent channels — the half of the contract that was missing.
+ *
+ * Several oracles reach a question no amount of structure answers, because the
+ * answer lives in intent rather than syntax: what IS the type contract of this
+ * boundary (`faults`), what does a row of this table plausibly hold
+ * (`services`), what value does this environment variable want (`envconfig`).
+ * `exerciser/agent_loop.py` renders each one into
+ * `.vinv/exercise/agent_<topic>.json` — deduplicated by shape, cached forever,
+ * budgeted — and its module docstring describes the transport as "the
+ * extension (or any agent) dispatches them and writes back a verdict".
+ *
+ * Nothing ever did. A grep of `extension/src` for any `agent_*.json` returns
+ * nothing, so every question those three oracles have ever raised was written
+ * to disk and left there. The engine side has been complete and inert: the
+ * fault oracle asks for a contract it never receives, the fixture questions
+ * seed placeholder rows forever, and configuration escalated to "the harness
+ * will answer" escalated into a void.
+ *
+ * This is that consumer. One dispatcher serves every topic, because the channel
+ * format is already uniform — a topic-specific dispatcher would be three copies
+ * of one loop, which is the mistake `_worker.py` was written to undo.
+ *
+ * Three properties it has to have:
+ *
+ *  - **batched.** Every pending question across every topic goes in ONE harness
+ *    run. A run per question is a bill that grows with the repo, and the whole
+ *    reason the channel deduplicates by shape is to keep that bill flat.
+ *  - **idempotent.** Answered questions are never re-asked; the engine already
+ *    caches them, and re-answering would overwrite a human's correction with a
+ *    model's guess.
+ *  - **honest on failure.** A harness that is not installed, not signed in, or
+ *    that answers nothing leaves the questions pending and says so. Writing a
+ *    fabricated answer to clear the queue would be strictly worse than leaving
+ *    it — the oracle would proceed on invented data believing it was told.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+/** One question as `agent_loop.Question.to_json` writes it. */
+export interface ChannelQuestion {
+	key: string;
+	topic: string;
+	subject: string;
+	prompt: string;
+	reply_schema: string;
+	context?: Record<string, unknown>;
+	answer?: unknown;
+}
+
+export interface ChannelFile {
+	path: string;
+	topic: string;
+	questions: Record<string, ChannelQuestion>;
+}
+
+export interface DrainReport {
+	/** Questions that were pending before this run. */
+	pending: number;
+	/** Questions this run wrote an answer for. */
+	answered: number;
+	/** Topics touched, for the status line. */
+	topics: string[];
+	/** Why nothing was answered, when nothing was. Never empty on a no-op. */
+	detail: string;
+	ok: boolean;
+}
+
+/** The subset of `runHarnessPrompt` this needs, injected so it is testable. */
+export type PromptRunner = (
+	name: string,
+	prompt: string,
+) => Promise<{ ok: boolean; stdout: string; detail?: string }>;
+
+const CHANNEL_PREFIX = 'agent_';
+const CHANNEL_SUFFIX = '.json';
+
+/** Cap on questions per harness run — a prompt has to stay readable to answer well. */
+const MAX_QUESTIONS_PER_RUN = 25;
+
+export function exerciseDir(workspaceRoot: string): string {
+	return path.join(workspaceRoot, '.vinv', 'exercise');
+}
+
+/** Every channel file in a workspace, with its questions parsed. */
+export function readChannels(workspaceRoot: string): ChannelFile[] {
+	const dir = exerciseDir(workspaceRoot);
+	let names: string[];
+	try {
+		names = fs.readdirSync(dir);
+	} catch {
+		return [];
+	}
+	const out: ChannelFile[] = [];
+	for (const name of names.sort()) {
+		if (!name.startsWith(CHANNEL_PREFIX) || !name.endsWith(CHANNEL_SUFFIX)) {continue;}
+		const full = path.join(dir, name);
+		try {
+			const doc = JSON.parse(fs.readFileSync(full, 'utf8')) as {
+				topic?: string;
+				questions?: Record<string, ChannelQuestion>;
+			};
+			out.push({
+				path: full,
+				topic: doc.topic ?? name.slice(CHANNEL_PREFIX.length, -CHANNEL_SUFFIX.length),
+				questions: doc.questions ?? {},
+			});
+		} catch {
+			// A malformed or half-written channel file contributes nothing. It is
+			// not an error here: the engine may be mid-write, and the next drain
+			// picks it up.
+			continue;
+		}
+	}
+	return out;
+}
+
+/** Questions still waiting for an answer, across every topic. */
+export function pendingQuestions(channels: ChannelFile[]): ChannelQuestion[] {
+	const out: ChannelQuestion[] = [];
+	for (const channel of channels) {
+		for (const question of Object.values(channel.questions)) {
+			// `null` and absent both mean unanswered; anything else is an answer,
+			// including `false` and `0`, which are legitimate replies.
+			if (question && (question.answer === null || question.answer === undefined)) {
+				out.push(question);
+			}
+		}
+	}
+	return out;
+}
+
+/**
+ * One prompt carrying every pending question.
+ *
+ * The reply is asked for as a single JSON object keyed by question id, so one
+ * run answers everything and the parse has an unambiguous shape to look for.
+ * Each question keeps its own `reply_schema` inline — they differ per topic and
+ * the engine validates against them.
+ */
+export function buildPrompt(questions: ChannelQuestion[]): string {
+	const blocks = questions.map((q, i) => {
+		const context = q.context && Object.keys(q.context).length
+			? `\ncontext: ${JSON.stringify(q.context)}`
+			: '';
+		return [
+			`### ${i + 1}. id \`${q.key}\`  (topic: ${q.topic}, subject: ${q.subject})`,
+			q.prompt,
+			`${context}`,
+			`reply shape for this one: ${q.reply_schema}`,
+		].join('\n');
+	});
+	return [
+		'Vinv could not answer the following questions structurally — each needs',
+		'intent, not syntax. Answer them from THIS repository: read the code, the',
+		'README, the settings classes and the docs. They are cached permanently,',
+		'so an answer given once is never asked again.',
+		'',
+		'Rules:',
+		'- Answer only what the repository actually supports. A wrong answer is',
+		'  worse than none, because the oracle proceeds believing it was told.',
+		'- If you cannot determine one, omit its id entirely rather than guessing.',
+		'- Never invent a credential. If a question needs a real secret, answer with',
+		'  the documented shape and leave the value null.',
+		'',
+		...blocks,
+		'',
+		'Reply with ONE json object and nothing else, mapping each id you answered',
+		'to its reply, exactly in this envelope:',
+		'{"answers": {"<id>": <reply matching that question\'s shape>, ...}}',
+	].join('\n');
+}
+
+/**
+ * The `{"answers": {...}}` object out of a harness's reply.
+ *
+ * Harnesses wrap JSON in prose and fences at will, so the last balanced object
+ * containing an `answers` key is taken rather than assuming the whole stdout
+ * parses. Returns an empty map when nothing usable is present — never throws,
+ * because an unparseable reply must leave the queue pending rather than
+ * take down the run.
+ */
+export function parseAnswers(stdout: string): Record<string, unknown> {
+	if (!stdout) {return {};}
+	const candidates: string[] = [];
+	// Fenced blocks first — the common shape — then the raw text.
+	const fence = /```(?:json)?\s*([\s\S]*?)```/g;
+	let match: RegExpExecArray | null;
+	while ((match = fence.exec(stdout)) !== null) {candidates.push(match[1]);}
+	candidates.push(stdout);
+
+	for (const text of candidates.reverse()) {
+		const start = text.indexOf('{');
+		if (start < 0) {continue;}
+		// Scan for the balanced close rather than regexing — replies nest.
+		let depth = 0;
+		let inString = false;
+		let escape = false;
+		for (let i = start; i < text.length; i++) {
+			const ch = text[i];
+			if (escape) { escape = false; continue; }
+			if (ch === '\\') { escape = true; continue; }
+			if (ch === '"') { inString = !inString; continue; }
+			if (inString) {continue;}
+			if (ch === '{') {depth++;}
+			else if (ch === '}') {
+				depth--;
+				if (depth === 0) {
+					try {
+						const parsed = JSON.parse(text.slice(start, i + 1)) as {
+							answers?: Record<string, unknown>;
+						};
+						if (parsed && typeof parsed === 'object' && parsed.answers) {
+							return parsed.answers;
+						}
+					} catch {
+						// Keep scanning: a later candidate may parse.
+					}
+					break;
+				}
+			}
+		}
+	}
+	return {};
+}
+
+/** Write answers back into their channel files. Returns how many landed. */
+export function applyAnswers(
+	channels: ChannelFile[],
+	answers: Record<string, unknown>,
+): number {
+	let written = 0;
+	for (const channel of channels) {
+		let touched = false;
+		for (const [key, question] of Object.entries(channel.questions)) {
+			const answer = answers[key];
+			if (answer === undefined) {continue;}
+			// Never overwrite an existing answer. The engine caches permanently and
+			// a human may have corrected one; a later model run must not undo that.
+			if (question.answer !== null && question.answer !== undefined) {continue;}
+			question.answer = answer;
+			touched = true;
+			written++;
+		}
+		if (!touched) {continue;}
+		try {
+			const doc = JSON.parse(fs.readFileSync(channel.path, 'utf8')) as Record<string, unknown>;
+			doc.questions = channel.questions;
+			fs.writeFileSync(channel.path, JSON.stringify(doc, null, 2), 'utf8');
+		} catch {
+			// A file that cannot be written back means those answers did not land.
+			written -= Object.keys(channel.questions).length;
+		}
+	}
+	return Math.max(0, written);
+}
+
+/**
+ * Ask the harness every pending question and write back what it answers.
+ *
+ * Returns without running anything when the queue is empty, which is the common
+ * case and must stay free.
+ */
+export async function drainAgentChannels(
+	workspaceRoot: string,
+	run: PromptRunner,
+): Promise<DrainReport> {
+	const channels = readChannels(workspaceRoot);
+	const pending = pendingQuestions(channels);
+	const topics = [...new Set(pending.map((q) => q.topic))].sort();
+
+	if (pending.length === 0) {
+		return { pending: 0, answered: 0, topics: [], detail: 'no questions pending', ok: true };
+	}
+
+	const batch = pending.slice(0, MAX_QUESTIONS_PER_RUN);
+	const result = await run('vinv: answer engine questions', buildPrompt(batch));
+	if (!result.ok) {
+		return {
+			pending: pending.length,
+			answered: 0,
+			topics,
+			detail: result.detail || 'the harness run failed',
+			ok: false,
+		};
+	}
+
+	const answers = parseAnswers(result.stdout);
+	const answered = applyAnswers(channels, answers);
+	return {
+		pending: pending.length,
+		answered,
+		topics,
+		detail: answered
+			? `answered ${answered}/${pending.length} across ${topics.join(', ')}`
+			: 'the harness answered nothing usable — questions stay pending',
+		ok: answered > 0,
+	};
+}

--- a/extension/src/harness/autoPilot.ts
+++ b/extension/src/harness/autoPilot.ts
@@ -34,6 +34,7 @@ import {
 	markNotAService,
 	noteSetupAttempt,
 	planPipelineAction,
+	settleUnreachableStages,
 	summarize,
 	type AutoPilotBudgets,
 	type PilotStep,
@@ -339,6 +340,8 @@ async function drive(
 			finishSummary(services, true);
 			return;
 		}
+		// A stage no live service will ever feed is decided, not outstanding.
+		ledger = settleUnreachableStages(services, ledger);
 		const action = planPipelineAction(discovered, services, ledger);
 
 		if (action.kind === 'done') {

--- a/extension/src/harness/autoPilotMachine.ts
+++ b/extension/src/harness/autoPilotMachine.ts
@@ -308,12 +308,22 @@ export type PipelineAction =
 	| { kind: 'exercise' };
 
 /**
- * The full-pipeline scheduler: services drain first (planNextAction), then —
- * only when at least one service actually went green (a workspace of
- * libraries/gave-ups has nothing to observe) — insights build, then probes
- * run. Terminal stage phases (done/failed/skipped) never re-enter; failures
- * are retried via decideOnStageFailure, which flips the stage back to
- * 'pending' while budget remains.
+ * The full-pipeline scheduler: services drain first (planNextAction), then the
+ * post-green stages.
+ *
+ * `insights` and `probes` genuinely require a live traced session — they read
+ * what a running service recorded, so with nothing green there is nothing to
+ * read. `exercise` does NOT: its crash, differential, fault and concurrency
+ * oracles drive code in workers from the source and the index, and need no
+ * port, no process and no traffic. Gating it on `anyGreen` too meant a
+ * workspace of libraries did nothing at all after discovery — on a clone of
+ * langchain, Auto-Pilot fired zero oracles, while the same repo yields 511
+ * targets and 1,944 calls when the exercise stage is allowed to run. A library
+ * is not "nothing to observe"; it is nothing to SERVE.
+ *
+ * Terminal stage phases (done/failed/skipped) never re-enter; failures are
+ * retried via decideOnStageFailure, which flips the stage back to 'pending'
+ * while budget remains.
  */
 export function planPipelineAction(
 	discovered: boolean,
@@ -325,13 +335,10 @@ export function planPipelineAction(
 		return serviceAction;
 	}
 	const anyGreen = services.some((s) => s.phase === 'green');
-	if (!anyGreen) {
-		return { kind: 'done' };
-	}
-	if (ledger.insights === 'pending') {
+	if (anyGreen && ledger.insights === 'pending') {
 		return { kind: 'insights' };
 	}
-	if (ledger.probes === 'pending') {
+	if (anyGreen && ledger.probes === 'pending') {
 		return { kind: 'probes' };
 	}
 	if (ledger.exercise === 'pending') {

--- a/extension/src/harness/autoPilotMachine.ts
+++ b/extension/src/harness/autoPilotMachine.ts
@@ -317,9 +317,11 @@ export type PipelineAction =
  * oracles drive code in workers from the source and the index, and need no
  * port, no process and no traffic. Gating it on `anyGreen` too meant a
  * workspace of libraries did nothing at all after discovery — on a clone of
- * langchain, Auto-Pilot fired zero oracles, while the same repo yields 511
- * targets and 1,944 calls when the exercise stage is allowed to run. A library
- * is not "nothing to observe"; it is nothing to SERVE.
+ * langchain, Auto-Pilot fired zero oracles. (The 511-target/1,944-call figure
+ * quoted for that repo comes from the standalone `functions` command with a
+ * raised `--max-targets`; this stage runs `campaign`, whose per-oracle cap is
+ * 50. The point is the same and the scale is not.) A library is not "nothing to
+ * observe"; it is nothing to SERVE.
  *
  * Terminal stage phases (done/failed/skipped) never re-enter; failures are
  * retried via decideOnStageFailure, which flips the stage back to 'pending'
@@ -345,6 +347,34 @@ export function planPipelineAction(
 		return { kind: 'exercise' };
 	}
 	return { kind: 'done' };
+}
+
+/**
+ * Settle the stages this workspace can never reach.
+ *
+ * `insights` and `probes` need a live traced session, so on a workspace of
+ * libraries they are not "still to do" — they are decided. Leaving them
+ * 'pending' let the scheduler reach 'done' with two stages that read, to
+ * anything displaying the ledger, as outstanding work that never arrives. A
+ * stage nothing will run is 'skipped', which is a phase the ledger already has.
+ *
+ * Idempotent, and never downgrades a stage that actually ran: only 'pending' is
+ * rewritten.
+ */
+export function settleUnreachableStages(
+	services: ServiceState[],
+	ledger: PipelineLedger,
+): PipelineLedger {
+	if (services.some((s) => s.phase === 'green')) {
+		return ledger;
+	}
+	let next = ledger;
+	for (const stage of ['insights', 'probes'] as const) {
+		if (next[stage] === 'pending') {
+			next = { ...next, [stage]: 'skipped' };
+		}
+	}
+	return next;
 }
 
 /** The post-green stages, in the order the scheduler drains them. */

--- a/extension/src/harness/exerciseRunner.ts
+++ b/extension/src/harness/exerciseRunner.ts
@@ -500,10 +500,44 @@ async function runServiceFreePass(
 
 	const found = issues?.clusters?.length ?? 0;
 	publishExerciseState(
-		exerciseStateFromArtifacts(null, issues, 'done', `${why} — drove the service-free oracles`),
+		exerciseStateFromArtifacts(null, issues, 'done', `${why} — ${engineVerdict(workspaceRoot, found)}`),
 	);
 	await dispatchFreshClusters(context, workspaceRoot, issues);
 	return { outcome: 'done', endpointsCovered: 0, total: 0, invariants: 0, issues: found };
+}
+
+/** The `functions.json` shape this file reads — status and diagnostics only. */
+interface FunctionsVerdict {
+	status?: string;
+	diagnostics?: string[];
+}
+
+/**
+ * What the run actually concluded, not just how many clusters it produced.
+ *
+ * The engine already refuses to call a run clean when it could not import the
+ * code — `status: "environment"` plus a diagnostic naming the interpreter, the
+ * unmet precondition or the escalated variables. The CLI prints those loudly.
+ * The EXTENSION read neither, so in the product a run that never executed the
+ * target still rendered as "drove the service-free oracles" with zero issues —
+ * which is the exact silent zero the engine-side work exists to remove,
+ * reproduced one layer up.
+ *
+ * A producer and a consumer are two ends, and a test on the writing end passes
+ * whether or not the reading end exists. This is the reading end.
+ */
+export function engineVerdict(workspaceRoot: string, clusters: number): string {
+	const doc = readExerciseJson<FunctionsVerdict>(workspaceRoot, 'functions.json');
+	const diagnostics = doc?.diagnostics ?? [];
+	if (doc?.status === 'environment') {
+		// The strongest thing the engine can say: it could not load the code, so
+		// "no issues" means nothing was tested rather than nothing was wrong.
+		return diagnostics[0] ?? 'the code under test could not be imported — nothing was exercised';
+	}
+	if (diagnostics.length > 0) {
+		return `drove the service-free oracles — ${diagnostics[0]}`;
+	}
+	return `drove the service-free oracles${clusters === 0 ? ' — no issues found' : ''}`;
 }
 
 /**

--- a/extension/src/harness/exerciseRunner.ts
+++ b/extension/src/harness/exerciseRunner.ts
@@ -376,6 +376,43 @@ async function recordDispatched(context: vscode.ExtensionContext, ids: Iterable<
 	await context.workspaceState.update(DISPATCHED_EXERCISE_KEY, [...merged].slice(-500));
 }
 
+/**
+ * The exercise pass for a repo with nothing serving: `campaign` alone, without
+ * `--base-url`, so the HTTP oracle stays unarmed and the four service-free
+ * oracles do the work. `plan`/`run`/`profile`/`scorecard` are all HTTP-shaped
+ * and are correctly absent here — findings land in issues.json exactly as they
+ * do on the served path, which is the file the dispatch path reads.
+ */
+async function runServiceFreePass(
+	workspaceRoot: string,
+	bin: string,
+	env: NodeJS.ProcessEnv,
+	why: string,
+): Promise<ExercisePassResult> {
+	publishExerciseState(
+		exerciseStateFromArtifacts(null, null, 'running', `${why} — exercising functions and contracts…`),
+	);
+	const campaign = await runEngine(
+		bin,
+		['campaign', workspaceRoot, '--budget', String(campaignBudget())],
+		workspaceRoot,
+		env,
+	);
+	const issues = readExerciseJson<ExerciseIssuesDoc>(workspaceRoot, 'issues.json');
+	if (!campaign.ok) {
+		publishExerciseState(exerciseStateFromArtifacts(null, issues, 'failed', 'campaign failed'));
+		return {
+			outcome: 'failed', endpointsCovered: 0, total: 0, invariants: 0, issues: 0,
+			error: campaign.error,
+		};
+	}
+	const found = issues?.clusters?.length ?? 0;
+	publishExerciseState(
+		exerciseStateFromArtifacts(null, issues, 'done', `${why} — drove the service-free oracles`),
+	);
+	return { outcome: 'done', endpointsCovered: 0, total: 0, invariants: 0, issues: found };
+}
+
 async function exercisePassOnce(
 	context: vscode.ExtensionContext,
 	workspaceRoot: string,
@@ -392,16 +429,23 @@ async function exercisePassOnce(
 	if (!isBinAvailable(context, 'exerciser')) {
 		return skip('exerciser engine not installed');
 	}
-	const target = pickTarget(workspaceRoot);
-	if (!target) {
-		return skip('no service with a recorded port to exercise');
-	}
-	if (!isServiceRunning(target.service)) {
-		return skip(`service '${target.service}' is not running — start it to exercise`);
-	}
-
 	const bin = getBinPath(context, 'exerciser');
 	const env = getHandbookEnv(path.dirname(bin), workspaceRoot);
+
+	// No live service is a reason to skip the HTTP oracle, not a reason to skip
+	// the pass. `campaign` still arms crash, differential, fault and concurrency
+	// — they drive code in workers off the source and the index, with no port
+	// and no traffic. Returning 'skipped' here is what made Vinv a no-op on
+	// every library repo: nothing was ever exercised because nothing was ever
+	// served.
+	const target = pickTarget(workspaceRoot);
+	if (!target || !isServiceRunning(target.service)) {
+		const why = target
+			? `service '${target.service}' is not running`
+			: 'no service with a recorded port';
+		return runServiceFreePass(workspaceRoot, bin, env, why);
+	}
+
 	const baseUrl = `http://127.0.0.1:${target.port}`;
 	const slug = serviceSlug(target.service);
 

--- a/extension/src/harness/exerciseRunner.ts
+++ b/extension/src/harness/exerciseRunner.ts
@@ -37,6 +37,7 @@ import { dispatchIssueEpisode } from './autoTrigger';
 import { drainAgentChannels, type DrainReport } from './agentChannel';
 import { runHarnessPrompt } from './harnessRunner';
 import { getHarnessId } from '../config/settings';
+import { openConfigRequestPanel, writeAnswers } from '../views/configRequestPanel';
 import { isAutoEpisodesEnabled } from '../config/settings';
 
 /** .vinv/exercise/<file> */
@@ -498,12 +499,60 @@ async function runServiceFreePass(
 		// went wrong.
 	}
 
+	// Anything the harness could not answer either is a question only a person
+	// can close. Opening the panel is the LAST step of the ladder, not a
+	// fallback for a failure — the engine derived what it could, induced what it
+	// could, asked the agent, and this is the remainder.
+	askUserForRemainingConfig(workspaceRoot, bin, env);
+
 	const found = issues?.clusters?.length ?? 0;
 	publishExerciseState(
 		exerciseStateFromArtifacts(null, issues, 'done', `${why} — ${engineVerdict(workspaceRoot, found)}`),
 	);
 	await dispatchFreshClusters(context, workspaceRoot, issues);
 	return { outcome: 'done', endpointsCovered: 0, total: 0, invariants: 0, issues: found };
+}
+
+/**
+ * Show the user whatever configuration is still unresolved, and re-run on submit.
+ *
+ * Opens nothing when nothing is being asked, which is the common case: the
+ * panel is the tail of the ladder, so a repo Vinv configured on its own never
+ * sees it. Deliberately not awaited — the exercise pass is finished and its
+ * findings are already published; a person filling in a form must not hold the
+ * pipeline open while they do it.
+ */
+function askUserForRemainingConfig(
+	workspaceRoot: string,
+	bin: string,
+	env: NodeJS.ProcessEnv,
+): void {
+	try {
+		openConfigRequestPanel(workspaceRoot, {
+			save: (answers) => writeAnswers(workspaceRoot, answers),
+			rerun: async () => {
+				publishExerciseState(
+					exerciseStateFromArtifacts(null, null, 'running', 'configuration supplied — re-running…'),
+				);
+				await runEngine(
+					bin,
+					['campaign', workspaceRoot, '--budget', String(campaignBudget())],
+					workspaceRoot,
+					env,
+				);
+				const issues = readExerciseJson<ExerciseIssuesDoc>(workspaceRoot, 'issues.json');
+				publishExerciseState(
+					exerciseStateFromArtifacts(
+						null, issues, 'done', engineVerdict(workspaceRoot, issues?.clusters?.length ?? 0),
+					),
+				);
+			},
+			showError: (message) => void vscode.window.showErrorMessage(message),
+		});
+	} catch {
+		// A panel that cannot open must never fail the exercise pass. The requests
+		// stay on disk and the next run offers them again.
+	}
 }
 
 /** The `functions.json` shape this file reads — status and diagnostics only. */

--- a/extension/src/harness/exerciseRunner.ts
+++ b/extension/src/harness/exerciseRunner.ts
@@ -349,6 +349,57 @@ export function runEngine(
 }
 
 /**
+ * Everything the pass does that reaches outside this module.
+ *
+ * A seam, not an abstraction: the pass ORCHESTRATES — which engine commands run,
+ * in what order, which failures are fatal, and whether findings are handed on —
+ * and none of that was reachable from a test, because every step went straight
+ * to a process spawn, the binary registry, or the episode dispatcher. So the
+ * orchestration was verified by reading it, which is exactly how the
+ * service-free pass shipped returning before the dispatch block it documented
+ * itself as reaching.
+ *
+ * Production wiring lives in `productionPorts`; a test supplies its own and gets
+ * to assert the SEQUENCE.
+ */
+export interface ExercisePassPorts {
+	binAvailable(name: string): boolean;
+	binPath(name: string): string;
+	handbookEnv(binDir: string, workspaceRoot: string): NodeJS.ProcessEnv;
+	runEngine(
+		bin: string,
+		args: string[],
+		cwd: string,
+		env: NodeJS.ProcessEnv,
+	): Promise<{ ok: boolean; error?: string }>;
+	pickTarget(workspaceRoot: string): { service: string; port: number } | null;
+	serviceRunning(name: string): boolean;
+	autoEpisodesEnabled(): boolean;
+	dispatch(
+		context: vscode.ExtensionContext,
+		workspaceRoot: string,
+		issues: ReadonlyArray<{ title: string; detail: string; rows?: number[] }>,
+		opts?: { trigger?: string; successCriteria?: string[] },
+	): Promise<boolean>;
+	drainChannels(workspaceRoot: string): Promise<DrainReport>;
+}
+
+/** The real effects. Every field is the function the pass used to call directly. */
+export function productionPorts(context: vscode.ExtensionContext): ExercisePassPorts {
+	return {
+		binAvailable: (name) => isBinAvailable(context, name),
+		binPath: (name) => getBinPath(context, name),
+		handbookEnv: (binDir, workspaceRoot) => getHandbookEnv(binDir, workspaceRoot),
+		runEngine,
+		pickTarget,
+		serviceRunning: isServiceRunning,
+		autoEpisodesEnabled: isAutoEpisodesEnabled,
+		dispatch: dispatchIssueEpisode,
+		drainChannels: drainChannelsAfterExercise,
+	};
+}
+
+/**
  * Runs one full behavioral-exercise pass: plan → run → profile → scorecard,
  * publishes the state, and dispatches NEW behavioral failure clusters as fix
  * episodes (signature-deduped, the same path probe failures use). Serialized;
@@ -363,7 +414,7 @@ export async function runExercisePass(
 	}
 	exerciseRunning = true;
 	try {
-		return await exercisePassOnce(context, workspaceRoot);
+		return await exercisePassOnce(context, workspaceRoot, productionPorts(context));
 	} catch (e) {
 		const error = e instanceof Error ? e.message : String(e);
 		publishExerciseState(exerciseStateFromArtifacts(null, null, 'failed', 'exercise pass failed'));
@@ -400,12 +451,13 @@ async function recordDispatched(context: vscode.ExtensionContext, ids: Iterable<
  * library repo published findings that were never handed to anyone. Publishing
  * a cluster and acting on it are different things, and only the first was wired.
  */
-async function dispatchFreshClusters(
+export async function dispatchFreshClusters(
 	context: vscode.ExtensionContext,
 	workspaceRoot: string,
 	issues: ExerciseIssuesDoc | null,
+	ports: ExercisePassPorts,
 ): Promise<void> {
-	if (!issues || issues.clusters.length === 0 || !isAutoEpisodesEnabled()) {
+	if (!issues || issues.clusters.length === 0 || !ports.autoEpisodesEnabled()) {
 		return;
 	}
 	const dispatched = readDispatched(context);
@@ -413,7 +465,7 @@ async function dispatchFreshClusters(
 	const errorShaped = fresh.filter((c) => !isAssertShapedKind(c.kind));
 	const assertShaped = fresh.filter((c) => isAssertShapedKind(c.kind));
 	if (errorShaped.length > 0) {
-		const handedOff = await dispatchIssueEpisode(
+		const handedOff = await ports.dispatch(
 			context, workspaceRoot, issueEpisodesFromClusters(errorShaped),
 		);
 		if (handedOff) {
@@ -421,7 +473,7 @@ async function dispatchFreshClusters(
 		}
 	}
 	if (assertShaped.length > 0) {
-		const handedOff = await dispatchIssueEpisode(
+		const handedOff = await ports.dispatch(
 			context, workspaceRoot, issueEpisodesFromClusters(assertShaped),
 			{ trigger: 'invariant-violation', successCriteria: [...ASSERT_SUCCESS_CRITERIA] },
 		);
@@ -444,11 +496,12 @@ async function runServiceFreePass(
 	bin: string,
 	env: NodeJS.ProcessEnv,
 	why: string,
+	ports: ExercisePassPorts,
 ): Promise<ExercisePassResult> {
 	publishExerciseState(
 		exerciseStateFromArtifacts(null, null, 'running', `${why} — exercising functions and contracts…`),
 	);
-	const campaign = await runEngine(
+	const campaign = await ports.runEngine(
 		bin,
 		['campaign', workspaceRoot, '--budget', String(campaignBudget())],
 		workspaceRoot,
@@ -468,7 +521,7 @@ async function runServiceFreePass(
 	// channels and, if the harness answered anything, run once more with what it
 	// said. ONE extra pass: the answers are cached permanently, so a second
 	// re-run would re-drive the same evidence for nothing.
-	const drained = await drainChannelsAfterExercise(workspaceRoot);
+	const drained = await ports.drainChannels(workspaceRoot);
 	if (drained.answered > 0) {
 		publishExerciseState(
 			exerciseStateFromArtifacts(
@@ -478,7 +531,7 @@ async function runServiceFreePass(
 				`${why} — ${drained.detail}, re-running with the answers`,
 			),
 		);
-		const second = await runEngine(
+		const second = await ports.runEngine(
 			bin,
 			['campaign', workspaceRoot, '--budget', String(campaignBudget())],
 			workspaceRoot,
@@ -503,13 +556,13 @@ async function runServiceFreePass(
 	// can close. Opening the panel is the LAST step of the ladder, not a
 	// fallback for a failure — the engine derived what it could, induced what it
 	// could, asked the agent, and this is the remainder.
-	askUserForRemainingConfig(workspaceRoot, bin, env);
+	askUserForRemainingConfig(workspaceRoot, bin, env, ports);
 
 	const found = issues?.clusters?.length ?? 0;
 	publishExerciseState(
 		exerciseStateFromArtifacts(null, issues, 'done', `${why} — ${engineVerdict(workspaceRoot, found)}`),
 	);
-	await dispatchFreshClusters(context, workspaceRoot, issues);
+	await dispatchFreshClusters(context, workspaceRoot, issues, ports);
 	return { outcome: 'done', endpointsCovered: 0, total: 0, invariants: 0, issues: found };
 }
 
@@ -526,6 +579,7 @@ function askUserForRemainingConfig(
 	workspaceRoot: string,
 	bin: string,
 	env: NodeJS.ProcessEnv,
+	ports: ExercisePassPorts,
 ): void {
 	try {
 		openConfigRequestPanel(workspaceRoot, {
@@ -534,7 +588,7 @@ function askUserForRemainingConfig(
 				publishExerciseState(
 					exerciseStateFromArtifacts(null, null, 'running', 'configuration supplied — re-running…'),
 				);
-				await runEngine(
+				await ports.runEngine(
 					bin,
 					['campaign', workspaceRoot, '--budget', String(campaignBudget())],
 					workspaceRoot,
@@ -619,9 +673,10 @@ async function drainChannelsAfterExercise(workspaceRoot: string): Promise<DrainR
 	}
 }
 
-async function exercisePassOnce(
+export async function exercisePassOnce(
 	context: vscode.ExtensionContext,
 	workspaceRoot: string,
+	ports: ExercisePassPorts,
 ): Promise<ExercisePassResult> {
 	const skip = (why: string): ExercisePassResult => {
 		publishExerciseState(exerciseStateFromArtifacts(
@@ -632,11 +687,11 @@ async function exercisePassOnce(
 		return { outcome: 'skipped', endpointsCovered: 0, total: 0, invariants: 0, issues: 0, error: why };
 	};
 
-	if (!isBinAvailable(context, 'exerciser')) {
+	if (!ports.binAvailable('exerciser')) {
 		return skip('exerciser engine not installed');
 	}
-	const bin = getBinPath(context, 'exerciser');
-	const env = getHandbookEnv(path.dirname(bin), workspaceRoot);
+	const bin = ports.binPath('exerciser');
+	const env = ports.handbookEnv(path.dirname(bin), workspaceRoot);
 
 	// No live service is a reason to skip the HTTP oracle, not a reason to skip
 	// the pass. `campaign` still arms crash, differential, fault and concurrency
@@ -644,26 +699,26 @@ async function exercisePassOnce(
 	// and no traffic. Returning 'skipped' here is what made Vinv a no-op on
 	// every library repo: nothing was ever exercised because nothing was ever
 	// served.
-	const target = pickTarget(workspaceRoot);
-	if (!target || !isServiceRunning(target.service)) {
+	const target = ports.pickTarget(workspaceRoot);
+	if (!target || !ports.serviceRunning(target.service)) {
 		const why = target
 			? `service '${target.service}' is not running`
 			: 'no service with a recorded port';
-		return runServiceFreePass(context, workspaceRoot, bin, env, why);
+		return runServiceFreePass(context, workspaceRoot, bin, env, why, ports);
 	}
 
 	const baseUrl = `http://127.0.0.1:${target.port}`;
 	const slug = serviceSlug(target.service);
 
 	publishExerciseState(exerciseStateFromArtifacts(null, null, 'running', `planning inputs for ${target.service}…`));
-	let step = await runEngine(bin, ['plan', workspaceRoot, '--service', slug, '--base-url', baseUrl], workspaceRoot, env);
+	let step = await ports.runEngine(bin, ['plan', workspaceRoot, '--service', slug, '--base-url', baseUrl], workspaceRoot, env);
 	if (!step.ok) {
 		publishExerciseState(exerciseStateFromArtifacts(null, null, 'failed', 'plan failed'));
 		return { outcome: 'failed', endpointsCovered: 0, total: 0, invariants: 0, issues: 0, error: step.error };
 	}
 
 	publishExerciseState(exerciseStateFromArtifacts(null, null, 'running', `exercising ${target.service}…`));
-	step = await runEngine(bin, ['run', workspaceRoot, '--base-url', baseUrl, '--service', slug], workspaceRoot, env);
+	step = await ports.runEngine(bin, ['run', workspaceRoot, '--base-url', baseUrl, '--service', slug], workspaceRoot, env);
 	if (!step.ok) {
 		publishExerciseState(exerciseStateFromArtifacts(null, null, 'failed', 'run failed'));
 		return { outcome: 'failed', endpointsCovered: 0, total: 0, invariants: 0, issues: 0, error: step.error };
@@ -687,7 +742,7 @@ async function exercisePassOnce(
 	publishExerciseState(
 		exerciseStateFromArtifacts(null, null, 'running', 'exercising functions, faults and contracts…'),
 	);
-	const campaign = await runEngine(
+	const campaign = await ports.runEngine(
 		bin,
 		['campaign', workspaceRoot, '--base-url', baseUrl, '--budget', String(campaignBudget())],
 		workspaceRoot,
@@ -701,13 +756,13 @@ async function exercisePassOnce(
 	// These two MUST be checked like plan/run above. Unchecked, a crashed profile
 	// is indistinguishable from a clean run: the reads below silently fall back to
 	// the PREVIOUS pass's artifacts and the pass reports 'done' with stale numbers.
-	step = await runEngine(bin, ['profile', workspaceRoot, '--service', slug], workspaceRoot, env);
+	step = await ports.runEngine(bin, ['profile', workspaceRoot, '--service', slug], workspaceRoot, env);
 	if (!step.ok) {
 		publishExerciseState(exerciseStateFromArtifacts(null, null, 'failed', 'profile failed'));
 		return { outcome: 'failed', endpointsCovered: 0, total: 0, invariants: 0, issues: 0, error: step.error };
 	}
 
-	step = await runEngine(bin, ['scorecard', workspaceRoot, '--service', slug], workspaceRoot, env);
+	step = await ports.runEngine(bin, ['scorecard', workspaceRoot, '--service', slug], workspaceRoot, env);
 	if (!step.ok) {
 		publishExerciseState(exerciseStateFromArtifacts(null, null, 'failed', 'scorecard failed'));
 		return { outcome: 'failed', endpointsCovered: 0, total: 0, invariants: 0, issues: 0, error: step.error };
@@ -722,7 +777,7 @@ async function exercisePassOnce(
 	);
 	publishExerciseState(state);
 
-	await dispatchFreshClusters(context, workspaceRoot, issues);
+	await dispatchFreshClusters(context, workspaceRoot, issues, ports);
 
 	return {
 		outcome: 'done',

--- a/extension/src/harness/exerciseRunner.ts
+++ b/extension/src/harness/exerciseRunner.ts
@@ -555,8 +555,8 @@ function askUserForRemainingConfig(
 	}
 }
 
-/** The `functions.json` shape this file reads — status and diagnostics only. */
-interface FunctionsVerdict {
+/** The status/diagnostics shape both engine summaries share. */
+interface EngineVerdictDoc {
 	status?: string;
 	diagnostics?: string[];
 }
@@ -576,7 +576,14 @@ interface FunctionsVerdict {
  * whether or not the reading end exists. This is the reading end.
  */
 export function engineVerdict(workspaceRoot: string, clusters: number): string {
-	const doc = readExerciseJson<FunctionsVerdict>(workspaceRoot, 'functions.json');
+	// `campaign_result.json` FIRST, because it describes the run. `functions.json`
+	// is rewritten by every crash play with `only_targets=[one]`, so its `status`
+	// is computed over a single module — one arm's verdict, shown as the run's,
+	// and stale from a previous run entirely when no crash play was drawn. It
+	// stays as the fallback: `exerciser functions` run directly writes only that.
+	const doc =
+		readExerciseJson<EngineVerdictDoc>(workspaceRoot, 'campaign_result.json') ??
+		readExerciseJson<EngineVerdictDoc>(workspaceRoot, 'functions.json');
 	const diagnostics = doc?.diagnostics ?? [];
 	if (doc?.status === 'environment') {
 		// The strongest thing the engine can say: it could not load the code, so

--- a/extension/src/harness/exerciseRunner.ts
+++ b/extension/src/harness/exerciseRunner.ts
@@ -377,13 +377,58 @@ async function recordDispatched(context: vscode.ExtensionContext, ids: Iterable<
 }
 
 /**
+ * Hand NEW behavioral failure clusters to the coding agent as fix episodes
+ * (signature-deduped). Error-shaped and assert-shaped clusters dispatch
+ * separately: a silent wrong-value violation needs value-shaped success
+ * criteria and its own trigger, not "no longer produces these errors". One
+ * episode runs at a time — whichever batch dispatches first wins this pass, the
+ * other stays eligible (dispatchIssueEpisode returns false while busy).
+ *
+ * Shared by both passes, and that is the point: this lived INLINE at the end of
+ * the served path, so the service-free pass returned before reaching it and a
+ * library repo published findings that were never handed to anyone. Publishing
+ * a cluster and acting on it are different things, and only the first was wired.
+ */
+async function dispatchFreshClusters(
+	context: vscode.ExtensionContext,
+	workspaceRoot: string,
+	issues: ExerciseIssuesDoc | null,
+): Promise<void> {
+	if (!issues || issues.clusters.length === 0 || !isAutoEpisodesEnabled()) {
+		return;
+	}
+	const dispatched = readDispatched(context);
+	const fresh = issues.clusters.filter((c) => !dispatched.has(c.signature));
+	const errorShaped = fresh.filter((c) => !isAssertShapedKind(c.kind));
+	const assertShaped = fresh.filter((c) => isAssertShapedKind(c.kind));
+	if (errorShaped.length > 0) {
+		const handedOff = await dispatchIssueEpisode(
+			context, workspaceRoot, issueEpisodesFromClusters(errorShaped),
+		);
+		if (handedOff) {
+			await recordDispatched(context, errorShaped.map((c) => c.signature));
+		}
+	}
+	if (assertShaped.length > 0) {
+		const handedOff = await dispatchIssueEpisode(
+			context, workspaceRoot, issueEpisodesFromClusters(assertShaped),
+			{ trigger: 'invariant-violation', successCriteria: [...ASSERT_SUCCESS_CRITERIA] },
+		);
+		if (handedOff) {
+			await recordDispatched(context, assertShaped.map((c) => c.signature));
+		}
+	}
+}
+
+/**
  * The exercise pass for a repo with nothing serving: `campaign` alone, without
  * `--base-url`, so the HTTP oracle stays unarmed and the four service-free
  * oracles do the work. `plan`/`run`/`profile`/`scorecard` are all HTTP-shaped
  * and are correctly absent here — findings land in issues.json exactly as they
- * do on the served path, which is the file the dispatch path reads.
+ * do on the served path, and go to the SAME dispatch path from there.
  */
 async function runServiceFreePass(
+	context: vscode.ExtensionContext,
 	workspaceRoot: string,
 	bin: string,
 	env: NodeJS.ProcessEnv,
@@ -410,6 +455,7 @@ async function runServiceFreePass(
 	publishExerciseState(
 		exerciseStateFromArtifacts(null, issues, 'done', `${why} — drove the service-free oracles`),
 	);
+	await dispatchFreshClusters(context, workspaceRoot, issues);
 	return { outcome: 'done', endpointsCovered: 0, total: 0, invariants: 0, issues: found };
 }
 
@@ -443,7 +489,7 @@ async function exercisePassOnce(
 		const why = target
 			? `service '${target.service}' is not running`
 			: 'no service with a recorded port';
-		return runServiceFreePass(workspaceRoot, bin, env, why);
+		return runServiceFreePass(context, workspaceRoot, bin, env, why);
 	}
 
 	const baseUrl = `http://127.0.0.1:${target.port}`;
@@ -516,35 +562,7 @@ async function exercisePassOnce(
 	);
 	publishExerciseState(state);
 
-	// Dispatch NEW behavioral failure clusters as fix episodes (signature-deduped).
-	// Error-shaped and assert-shaped clusters dispatch separately: a silent
-	// wrong-value violation needs value-shaped success criteria and its own
-	// trigger, not "no longer produces these errors". One episode runs at a
-	// time — whichever batch dispatches first wins this pass, the other stays
-	// eligible (dispatchIssueEpisode returns false while busy).
-	if (issues && issues.clusters.length > 0 && isAutoEpisodesEnabled()) {
-		const dispatched = readDispatched(context);
-		const fresh = issues.clusters.filter((c) => !dispatched.has(c.signature));
-		const errorShaped = fresh.filter((c) => !isAssertShapedKind(c.kind));
-		const assertShaped = fresh.filter((c) => isAssertShapedKind(c.kind));
-		if (errorShaped.length > 0) {
-			const handedOff = await dispatchIssueEpisode(
-				context, workspaceRoot, issueEpisodesFromClusters(errorShaped),
-			);
-			if (handedOff) {
-				await recordDispatched(context, errorShaped.map((c) => c.signature));
-			}
-		}
-		if (assertShaped.length > 0) {
-			const handedOff = await dispatchIssueEpisode(
-				context, workspaceRoot, issueEpisodesFromClusters(assertShaped),
-				{ trigger: 'invariant-violation', successCriteria: [...ASSERT_SUCCESS_CRITERIA] },
-			);
-			if (handedOff) {
-				await recordDispatched(context, assertShaped.map((c) => c.signature));
-			}
-		}
-	}
+	await dispatchFreshClusters(context, workspaceRoot, issues);
 
 	return {
 		outcome: 'done',

--- a/extension/src/harness/exerciseRunner.ts
+++ b/extension/src/harness/exerciseRunner.ts
@@ -152,6 +152,13 @@ export function evidenceFileForKind(kind: string): string {
 	switch (kind) {
 		case 'function-crash':
 		case 'function-sandboxed':
+		// An import failure is produced by the FUNCTION oracle and its rows live
+		// in that oracle's artifact, like every other kind here. Missing from
+		// this switch, it fell through to the HTTP oracle's `results.jsonl` —
+		// the exact "points a fixing agent at an empty file" failure this
+		// function was written to stop, reproduced for the one kind that fires
+		// most on an unconfigured repo.
+		case 'import-error':
 			return 'function_results.jsonl';
 		case 'differential-mismatch':
 			return 'differential_results.jsonl';

--- a/extension/src/harness/exerciseRunner.ts
+++ b/extension/src/harness/exerciseRunner.ts
@@ -34,6 +34,9 @@ import {
 	type ExerciseState,
 } from './pipelineState';
 import { dispatchIssueEpisode } from './autoTrigger';
+import { drainAgentChannels, type DrainReport } from './agentChannel';
+import { runHarnessPrompt } from './harnessRunner';
+import { getHarnessId } from '../config/settings';
 import { isAutoEpisodesEnabled } from '../config/settings';
 
 /** .vinv/exercise/<file> */
@@ -458,12 +461,72 @@ async function runServiceFreePass(
 			error: campaign.error,
 		};
 	}
+	// The oracles have now raised whatever they could not answer structurally —
+	// a boundary's type contract, a fixture row, an environment variable. Those
+	// questions are only worth raising if something answers them, so drain the
+	// channels and, if the harness answered anything, run once more with what it
+	// said. ONE extra pass: the answers are cached permanently, so a second
+	// re-run would re-drive the same evidence for nothing.
+	const drained = await drainChannelsAfterExercise(workspaceRoot);
+	if (drained.answered > 0) {
+		publishExerciseState(
+			exerciseStateFromArtifacts(
+				null,
+				issues,
+				'running',
+				`${why} — ${drained.detail}, re-running with the answers`,
+			),
+		);
+		const second = await runEngine(
+			bin,
+			['campaign', workspaceRoot, '--budget', String(campaignBudget())],
+			workspaceRoot,
+			env,
+		);
+		if (second.ok) {
+			const reissued = readExerciseJson<ExerciseIssuesDoc>(workspaceRoot, 'issues.json');
+			publishExerciseState(
+				exerciseStateFromArtifacts(null, reissued, 'done', `${why} — ${drained.detail}`),
+			);
+			return {
+				outcome: 'done', endpointsCovered: 0, total: 0, invariants: 0,
+				issues: reissued?.clusters?.length ?? 0,
+			};
+		}
+		// The re-run failed. The FIRST pass's findings are still real and still
+		// earned, so they stand rather than being discarded for a retry that
+		// went wrong.
+	}
+
 	const found = issues?.clusters?.length ?? 0;
 	publishExerciseState(
 		exerciseStateFromArtifacts(null, issues, 'done', `${why} — drove the service-free oracles`),
 	);
 	await dispatchFreshClusters(context, workspaceRoot, issues);
 	return { outcome: 'done', endpointsCovered: 0, total: 0, invariants: 0, issues: found };
+}
+
+/**
+ * Ask the harness whatever the engine could not decide, and report what landed.
+ *
+ * Never throws and never fails the exercise pass: an unanswered question leaves
+ * the oracle exactly where it already was, which is where every run before this
+ * existed left it.
+ */
+async function drainChannelsAfterExercise(workspaceRoot: string): Promise<DrainReport> {
+	try {
+		const harnessId = getHarnessId();
+		return await drainAgentChannels(workspaceRoot, async (name, prompt) => {
+			const run = await runHarnessPrompt(harnessId, workspaceRoot, name, prompt);
+			return { ok: run.ok, stdout: run.stdout, detail: run.detail };
+		});
+	} catch (err) {
+		return {
+			pending: 0, answered: 0, topics: [],
+			detail: `channel dispatch skipped: ${err instanceof Error ? err.message : String(err)}`,
+			ok: false,
+		};
+	}
 }
 
 async function exercisePassOnce(

--- a/extension/src/test/agentChannel.test.ts
+++ b/extension/src/test/agentChannel.test.ts
@@ -1,0 +1,303 @@
+/**
+ * The consumer that never existed.
+ *
+ * `exerciser/agent_loop.py` describes its transport as "the extension (or any
+ * agent) dispatches them and writes back a verdict". A grep of `extension/src`
+ * for `agent_*.json` returned nothing, so every question the fault, fixture and
+ * config oracles ever raised was written to disk and left there — the engine
+ * side complete and inert.
+ *
+ * These tests are built around the ways a dispatcher could be worse than no
+ * dispatcher at all:
+ *
+ *  - it clears the queue with fabricated answers when the harness fails, so an
+ *    oracle proceeds on invented data believing it was told;
+ *  - it overwrites an answer a human corrected with a later model's guess;
+ *  - it re-asks what is already answered, so the permanent cache buys nothing;
+ *  - it runs the harness when there is nothing to ask.
+ */
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+	applyAnswers,
+	buildPrompt,
+	drainAgentChannels,
+	parseAnswers,
+	pendingQuestions,
+	readChannels,
+} from '../harness/agentChannel';
+
+function makeWorkspace(channels: Record<string, unknown>): string {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'vinv-channel-'));
+	const dir = path.join(root, '.vinv', 'exercise');
+	fs.mkdirSync(dir, { recursive: true });
+	for (const [name, doc] of Object.entries(channels)) {
+		fs.writeFileSync(path.join(dir, name), JSON.stringify(doc, null, 2), 'utf8');
+	}
+	return root;
+}
+
+function question(key: string, topic: string, extra: Record<string, unknown> = {}) {
+	return {
+		key,
+		topic,
+		subject: `subject-${key}`,
+		prompt: `what is ${key}?`,
+		reply_schema: '{"value": "<string>"}',
+		context: { variable: key },
+		answer: null,
+		...extra,
+	};
+}
+
+suite('agent channel dispatch', () => {
+	test('every topic is read through one dispatcher', () => {
+		const root = makeWorkspace({
+			'agent_config.json': { topic: 'config', questions: { a: question('a', 'config') } },
+			'agent_contract.json': { topic: 'contract', questions: { b: question('b', 'contract') } },
+			'agent_fixture.json': { topic: 'fixture', questions: { c: question('c', 'fixture') } },
+			'functions.json': { status: 'ok' },
+		});
+		const channels = readChannels(root);
+		assert.deepStrictEqual(
+			channels.map((c) => c.topic).sort(),
+			['config', 'contract', 'fixture'],
+		);
+		assert.strictEqual(pendingQuestions(channels).length, 3);
+	});
+
+	test('an answered question is not pending', () => {
+		const root = makeWorkspace({
+			'agent_config.json': {
+				topic: 'config',
+				questions: {
+					a: question('a', 'config', { answer: { value: 'x' } }),
+					b: question('b', 'config'),
+				},
+			},
+		});
+		assert.deepStrictEqual(
+			pendingQuestions(readChannels(root)).map((q) => q.key),
+			['b'],
+		);
+	});
+
+	test('a falsy answer still counts as answered', () => {
+		// `false` and `0` are legitimate replies; only null/absent mean unanswered.
+		const root = makeWorkspace({
+			'agent_contract.json': {
+				topic: 'contract',
+				questions: {
+					a: question('a', 'contract', { answer: false }),
+					b: question('b', 'contract', { answer: 0 }),
+				},
+			},
+		});
+		assert.strictEqual(pendingQuestions(readChannels(root)).length, 0);
+	});
+
+	test('a malformed channel file is skipped, not fatal', () => {
+		const root = makeWorkspace({
+			'agent_config.json': { topic: 'config', questions: { a: question('a', 'config') } },
+		});
+		fs.writeFileSync(
+			path.join(root, '.vinv', 'exercise', 'agent_broken.json'),
+			'{ half-written',
+			'utf8',
+		);
+		const channels = readChannels(root);
+		assert.strictEqual(channels.length, 1);
+		assert.strictEqual(channels[0].topic, 'config');
+	});
+
+	test('a workspace with no channels yields nothing', () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), 'vinv-empty-'));
+		assert.deepStrictEqual(readChannels(root), []);
+	});
+});
+
+suite('reply parsing', () => {
+	test('a fenced reply is read', () => {
+		const answers = parseAnswers('Sure!\n```json\n{"answers": {"a": {"value": "x"}}}\n```\n');
+		assert.deepStrictEqual(answers, { a: { value: 'x' } });
+	});
+
+	test('a bare reply is read', () => {
+		assert.deepStrictEqual(parseAnswers('{"answers": {"a": 1}}'), { a: 1 });
+	});
+
+	test('nested objects do not truncate the parse', () => {
+		const answers = parseAnswers(
+			'{"answers": {"a": {"value": {"deep": [1, 2]}, "is_secret": false}}}',
+		);
+		assert.deepStrictEqual(answers, { a: { value: { deep: [1, 2] }, is_secret: false } });
+	});
+
+	test('a brace inside a string does not truncate the parse', () => {
+		const answers = parseAnswers('{"answers": {"a": {"value": "a } brace"}}}');
+		assert.deepStrictEqual(answers, { a: { value: 'a } brace' } });
+	});
+
+	test('prose with no json yields nothing rather than throwing', () => {
+		assert.deepStrictEqual(parseAnswers("I couldn't determine these."), {});
+		assert.deepStrictEqual(parseAnswers(''), {});
+	});
+
+	test('an object without an answers key is not mistaken for one', () => {
+		assert.deepStrictEqual(parseAnswers('{"value": "x"}'), {});
+	});
+});
+
+suite('writing answers back', () => {
+	test('answers land in the file the question came from', () => {
+		const root = makeWorkspace({
+			'agent_config.json': { topic: 'config', questions: { a: question('a', 'config') } },
+		});
+		const channels = readChannels(root);
+		assert.strictEqual(applyAnswers(channels, { a: { value: 'eu-west-2' } }), 1);
+
+		const doc = JSON.parse(
+			fs.readFileSync(path.join(root, '.vinv', 'exercise', 'agent_config.json'), 'utf8'),
+		);
+		assert.deepStrictEqual(doc.questions.a.answer, { value: 'eu-west-2' });
+	});
+
+	test('an existing answer is never overwritten', () => {
+		// The engine caches permanently and a human may have corrected one. A
+		// later model run must not silently undo that.
+		const root = makeWorkspace({
+			'agent_config.json': {
+				topic: 'config',
+				questions: { a: question('a', 'config', { answer: { value: 'human-said-this' } }) },
+			},
+		});
+		const channels = readChannels(root);
+		assert.strictEqual(applyAnswers(channels, { a: { value: 'model-guess' } }), 0);
+
+		const doc = JSON.parse(
+			fs.readFileSync(path.join(root, '.vinv', 'exercise', 'agent_config.json'), 'utf8'),
+		);
+		assert.deepStrictEqual(doc.questions.a.answer, { value: 'human-said-this' });
+	});
+
+	test('an answer for an unknown id is ignored', () => {
+		const root = makeWorkspace({
+			'agent_config.json': { topic: 'config', questions: { a: question('a', 'config') } },
+		});
+		assert.strictEqual(applyAnswers(readChannels(root), { nope: 1 }), 0);
+	});
+});
+
+suite('draining end to end', () => {
+	test('an empty queue runs no harness at all', async () => {
+		const root = makeWorkspace({
+			'agent_config.json': {
+				topic: 'config',
+				questions: { a: question('a', 'config', { answer: { value: 'x' } }) },
+			},
+		});
+		let ran = false;
+		const report = await drainAgentChannels(root, async () => {
+			ran = true;
+			return { ok: true, stdout: '' };
+		});
+		assert.strictEqual(ran, false, 'the harness was run with nothing to ask');
+		assert.strictEqual(report.pending, 0);
+		assert.strictEqual(report.ok, true);
+	});
+
+	test('pending questions are answered and reported', async () => {
+		const root = makeWorkspace({
+			'agent_config.json': { topic: 'config', questions: { a: question('a', 'config') } },
+			'agent_contract.json': { topic: 'contract', questions: { b: question('b', 'contract') } },
+		});
+		const report = await drainAgentChannels(root, async () => ({
+			ok: true,
+			stdout: '{"answers": {"a": {"value": "x"}, "b": {"content": "str"}}}',
+		}));
+		assert.strictEqual(report.answered, 2);
+		assert.deepStrictEqual(report.topics, ['config', 'contract']);
+		assert.strictEqual(pendingQuestions(readChannels(root)).length, 0);
+	});
+
+	test('every pending question goes in ONE run', async () => {
+		const questions: Record<string, unknown> = {};
+		for (const key of ['a', 'b', 'c', 'd']) {questions[key] = question(key, 'config');}
+		const root = makeWorkspace({ 'agent_config.json': { topic: 'config', questions } });
+
+		let runs = 0;
+		await drainAgentChannels(root, async () => {
+			runs++;
+			return { ok: true, stdout: '{"answers": {}}' };
+		});
+		assert.strictEqual(runs, 1, 'a run per question is a bill that grows with the repo');
+	});
+
+	test('a failed harness leaves the queue pending and says why', async () => {
+		const root = makeWorkspace({
+			'agent_config.json': { topic: 'config', questions: { a: question('a', 'config') } },
+		});
+		const report = await drainAgentChannels(root, async () => ({
+			ok: false,
+			stdout: '',
+			detail: 'cursor-agent is not signed in',
+		}));
+
+		assert.strictEqual(report.answered, 0);
+		assert.strictEqual(report.ok, false);
+		assert.match(report.detail, /not signed in/);
+		// The crucial part: nothing was invented to clear the queue.
+		assert.strictEqual(pendingQuestions(readChannels(root)).length, 1);
+	});
+
+	test('an unusable reply leaves the queue pending and says so', async () => {
+		const root = makeWorkspace({
+			'agent_config.json': { topic: 'config', questions: { a: question('a', 'config') } },
+		});
+		const report = await drainAgentChannels(root, async () => ({
+			ok: true,
+			stdout: "I don't know.",
+		}));
+		assert.strictEqual(report.answered, 0);
+		assert.strictEqual(report.ok, false);
+		assert.match(report.detail, /nothing usable/);
+		assert.strictEqual(pendingQuestions(readChannels(root)).length, 1);
+	});
+
+	test('a partially answered batch keeps the rest pending', async () => {
+		const root = makeWorkspace({
+			'agent_config.json': {
+				topic: 'config',
+				questions: { a: question('a', 'config'), b: question('b', 'config') },
+			},
+		});
+		await drainAgentChannels(root, async () => ({
+			ok: true,
+			stdout: '{"answers": {"a": {"value": "x"}}}',
+		}));
+		assert.deepStrictEqual(
+			pendingQuestions(readChannels(root)).map((q) => q.key),
+			['b'],
+		);
+	});
+});
+
+suite('the prompt', () => {
+	test('it carries each question id, prompt and reply shape', () => {
+		const prompt = buildPrompt([question('k1', 'config'), question('k2', 'contract')]);
+		assert.ok(prompt.includes('k1') && prompt.includes('k2'));
+		assert.ok(prompt.includes('what is k1?'));
+		assert.ok(prompt.includes('{"value": "<string>"}'));
+		assert.ok(prompt.includes('{"answers"'), 'the reply envelope must be stated');
+	});
+
+	test('it forbids guessing and forbids inventing credentials', () => {
+		const prompt = buildPrompt([question('k1', 'config')]);
+		assert.match(prompt, /omit its id entirely rather than guessing/);
+		assert.match(prompt, /Never invent a credential/);
+	});
+});

--- a/extension/src/test/cockpit.test.ts
+++ b/extension/src/test/cockpit.test.ts
@@ -581,7 +581,15 @@ suite('Episode telemetry (bandit over pack composition)', () => {
 		}
 	});
 
-	test('the loop LEARNS: Thompson selection + ledger update converges to the best arm', () => {
+	test('the loop LEARNS: Thompson selection + ledger update converges to the best arm', function () {
+		// 60 episodes, each of which LOADS the policy, appends two ledger events
+		// and rewrites the posterior — around 300 synchronous filesystem calls.
+		// That is inherent to the thing being tested (the ledger is the mechanism,
+		// so stubbing it would test nothing), and it is comfortably past mocha's
+		// 2s default on Windows, where each call carries the filter driver's
+		// overhead. A slow test is not a hanging one, and it was being reported as
+		// a hang.
+		this.timeout(60_000);
 		// The value-prop test — the old Bernstein-promotion policy never moved
 		// from its hand-coded prior in realistic use; this proves TS converges.
 		const previous = process.env.VINV_HOME;

--- a/extension/src/test/configRequestPanel.test.ts
+++ b/extension/src/test/configRequestPanel.test.ts
@@ -21,6 +21,7 @@ import * as path from 'path';
 import {
 	buildAnswers,
 	buildModel,
+	configAnswersPath,
 	getConfigPanelHtml,
 	handlePanelMessage,
 	readConfigRequests,
@@ -249,5 +250,43 @@ suite('the rendered form', () => {
 		const html = getConfigPanelHtml('vscode-resource://abc', { requests: [], repoLabel: 'd' });
 		assert.match(html, /Content-Security-Policy/);
 		assert.match(html, /vscode-resource:\/\/abc/);
+	});
+});
+
+suite('the answers file holds credentials, so it is owner-only', () => {
+	// `config_answers.json` is the one file under `.vinv/` whose entire content is
+	// secrets a human typed. The default 0644 makes it readable by every account
+	// on the machine; the standard other tools hold plaintext credentials to is
+	// 0600 (`~/.aws/credentials`, `~/.netrc`, which ssh and curl refuse when it is
+	// group-readable). Skipped on Windows, which has no POSIX mode bits.
+	const posix = process.platform !== 'win32';
+
+	test('a newly created answers file is 0600', function () {
+		if (!posix) {this.skip();}
+		const root = workspace([request('OPENAI_API_KEY', { secret: true })]);
+		writeAnswers(root, { OPENAI_API_KEY: 'sk-not-a-real-key' });
+		const mode = fs.statSync(configAnswersPath(root)).mode & 0o777;
+		assert.strictEqual(mode.toString(8), '600');
+	});
+
+	test('an answers file that already exists is tightened too', function () {
+		if (!posix) {this.skip();}
+		// `mode` on writeFileSync only applies when the file is CREATED, so a file
+		// left world-readable by an older version stays that way without the
+		// explicit chmod.
+		const root = workspace([request('OPENAI_API_KEY', { secret: true })]);
+		const target = configAnswersPath(root);
+		fs.mkdirSync(path.dirname(target), { recursive: true });
+		fs.writeFileSync(target, JSON.stringify({ version: 1, answers: {} }), { mode: 0o644 });
+
+		writeAnswers(root, { OPENAI_API_KEY: 'sk-not-a-real-key' });
+
+		assert.strictEqual((fs.statSync(target).mode & 0o777).toString(8), '600');
+	});
+
+	test('the value still round-trips', () => {
+		const root = workspace([request('OPENAI_API_KEY', { secret: true })]);
+		writeAnswers(root, { OPENAI_API_KEY: 'sk-not-a-real-key' });
+		assert.deepStrictEqual(readAnswers(root), { OPENAI_API_KEY: 'sk-not-a-real-key' });
 	});
 });

--- a/extension/src/test/configRequestPanel.test.ts
+++ b/extension/src/test/configRequestPanel.test.ts
@@ -1,0 +1,253 @@
+/**
+ * The human end of configuration escalation.
+ *
+ * Everything reaching this panel has already survived the engine trying not to
+ * need it: what the repo publishes, then induction from the target's own
+ * failure. So the ways this can be wrong are not "it looks bad" — they are:
+ *
+ *  - an empty field written as a VALUE, satisfying a presence check and failing
+ *    somewhere less obvious than where it would have failed honestly;
+ *  - a secret echoed back into the panel model, a log, or a status line;
+ *  - answers replaced rather than merged, losing what was answered yesterday;
+ *  - an answer saved that nothing acts on, so the user presses save and the
+ *    stall simply continues.
+ */
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+	buildAnswers,
+	buildModel,
+	getConfigPanelHtml,
+	handlePanelMessage,
+	readConfigRequests,
+	writeAnswers,
+	type ConfigPanelActions,
+	type ConfigRequest,
+} from '../views/configRequestPanel';
+
+function request(variable: string, extra: Partial<ConfigRequest> = {}): ConfigRequest {
+	return {
+		variable,
+		secret: false,
+		description: `what ${variable} is`,
+		example: null,
+		blocked_modules: ['app.core.config'],
+		blocked_count: 1,
+		tried: ['vinv-placeholder'],
+		reason: 'Field required',
+		status: 'awaiting-user',
+		...extra,
+	};
+}
+
+function workspace(requests: ConfigRequest[] | null): string {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'vinv-cfgpanel-'));
+	fs.mkdirSync(path.join(root, '.vinv', 'exercise'), { recursive: true });
+	if (requests !== null) {
+		fs.writeFileSync(
+			path.join(root, '.vinv', 'exercise', 'config_requests.json'),
+			JSON.stringify({ version: 1, requests }),
+			'utf8',
+		);
+	}
+	return root;
+}
+
+function readAnswers(root: string): Record<string, string> {
+	const doc = JSON.parse(
+		fs.readFileSync(path.join(root, '.vinv', 'exercise', 'config_answers.json'), 'utf8'),
+	) as { answers?: Record<string, string> };
+	return doc.answers ?? {};
+}
+
+suite('reading what is being asked', () => {
+	test('requests are read from the engine artifact', () => {
+		const root = workspace([request('PROJECT_NAME'), request('API_KEY', { secret: true })]);
+		assert.deepStrictEqual(
+			readConfigRequests(root).map((r) => r.variable),
+			['PROJECT_NAME', 'API_KEY'],
+		);
+	});
+
+	test('an absent artifact means nothing is being asked, not an error', () => {
+		assert.deepStrictEqual(readConfigRequests(workspace(null)), []);
+	});
+
+	test('an empty request list clears the panel', () => {
+		// The engine rewrites this file every run, including empty, so a stale
+		// prompt for a variable that is now satisfied cannot persist.
+		assert.deepStrictEqual(buildModel(workspace([])).requests, []);
+	});
+
+	test('a malformed artifact does not throw', () => {
+		const root = workspace([]);
+		fs.writeFileSync(
+			path.join(root, '.vinv', 'exercise', 'config_requests.json'),
+			'{ not json',
+			'utf8',
+		);
+		assert.deepStrictEqual(readConfigRequests(root), []);
+	});
+});
+
+suite('validating what was typed', () => {
+	test('a blank field is not written as a value', () => {
+		// An empty string IS a value: the engine would export it, satisfy the
+		// presence check, and fail somewhere less obvious.
+		const answers = buildAnswers([request('A'), request('B')], { A: '   ', B: 'real' });
+		assert.deepStrictEqual(answers, { B: 'real' });
+	});
+
+	test('values are trimmed', () => {
+		assert.deepStrictEqual(buildAnswers([request('A')], { A: '  x  ' }), { A: 'x' });
+	});
+
+	test('an answer for something not being asked is dropped', () => {
+		assert.deepStrictEqual(buildAnswers([request('A')], { A: '1', SNEAKY: '2' }), { A: '1' });
+	});
+});
+
+suite('persisting answers', () => {
+	test('answers land where the engine reads them', () => {
+		const root = workspace([request('PROJECT_NAME')]);
+		assert.strictEqual(writeAnswers(root, { PROJECT_NAME: 'demo' }), 1);
+		assert.deepStrictEqual(readAnswers(root), { PROJECT_NAME: 'demo' });
+	});
+
+	test('a later answer merges rather than replacing', () => {
+		// Answering two variables today and one tomorrow must not lose the first.
+		const root = workspace([request('A'), request('B')]);
+		writeAnswers(root, { A: '1' });
+		writeAnswers(root, { B: '2' });
+		assert.deepStrictEqual(readAnswers(root), { A: '1', B: '2' });
+	});
+
+	test('re-answering a variable updates it', () => {
+		const root = workspace([request('A')]);
+		writeAnswers(root, { A: 'wrong' });
+		writeAnswers(root, { A: 'right' });
+		assert.deepStrictEqual(readAnswers(root), { A: 'right' });
+	});
+});
+
+suite('the submit arm', () => {
+	function actions(root: string, log: string[]): ConfigPanelActions {
+		return {
+			save: (answers) => writeAnswers(root, answers),
+			rerun: async () => { log.push('rerun'); },
+			showError: (m) => log.push(`error:${m}`),
+		};
+	}
+
+	test('a filled form saves and re-runs', async () => {
+		// Saving without re-running is the same stall in a different place.
+		const root = workspace([request('A')]);
+		const log: string[] = [];
+		const outcome = await handlePanelMessage(
+			{ type: 'submit', values: { A: 'x' } },
+			[request('A')],
+			actions(root, log),
+		);
+		assert.strictEqual(outcome.saved, 1);
+		assert.strictEqual(outcome.reran, true);
+		assert.deepStrictEqual(log, ['rerun']);
+		assert.deepStrictEqual(readAnswers(root), { A: 'x' });
+	});
+
+	test('an entirely blank form re-runs nothing and says so', async () => {
+		const root = workspace([request('A')]);
+		const log: string[] = [];
+		const outcome = await handlePanelMessage(
+			{ type: 'submit', values: { A: '  ' } },
+			[request('A')],
+			actions(root, log),
+		);
+		assert.strictEqual(outcome.saved, 0);
+		assert.strictEqual(outcome.reran, false);
+		assert.ok(log[0].startsWith('error:'));
+	});
+
+	test('a failed write does not claim success and does not re-run', async () => {
+		const log: string[] = [];
+		const outcome = await handlePanelMessage({ type: 'submit', values: { A: 'x' } }, [request('A')], {
+			save: () => { throw new Error('disk full'); },
+			rerun: async () => { log.push('rerun'); },
+			showError: (m) => log.push(`error:${m}`),
+		});
+		assert.strictEqual(outcome.saved, 0);
+		assert.strictEqual(outcome.reran, false, 're-ran on answers that were never saved');
+		assert.ok(log.some((l) => l.includes('disk full')));
+	});
+
+	test('an unknown message is ignored', async () => {
+		const outcome = await handlePanelMessage({ type: 'noise' }, [request('A')], {
+			save: () => { throw new Error('should not be called'); },
+			rerun: async () => { throw new Error('should not be called'); },
+			showError: () => { throw new Error('should not be called'); },
+		});
+		assert.deepStrictEqual(outcome, { saved: 0, reran: false });
+	});
+});
+
+suite('the rendered form', () => {
+	test('a secret renders as a masked field and is marked', () => {
+		const html = getConfigPanelHtml('vscode-resource:', {
+			requests: [request('OPENAI_API_KEY', { secret: true })],
+			repoLabel: 'demo',
+		});
+		assert.match(html, /type="password"/);
+		assert.match(html, /badge secret/);
+	});
+
+	test('a non-secret renders as a plain field', () => {
+		const html = getConfigPanelHtml('vscode-resource:', {
+			requests: [request('PROJECT_NAME')],
+			repoLabel: 'demo',
+		});
+		assert.match(html, /type="text"/);
+		assert.doesNotMatch(html, /type="password"/);
+	});
+
+	test('the description, example and blocked modules are shown', () => {
+		const html = getConfigPanelHtml('vscode-resource:', {
+			requests: [
+				request('POSTGRES_SERVER', {
+					description: 'Database host the app connects to.',
+					example: 'localhost',
+					blocked_modules: ['app.core.db'],
+					blocked_count: 2,
+				}),
+			],
+			repoLabel: 'demo',
+		});
+		assert.match(html, /Database host the app connects to\./);
+		assert.match(html, /localhost/);
+		assert.match(html, /blocks 2 modules/);
+		assert.match(html, /app\.core\.db/);
+	});
+
+	test('html in a value cannot break out of the markup', () => {
+		const html = getConfigPanelHtml('vscode-resource:', {
+			requests: [request('X', { description: '<img src=x onerror=alert(1)>' })],
+			repoLabel: 'demo',
+		});
+		assert.doesNotMatch(html, /<img src=x/);
+		assert.match(html, /&lt;img src=x/);
+	});
+
+	test('nothing to configure renders an explanation, not an empty form', () => {
+		const html = getConfigPanelHtml('vscode-resource:', { requests: [], repoLabel: 'demo' });
+		assert.match(html, /Nothing to configure/);
+		assert.doesNotMatch(html, /<form/);
+	});
+
+	test('the csp source is honoured', () => {
+		const html = getConfigPanelHtml('vscode-resource://abc', { requests: [], repoLabel: 'd' });
+		assert.match(html, /Content-Security-Policy/);
+		assert.match(html, /vscode-resource:\/\/abc/);
+	});
+});

--- a/extension/src/test/exercisePassEndToEnd.test.ts
+++ b/extension/src/test/exercisePassEndToEnd.test.ts
@@ -1,0 +1,456 @@
+/**
+ * The whole loop: the extension's pass, the REAL engine, and the dispatch.
+ *
+ * `integrationPipeline.test.ts` drives the readers. This drives the
+ * ORCHESTRATION — which engine commands run, in what order, which failures are
+ * fatal, and whether findings are handed to the coding agent — against artifacts
+ * the engine actually produced rather than any this file wrote.
+ *
+ * That distinction is the whole reason this exists. Every other test on this
+ * side builds its own fixture, so it passes whether or not the engine emits that
+ * shape; and every test on the engine side asserts what it wrote, so it passes
+ * whether or not anything reads it. The pass returning BEFORE the dispatch block
+ * its own docstring said it reached survived both kinds for three rounds.
+ *
+ * The engine artifacts come from `exerciser/tests/test_integration_end_to_end.py`,
+ * which writes them under `src/test/fixtures/engine-artifacts/` on every run. If
+ * that directory is absent the artifact-backed tests SKIP rather than silently
+ * pass on a fixture nobody produced — a skip is visible, a fabricated pass is not.
+ */
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import type * as vscode from 'vscode';
+
+import {
+	dispatchFreshClusters,
+	exercisePassOnce,
+	readExerciseJson,
+	type ExerciseIssuesDoc,
+	type ExercisePassPorts,
+} from '../harness/exerciseRunner';
+
+// =========================================================================
+// Test doubles for the world outside the pass
+// =========================================================================
+
+interface EngineCall {
+	args: string[];
+	cwd: string;
+}
+
+interface Recorder {
+	calls: EngineCall[];
+	dispatched: Array<{ titles: string[]; trigger?: string }>;
+	drained: number;
+	ports: ExercisePassPorts;
+}
+
+/** Ports that record what the pass did, with everything succeeding by default. */
+function recorder(over: Partial<ExercisePassPorts> = {}): Recorder {
+	const calls: EngineCall[] = [];
+	const dispatched: Array<{ titles: string[]; trigger?: string }> = [];
+	let drained = 0;
+	const rec: Recorder = {
+		calls,
+		dispatched,
+		get drained() {
+			return drained;
+		},
+		ports: {
+			binAvailable: () => true,
+			binPath: () => path.join(os.tmpdir(), 'bin', 'exerciser'),
+			handbookEnv: () => ({}),
+			runEngine: async (_bin, args, cwd) => {
+				calls.push({ args, cwd });
+				return { ok: true };
+			},
+			// No service by default: the case the branch existed to fix.
+			pickTarget: () => null,
+			serviceRunning: () => false,
+			autoEpisodesEnabled: () => true,
+			dispatch: async (_ctx, _root, issues, opts) => {
+				dispatched.push({ titles: issues.map((i) => i.title), trigger: opts?.trigger });
+				return true;
+			},
+			drainChannels: async () => {
+				drained += 1;
+				return { pending: 0, answered: 0, topics: [], detail: 'no questions pending', ok: true };
+			},
+			...over,
+		},
+	} as Recorder;
+	return rec;
+}
+
+/** The slice of ExtensionContext the pass touches: a workspaceState memento. */
+function fakeContext(): vscode.ExtensionContext {
+	const store = new Map<string, unknown>();
+	return {
+		workspaceState: {
+			get: <T>(key: string, fallback?: T) => (store.has(key) ? (store.get(key) as T) : fallback),
+			update: async (key: string, value: unknown) => {
+				store.set(key, value);
+			},
+			keys: () => [...store.keys()],
+		},
+	} as unknown as vscode.ExtensionContext;
+}
+
+function workspace(files: Record<string, unknown> = {}): string {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'vinv-pass-'));
+	fs.mkdirSync(path.join(root, '.vinv', 'exercise'), { recursive: true });
+	for (const [name, doc] of Object.entries(files)) {
+		fs.writeFileSync(
+			path.join(root, '.vinv', 'exercise', name),
+			typeof doc === 'string' ? doc : JSON.stringify(doc, null, 2),
+			'utf8',
+		);
+	}
+	return root;
+}
+
+// =========================================================================
+// Artifacts the ENGINE wrote, not this file
+// =========================================================================
+
+const FIXTURE_DIR = path.join(__dirname, '..', '..', 'src', 'test', 'fixtures', 'engine-artifacts');
+
+function engineArtifacts(): Record<string, string> | null {
+	try {
+		const names = fs.readdirSync(FIXTURE_DIR).filter((n) => n.endsWith('.json'));
+		if (names.length === 0) {
+			return null;
+		}
+		return Object.fromEntries(
+			names.map((n) => [n, fs.readFileSync(path.join(FIXTURE_DIR, n), 'utf8')]),
+		);
+	} catch {
+		return null;
+	}
+}
+
+// =========================================================================
+// The service-free pass, which is what a library repo takes
+// =========================================================================
+
+suite('the exercise pass: nothing serving', () => {
+	test('runs the campaign, publishes, drains the channels and DISPATCHES', async () => {
+		const root = workspace({
+			'issues.json': {
+				cluster_count: 1,
+				clusters: [
+					{
+						signature: 'sig-crash-1',
+						kind: 'function-crash',
+						title: 'demo.pure:divide — ZeroDivisionError',
+						endpoint_id: 'demo.pure:divide',
+						method: 'CALL',
+						path: 'demo.pure:divide',
+					},
+				],
+			},
+			'campaign_result.json': { status: 'ok', diagnostics: [] },
+		});
+		const rec = recorder();
+
+		const result = await exercisePassOnce(fakeContext(), root, rec.ports);
+
+		assert.strictEqual(result.outcome, 'done');
+		// The HTTP-shaped commands must NOT run: there is no service.
+		const commands = rec.calls.map((c) => c.args[0]);
+		assert.deepStrictEqual(commands, ['campaign']);
+		assert.ok(
+			!rec.calls[0].args.includes('--base-url'),
+			'the HTTP oracle must stay unarmed with nothing serving',
+		);
+		// The regression this suite exists for: the pass returned before here.
+		assert.strictEqual(rec.dispatched.length, 1, 'findings were published and handed to nobody');
+		// The episode title is composed from the cluster's; assert it CARRIES the
+		// finding rather than pinning the composition, which is not this test's claim.
+		assert.match(rec.dispatched[0].titles[0], /demo\.pure:divide — ZeroDivisionError/);
+	});
+
+	test('a finding is dispatched once, not again on the next pass', async () => {
+		const files = {
+			'issues.json': {
+				cluster_count: 1,
+				clusters: [
+					{
+						signature: 'sig-stable',
+						kind: 'function-crash',
+						title: 'demo:fn — TypeError',
+						endpoint_id: 'demo:fn',
+						method: 'CALL',
+						path: 'demo:fn',
+					},
+				],
+			},
+		};
+		const root = workspace(files);
+		const context = fakeContext();
+		const rec = recorder();
+
+		await exercisePassOnce(context, root, rec.ports);
+		await exercisePassOnce(context, root, rec.ports);
+
+		assert.strictEqual(rec.dispatched.length, 1, 'the same defect was dispatched twice');
+	});
+
+	test('assert-shaped findings dispatch under their own trigger', async () => {
+		const root = workspace({
+			'issues.json': {
+				cluster_count: 2,
+				clusters: [
+					{
+						signature: 'a',
+						kind: 'function-crash',
+						title: 'raises',
+						endpoint_id: 'x:a',
+						method: 'CALL',
+						path: 'x:a',
+					},
+					{
+						signature: 'b',
+						kind: 'invariant-violation',
+						title: 'wrong value',
+						endpoint_id: 'x:b',
+						method: 'CALL',
+						path: 'x:b',
+					},
+				],
+			},
+		});
+		const rec = recorder();
+		await exercisePassOnce(fakeContext(), root, rec.ports);
+
+		const triggers = rec.dispatched.map((d) => d.trigger);
+		assert.ok(triggers.includes(undefined), 'the error-shaped batch uses the default trigger');
+		assert.ok(
+			triggers.includes('invariant-violation'),
+			'a silent wrong value needs value-shaped criteria, not "no longer raises"',
+		);
+	});
+
+	test('a failed campaign is reported and dispatches nothing', async () => {
+		const root = workspace({ 'issues.json': { cluster_count: 0, clusters: [] } });
+		const rec = recorder({ runEngine: async () => ({ ok: false, error: 'engine exploded' }) });
+
+		const result = await exercisePassOnce(fakeContext(), root, rec.ports);
+
+		assert.strictEqual(result.outcome, 'failed');
+		assert.match(String(result.error), /engine exploded/);
+		assert.strictEqual(rec.dispatched.length, 0);
+	});
+
+	test('a missing engine skips the pass rather than failing it', async () => {
+		const rec = recorder({ binAvailable: () => false });
+		const result = await exercisePassOnce(fakeContext(), workspace(), rec.ports);
+		assert.strictEqual(result.outcome, 'skipped');
+		assert.strictEqual(rec.calls.length, 0);
+	});
+
+	test('auto-episodes off means findings are published and not actioned', async () => {
+		const root = workspace({
+			'issues.json': {
+				cluster_count: 1,
+				clusters: [
+					{
+						signature: 's',
+						kind: 'function-crash',
+						title: 't',
+						endpoint_id: 'e',
+						method: 'CALL',
+						path: 'p',
+					},
+				],
+			},
+		});
+		const rec = recorder({ autoEpisodesEnabled: () => false });
+		const result = await exercisePassOnce(fakeContext(), root, rec.ports);
+		assert.strictEqual(result.outcome, 'done');
+		assert.strictEqual(rec.dispatched.length, 0);
+	});
+});
+
+// =========================================================================
+// The served pass, which is the original path
+// =========================================================================
+
+suite('the exercise pass: a service is up', () => {
+	test('drives the HTTP sequence in order and still dispatches', async () => {
+		const root = workspace({
+			'issues.json': {
+				cluster_count: 1,
+				clusters: [
+					{
+						signature: 'http-1',
+						kind: 'server-error',
+						title: 'GET /items — HTTP 500',
+						endpoint_id: 'GET_items',
+						method: 'GET',
+						path: '/items',
+					},
+				],
+			},
+			'profile.json': {
+				endpoint_count: 3,
+				endpoints_with_coverage: 2,
+				invariants_learned: 5,
+				total_symbols: 0,
+				total_symbols_covered: 0,
+				endpoints: [],
+			},
+		});
+		const rec = recorder({
+			pickTarget: () => ({ service: 'api', port: 8000 }),
+			serviceRunning: () => true,
+		});
+
+		const result = await exercisePassOnce(fakeContext(), root, rec.ports);
+
+		assert.strictEqual(result.outcome, 'done');
+		// plan → run → campaign → profile → scorecard. `campaign` runs AFTER `run`
+		// because `run` rewrites issues.json wholesale.
+		assert.deepStrictEqual(
+			rec.calls.map((c) => c.args[0]),
+			['plan', 'run', 'campaign', 'profile', 'scorecard'],
+		);
+		const campaign = rec.calls.find((c) => c.args[0] === 'campaign');
+		assert.ok(campaign?.args.includes('--base-url'), 'the HTTP oracle arms when a service is up');
+		assert.strictEqual(rec.dispatched.length, 1);
+		assert.strictEqual(result.invariants, 5, 'the profile is read back into the result');
+	});
+
+	test('a failed plan stops the pass before it can report coverage', async () => {
+		const rec = recorder({
+			pickTarget: () => ({ service: 'api', port: 8000 }),
+			serviceRunning: () => true,
+			runEngine: async (_b, args) => ({ ok: args[0] !== 'plan', error: 'plan blew up' }),
+		});
+		const result = await exercisePassOnce(fakeContext(), workspace(), rec.ports);
+		assert.strictEqual(result.outcome, 'failed');
+		assert.match(String(result.error), /plan blew up/);
+	});
+
+	test('a campaign failure does NOT discard the HTTP findings already earned', async () => {
+		const root = workspace({
+			'issues.json': {
+				cluster_count: 1,
+				clusters: [
+					{
+						signature: 'earned',
+						kind: 'server-error',
+						title: 'GET /x — HTTP 500',
+						endpoint_id: 'GET_x',
+						method: 'GET',
+						path: '/x',
+					},
+				],
+			},
+		});
+		const rec = recorder({
+			pickTarget: () => ({ service: 'api', port: 8000 }),
+			serviceRunning: () => true,
+			runEngine: async (_b, args) => ({
+				ok: args[0] !== 'campaign',
+				error: args[0] === 'campaign' ? 'campaign failed' : undefined,
+			}),
+		});
+
+		const result = await exercisePassOnce(fakeContext(), root, rec.ports);
+
+		assert.strictEqual(result.outcome, 'done', 'the earned findings were thrown away');
+		assert.strictEqual(rec.dispatched.length, 1);
+	});
+});
+
+// =========================================================================
+// Against artifacts the engine actually wrote
+// =========================================================================
+
+suite('the pass over REAL engine artifacts', () => {
+	test('every artifact the engine emitted is consumed without a hand-written fixture', async function () {
+		const artifacts = engineArtifacts();
+		if (!artifacts) {
+			// Visible rather than silent: the Python integration suite writes these.
+			this.skip();
+			return;
+		}
+		const root = workspace(artifacts);
+		const rec = recorder();
+
+		const result = await exercisePassOnce(fakeContext(), root, rec.ports);
+
+		assert.strictEqual(result.outcome, 'done');
+		const issues = readExerciseJson<ExerciseIssuesDoc>(root, 'issues.json');
+		if (issues && issues.cluster_count > 0) {
+			assert.strictEqual(
+				result.issues,
+				issues.cluster_count,
+				'the pass reported a different count than the engine wrote',
+			);
+			assert.ok(rec.dispatched.length >= 1, 'real findings reached nobody');
+		}
+	});
+
+	test('the engine-written verdict is what the pass publishes', function () {
+		const artifacts = engineArtifacts();
+		if (!artifacts?.['campaign_result.json']) {
+			this.skip();
+			return;
+		}
+		const doc = JSON.parse(artifacts['campaign_result.json']) as {
+			status?: string;
+			diagnostics?: string[];
+		};
+		// The two fields `engineVerdict` reads, asserted against what the engine
+		// really emitted rather than against a shape this file invented.
+		assert.ok(typeof doc.status === 'string', 'the engine stopped emitting `status`');
+		assert.ok(Array.isArray(doc.diagnostics), 'the engine stopped emitting `diagnostics`');
+	});
+});
+
+// =========================================================================
+// The dispatch selection itself
+// =========================================================================
+
+suite('what becomes an episode', () => {
+	test('a diagnostic-only kind is never actioned', async () => {
+		const root = workspace({
+			'issues.json': {
+				cluster_count: 1,
+				clusters: [
+					{
+						signature: 'drift',
+						kind: 'signature-drift',
+						title: 'upstream changed its API',
+						endpoint_id: 'dep:fn',
+						method: 'CALL',
+						path: 'dep:fn',
+					},
+				],
+			},
+		});
+		const rec = recorder();
+		await dispatchFreshClusters(
+			fakeContext(),
+			root,
+			readExerciseJson<ExerciseIssuesDoc>(root, 'issues.json'),
+			rec.ports,
+		);
+		// There is no edit to this repo that fixes an upstream API change; a fix
+		// budget spent on one is spent on something unresolvable.
+		const titles = rec.dispatched.flatMap((d) => d.titles).join(' | ');
+		assert.ok(!titles.includes('upstream changed its API'), titles);
+	});
+
+	test('nothing to report dispatches nothing and still completes', async () => {
+		const root = workspace({ 'issues.json': { cluster_count: 0, clusters: [] } });
+		const rec = recorder();
+		const result = await exercisePassOnce(fakeContext(), root, rec.ports);
+		assert.strictEqual(result.outcome, 'done');
+		assert.strictEqual(rec.dispatched.length, 0);
+	});
+});

--- a/extension/src/test/exerciseWiring.test.ts
+++ b/extension/src/test/exerciseWiring.test.ts
@@ -1,4 +1,7 @@
 import * as assert from 'assert';
+import * as fsx from 'fs';
+import * as osx from 'os';
+import * as pathx from 'path';
 import {
 	applyStageOutcome,
 	decideOnStageFailure,
@@ -15,6 +18,7 @@ import {
 	isAssertShapedKind,
 	isDispatchableKind,
 	evidenceFileForKind,
+	engineVerdict,
 	ASSERT_SUCCESS_CRITERIA,
 } from '../harness/exerciseRunner';
 import { computeFlowModel, type FlowFacts } from '../views/flowModel';
@@ -219,5 +223,62 @@ suite('exercise facts render into the Verify stage', () => {
 		const verify = model.stages.find((s) => s.id === 'verify');
 		assert.ok(verify);
 		assert.ok(!verify.links.some((l) => l.label.includes('Behavior coverage')));
+	});
+});
+
+/**
+ * The reading end of `functions.json`.
+ *
+ * The engine refuses to call a run clean when it could not import the code —
+ * `status: "environment"` plus a diagnostic naming the cause. The CLI prints
+ * those loudly; the extension read neither, so in the product a run that never
+ * executed the target rendered as "drove the service-free oracles" with zero
+ * issues. That is the silent zero the engine-side work exists to remove,
+ * reproduced one layer up.
+ */
+suite('the engine verdict reaches the UI', () => {
+	function workspaceWith(doc: unknown | null): string {
+		const root = fsx.mkdtempSync(pathx.join(osx.tmpdir(), 'vinv-verdict-'));
+		fsx.mkdirSync(pathx.join(root, '.vinv', 'exercise'), { recursive: true });
+		if (doc !== null) {
+			fsx.writeFileSync(
+				pathx.join(root, '.vinv', 'exercise', 'functions.json'),
+				JSON.stringify(doc),
+				'utf8',
+			);
+		}
+		return root;
+	}
+
+	test('an environment failure is stated, not rendered as a clean run', () => {
+		const root = workspaceWith({
+			status: 'environment',
+			diagnostics: ['14/15 module(s) could not be imported by /usr/bin/python3'],
+		});
+		const verdict = engineVerdict(root, 0);
+		assert.match(verdict, /could not be imported/);
+		assert.doesNotMatch(verdict, /no issues found/);
+	});
+
+	test('an environment failure with no diagnostic still says nothing was exercised', () => {
+		const verdict = engineVerdict(workspaceWith({ status: 'environment' }), 0);
+		assert.match(verdict, /nothing was exercised/);
+	});
+
+	test('a diagnostic on an ok run is surfaced too', () => {
+		const root = workspaceWith({
+			status: 'ok',
+			diagnostics: ['2 environment variable(s) were escalated: VINV_REGION'],
+		});
+		assert.match(engineVerdict(root, 3), /escalated: VINV_REGION/);
+	});
+
+	test('a genuinely clean run says so', () => {
+		const verdict = engineVerdict(workspaceWith({ status: 'ok', diagnostics: [] }), 0);
+		assert.match(verdict, /no issues found/);
+	});
+
+	test('a missing artifact degrades to the plain label rather than throwing', () => {
+		assert.strictEqual(typeof engineVerdict(workspaceWith(null), 0), 'string');
 	});
 });

--- a/extension/src/test/exerciseWiring.test.ts
+++ b/extension/src/test/exerciseWiring.test.ts
@@ -282,3 +282,49 @@ suite('the engine verdict reaches the UI', () => {
 		assert.strictEqual(typeof engineVerdict(workspaceWith(null), 0), 'string');
 	});
 });
+
+suite('the verdict describes the run, not the last play', () => {
+	function workspace(files: Record<string, unknown>): string {
+		const root = fsx.mkdtempSync(pathx.join(osx.tmpdir(), 'vinv-verdict2-'));
+		fsx.mkdirSync(pathx.join(root, '.vinv', 'exercise'), { recursive: true });
+		for (const [name, doc] of Object.entries(files)) {
+			fsx.writeFileSync(
+				pathx.join(root, '.vinv', 'exercise', name),
+				JSON.stringify(doc),
+				'utf8',
+			);
+		}
+		return root;
+	}
+
+	test('campaign_result.json wins over functions.json', () => {
+		// `functions.json` is rewritten by every crash play with
+		// `only_targets=[one]`, so its `status` is computed over a SINGLE module.
+		// One unimportable target made the extension announce that the whole run
+		// never executed.
+		const root = workspace({
+			'functions.json': { status: 'environment', diagnostics: ['one target failed to import'] },
+			'campaign_result.json': { status: 'ok', diagnostics: [] },
+		});
+		assert.doesNotMatch(engineVerdict(root, 0), /could not be imported/);
+		assert.match(engineVerdict(root, 0), /no issues found/);
+	});
+
+	test('and states the campaign-level environment failure when there is one', () => {
+		const root = workspace({
+			'functions.json': { status: 'ok', diagnostics: [] },
+			'campaign_result.json': {
+				status: 'environment',
+				diagnostics: ['4/4 plays could not import the repo\'s own package(s) acme_core'],
+			},
+		});
+		assert.match(engineVerdict(root, 0), /could not import the repo/);
+	});
+
+	test('functions.json is still the fallback for a direct `exerciser functions` run', () => {
+		const root = workspace({
+			'functions.json': { status: 'environment', diagnostics: ['nothing imported'] },
+		});
+		assert.match(engineVerdict(root, 0), /nothing imported/);
+	});
+});

--- a/extension/src/test/fixtures/engine-artifacts/campaign_result.json
+++ b/extension/src/test/fixtures/engine-artifacts/campaign_result.json
@@ -8,7 +8,7 @@
     "fault oracle skipped 2 target(s): no annotated parameter to derive a contract from"
   ],
   "interpreter": {
-    "python": "C:\\Anshul\\VinvAI\\vinv\\.venv\\Scripts\\python.exe",
+    "python": "<python>",
     "origin": "vinv's own interpreter",
     "handed_off": false,
     "python_version": "3.13.14",
@@ -26,7 +26,7 @@
     ],
     "considered": [
       {
-        "python": "C:\\Anshul\\VinvAI\\vinv\\.venv\\Scripts\\python.exe",
+        "python": "<python>",
         "origin": "vinv's own interpreter",
         "detail": "fallback",
         "ok": true,
@@ -37,7 +37,7 @@
       }
     ]
   },
-  "repo": "C:\\Users\\SERVER\\AppData\\Local\\Temp\\pytest-of-SERVER\\pytest-344\\demo-repo0",
+  "repo": "<repo>",
   "actions": 15,
   "armed": {
     "concurrency": 5,
@@ -60,7 +60,7 @@
       "plays": 2,
       "violations": 0,
       "coverage_sum": 2,
-      "cost_sum": 4.8897,
+      "cost_sum": 5.4969,
       "posterior_mean": 0.375
     },
     "deterministic": {
@@ -74,7 +74,7 @@
       "plays": 2,
       "violations": 1,
       "coverage_sum": 1,
-      "cost_sum": 7.5142,
+      "cost_sum": 8.0031,
       "posterior_mean": 0.4
     }
   },
@@ -83,7 +83,7 @@
       "plays": 2,
       "violations": 1,
       "coverage_sum": 1,
-      "cost_sum": 7.5142,
+      "cost_sum": 8.0031,
       "posterior_mean": 0.4
     },
     "crash": {
@@ -97,7 +97,7 @@
       "plays": 2,
       "violations": 0,
       "coverage_sum": 2,
-      "cost_sum": 4.8897,
+      "cost_sum": 5.4969,
       "posterior_mean": 0.375
     }
   },
@@ -106,5 +106,5 @@
     "technique": "deterministic",
     "oracle": "crash"
   },
-  "campaign_file": "C:\\Users\\SERVER\\AppData\\Local\\Temp\\pytest-of-SERVER\\pytest-344\\demo-repo0\\.vinv\\exercise\\campaign.json"
+  "campaign_file": "<repo>\\.vinv\\exercise\\campaign.json"
 }

--- a/extension/src/test/fixtures/engine-artifacts/campaign_result.json
+++ b/extension/src/test/fixtures/engine-artifacts/campaign_result.json
@@ -1,0 +1,110 @@
+{
+  "status": "ok",
+  "own_packages_unimportable": [],
+  "diagnostics": [
+    "no --base-url \u2014 the HTTP oracle is not armed",
+    "no differential references proposed \u2014 the differential oracle is not armed",
+    "no boundaries.json \u2014 derived 3 boundary(ies) from the consumers' own annotations, and refused 2",
+    "fault oracle skipped 2 target(s): no annotated parameter to derive a contract from"
+  ],
+  "interpreter": {
+    "python": "C:\\Anshul\\VinvAI\\vinv\\.venv\\Scripts\\python.exe",
+    "origin": "vinv's own interpreter",
+    "handed_off": false,
+    "python_version": "3.13.14",
+    "target_installed": false,
+    "repo_distributions": {
+      "declared": 1,
+      "present": 0
+    },
+    "third_party": {
+      "declared": 1,
+      "present": 1
+    },
+    "missing_sample": [
+      "demo-app"
+    ],
+    "considered": [
+      {
+        "python": "C:\\Anshul\\VinvAI\\vinv\\.venv\\Scripts\\python.exe",
+        "origin": "vinv's own interpreter",
+        "detail": "fallback",
+        "ok": true,
+        "python_version": "3.13.14",
+        "repo_distributions_present": "0/1",
+        "third_party_present": "1/1",
+        "error": null
+      }
+    ]
+  },
+  "repo": "C:\\Users\\SERVER\\AppData\\Local\\Temp\\pytest-of-SERVER\\pytest-344\\demo-repo0",
+  "actions": 15,
+  "armed": {
+    "concurrency": 5,
+    "crash": 7,
+    "differential": 0,
+    "fault": 3
+  },
+  "budget": 4,
+  "plays_run": 4,
+  "inconclusive_plays": 0,
+  "issues_merged": 1,
+  "warm_started_arms": 4,
+  "violations": 1,
+  "repeat_violations": 0,
+  "credited_signatures": 1,
+  "new_ground": 3,
+  "stopped": "budget-exhausted",
+  "by_technique": {
+    "contract-faults": {
+      "plays": 2,
+      "violations": 0,
+      "coverage_sum": 2,
+      "cost_sum": 4.8897,
+      "posterior_mean": 0.375
+    },
+    "deterministic": {
+      "plays": 0,
+      "violations": 0,
+      "coverage_sum": 0,
+      "cost_sum": 0.0,
+      "posterior_mean": 0.4839
+    },
+    "schedule": {
+      "plays": 2,
+      "violations": 1,
+      "coverage_sum": 1,
+      "cost_sum": 7.5142,
+      "posterior_mean": 0.4
+    }
+  },
+  "by_oracle": {
+    "concurrency": {
+      "plays": 2,
+      "violations": 1,
+      "coverage_sum": 1,
+      "cost_sum": 7.5142,
+      "posterior_mean": 0.4
+    },
+    "crash": {
+      "plays": 0,
+      "violations": 0,
+      "coverage_sum": 0,
+      "cost_sum": 0.0,
+      "posterior_mean": 0.4839
+    },
+    "fault": {
+      "plays": 2,
+      "violations": 0,
+      "coverage_sum": 2,
+      "cost_sum": 4.8897,
+      "posterior_mean": 0.375
+    }
+  },
+  "preferred": {
+    "target": "demo.pure:add",
+    "technique": "deterministic",
+    "oracle": "crash"
+  },
+  "campaign_file": "C:\\Users\\SERVER\\AppData\\Local\\Temp\\pytest-of-SERVER\\pytest-344\\demo-repo0\\.vinv\\exercise\\campaign.json"
+}

--- a/extension/src/test/fixtures/engine-artifacts/functions.json
+++ b/extension/src/test/fixtures/engine-artifacts/functions.json
@@ -1,0 +1,168 @@
+{
+  "status": "ok",
+  "import_canary": {
+    "own_packages_unimportable": [],
+    "modules_failed": 0,
+    "modules_attempted": 1,
+    "blocking": false
+  },
+  "interpreter": {
+    "python": "C:\\Anshul\\VinvAI\\vinv\\.venv\\Scripts\\python.exe",
+    "origin": "vinv's own interpreter",
+    "handed_off": false,
+    "python_version": "3.13.14",
+    "target_installed": false,
+    "repo_distributions": {
+      "declared": 1,
+      "present": 0
+    },
+    "third_party": {
+      "declared": 1,
+      "present": 1
+    },
+    "missing_sample": [
+      "demo-app"
+    ],
+    "considered": [
+      {
+        "python": "C:\\Anshul\\VinvAI\\vinv\\.venv\\Scripts\\python.exe",
+        "origin": "vinv's own interpreter",
+        "detail": "fallback",
+        "ok": true,
+        "python_version": "3.13.14",
+        "repo_distributions_present": "0/1",
+        "third_party_present": "1/1",
+        "error": null
+      }
+    ]
+  },
+  "import_preconditions": [],
+  "workdir_resolutions": [],
+  "env_inductions": [],
+  "config_requests": [],
+  "config_supplied_by_harness": [],
+  "config_channel": {
+    "topic": "config",
+    "asked_this_run": 0,
+    "pending": 0,
+    "answered": 0,
+    "overflow": 0,
+    "file": "C:\\Users\\SERVER\\AppData\\Local\\Temp\\pytest-of-SERVER\\pytest-344\\demo-repo0\\.vinv\\exercise\\agent_config.json"
+  },
+  "blocked_imports_asked": [],
+  "blocked_channel": {
+    "topic": "blocked-import",
+    "asked_this_run": 0,
+    "pending": 0,
+    "answered": 0,
+    "overflow": 0,
+    "file": "C:\\Users\\SERVER\\AppData\\Local\\Temp\\pytest-of-SERVER\\pytest-344\\demo-repo0\\.vinv\\exercise\\agent_blocked-import.json"
+  },
+  "diagnostics": [],
+  "repo": "C:\\Users\\SERVER\\AppData\\Local\\Temp\\pytest-of-SERVER\\pytest-344\\demo-repo0",
+  "service": null,
+  "targets": 1,
+  "modules": 1,
+  "calls": 3,
+  "errors": 0,
+  "verdicts": {
+    "ok": 3
+  },
+  "substitution_gaps": [],
+  "exception_policy": {
+    "TypeError@stdlib": {
+      "defect_probability": 0.055,
+      "confident": false,
+      "label_mass": 0.0,
+      "targets": 1,
+      "occurrences": 1
+    },
+    "ZeroDivisionError@stdlib": {
+      "defect_probability": 0.335,
+      "confident": false,
+      "label_mass": 0.0,
+      "targets": 1,
+      "occurrences": 1
+    }
+  },
+  "surfaced_by_exploration": [],
+  "module_timeouts": [],
+  "skipped": [
+    {
+      "id": "demo.impure:record",
+      "reason": "impure-body: indirect call target \u2014 cannot verify"
+    },
+    {
+      "id": "demo.provider:ask",
+      "reason": "impure-body: calls .json() on reply, built by requests.post(); calls requests.post()"
+    }
+  ],
+  "skipped_count": 2,
+  "sandbox": {
+    "enabled": true,
+    "status": "ok",
+    "reason": "no impurity-only refusals to drive",
+    "policy": {
+      "enabled": true,
+      "max_copy_mb": 256.0,
+      "address_space_mb": 2048,
+      "max_open_files": 512,
+      "max_processes": null,
+      "block_network": true,
+      "block_subprocess": true,
+      "block_escaping_writes": true,
+      "honour_gitignore": false,
+      "synthesize_services": true,
+      "seed_rows": 1,
+      "require_tier": null,
+      "max_tier": null
+    },
+    "tier": "process-shim",
+    "containment": {
+      "tier": "process-shim",
+      "mechanism": "python-shim",
+      "tool": null,
+      "blocks_writes_outside_root": false,
+      "blocks_network": false,
+      "effects_complete": false,
+      "detail": "generated sitecustomize patches the Python entry points; the durable guarantee is the disposable tree and the copied repo",
+      "checks": [
+        "shim-loaded-in-worker"
+      ],
+      "fallback_reason": "no OS containment mechanism is known for platform 'win32'",
+      "guarantees": {
+        "writes_outside_root": "intercepted at the Python level (open/os.open/os.* family); a C extension calling open(2) is NOT stopped",
+        "network": "intercepted at the Python level (socket/ssl); a C extension calling connect(2) is NOT stopped",
+        "subprocess": "intercepted at the Python level (subprocess/os.exec*/os.spawn*)",
+        "effect_ledger": "INCOMPLETE wherever the static guard predicted C-level I/O \u2014 an empty effects map means 'we could not see', not 'nothing happened'"
+      },
+      "candidates": []
+    },
+    "effects_complete": false,
+    "candidates": 0,
+    "targets": 0,
+    "modules": 0,
+    "calls": 0,
+    "verdicts": {},
+    "copy": null,
+    "root": null,
+    "root_removed": false,
+    "effects": [],
+    "effect_totals": {
+      "filesystem": 0,
+      "filesystem-escape": 0,
+      "network": 0,
+      "subprocess": 0,
+      "os-denied": 0,
+      "substitution-gap": 0
+    },
+    "unobservable": [],
+    "unobservable_totals": {},
+    "filesystem_delta": [],
+    "module_timeouts": [],
+    "refused": []
+  },
+  "issue_clusters": 0,
+  "clusters": [],
+  "results_file": "C:\\Users\\SERVER\\AppData\\Local\\Temp\\pytest-of-SERVER\\pytest-344\\demo-repo0\\.vinv\\exercise\\function_results.jsonl"
+}

--- a/extension/src/test/fixtures/engine-artifacts/functions.json
+++ b/extension/src/test/fixtures/engine-artifacts/functions.json
@@ -7,7 +7,7 @@
     "blocking": false
   },
   "interpreter": {
-    "python": "C:\\Anshul\\VinvAI\\vinv\\.venv\\Scripts\\python.exe",
+    "python": "<python>",
     "origin": "vinv's own interpreter",
     "handed_off": false,
     "python_version": "3.13.14",
@@ -25,7 +25,7 @@
     ],
     "considered": [
       {
-        "python": "C:\\Anshul\\VinvAI\\vinv\\.venv\\Scripts\\python.exe",
+        "python": "<python>",
         "origin": "vinv's own interpreter",
         "detail": "fallback",
         "ok": true,
@@ -47,7 +47,7 @@
     "pending": 0,
     "answered": 0,
     "overflow": 0,
-    "file": "C:\\Users\\SERVER\\AppData\\Local\\Temp\\pytest-of-SERVER\\pytest-344\\demo-repo0\\.vinv\\exercise\\agent_config.json"
+    "file": "<repo>\\.vinv\\exercise\\agent_config.json"
   },
   "blocked_imports_asked": [],
   "blocked_channel": {
@@ -56,10 +56,10 @@
     "pending": 0,
     "answered": 0,
     "overflow": 0,
-    "file": "C:\\Users\\SERVER\\AppData\\Local\\Temp\\pytest-of-SERVER\\pytest-344\\demo-repo0\\.vinv\\exercise\\agent_blocked-import.json"
+    "file": "<repo>\\.vinv\\exercise\\agent_blocked-import.json"
   },
   "diagnostics": [],
-  "repo": "C:\\Users\\SERVER\\AppData\\Local\\Temp\\pytest-of-SERVER\\pytest-344\\demo-repo0",
+  "repo": "<repo>",
   "service": null,
   "targets": 1,
   "modules": 1,
@@ -164,5 +164,5 @@
   },
   "issue_clusters": 0,
   "clusters": [],
-  "results_file": "C:\\Users\\SERVER\\AppData\\Local\\Temp\\pytest-of-SERVER\\pytest-344\\demo-repo0\\.vinv\\exercise\\function_results.jsonl"
+  "results_file": "<repo>\\.vinv\\exercise\\function_results.jsonl"
 }

--- a/extension/src/test/fixtures/engine-artifacts/issues.json
+++ b/extension/src/test/fixtures/engine-artifacts/issues.json
@@ -1,0 +1,24 @@
+{
+  "version": 1,
+  "cluster_count": 1,
+  "clusters": [
+    {
+      "signature": "4f73c3ec3b975da40bc3c07d",
+      "kind": "import-error",
+      "title": "demo.settings_dump:region \u2014 ValueError: 1 validation error for Settings\nDEMO_REGION\n  Field required [type=missing, input_value={}]",
+      "endpoint_id": "demo.settings_dump:region",
+      "method": "CONC",
+      "path": "demo.settings_dump:region",
+      "count": 1,
+      "exemplar": {
+        "input": null,
+        "strategy": "concurrency/schedule",
+        "status": null,
+        "error": "ValueError: 1 validation error for Settings\nDEMO_REGION\n  Field required [type=missing, input_value={}]",
+        "detail": "ValueError: 1 validation error for Settings\nDEMO_REGION\n  Field required [type=missing, input_value={}]",
+        "expected": "concurrent calls agree with the serial baseline and all return"
+      },
+      "covered_frames": []
+    }
+  ]
+}

--- a/extension/src/test/integrationPipeline.test.ts
+++ b/extension/src/test/integrationPipeline.test.ts
@@ -1,0 +1,486 @@
+/**
+ * The extension half of the end-to-end contract, driven over REAL artifact shapes.
+ *
+ * `exerciser/tests/test_integration_end_to_end.py` runs the engine and asserts
+ * that what it writes carries the fields this side reads. This is the other end
+ * of that handshake: it lays down artifacts in the exact shape the engine
+ * produces and drives the extension's readers over them — the scheduler, the
+ * verdict, the dispatch selection, the agent-channel drain and the config panel
+ * — so a stage that stopped consuming its input fails here rather than in
+ * production.
+ *
+ * Why it is written this way: this branch hit the same defect five times, a
+ * producer whose output nothing consumes, with BOTH ends reporting success.
+ * Neither a writer-side test nor a reader-side test catches that; only a test
+ * that fixes the shape once and runs both sides against it does.
+ */
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+	applyStageOutcome,
+	initialPipelineLedger,
+	planPipelineAction,
+	settleUnreachableStages,
+	type ServiceState,
+} from '../harness/autoPilotMachine';
+import {
+	engineVerdict,
+	exerciseStateFromArtifacts,
+	isAssertShapedKind,
+	isDispatchableKind,
+	issueEpisodesFromClusters,
+	type ExerciseIssuesDoc,
+} from '../harness/exerciseRunner';
+import {
+	applyAnswers,
+	buildPrompt,
+	drainAgentChannels,
+	parseAnswers,
+	pendingQuestions,
+	readChannels,
+} from '../harness/agentChannel';
+import {
+	buildAnswers,
+	buildModel,
+	configAnswersPath,
+	getConfigPanelHtml,
+	handlePanelMessage,
+	readConfigRequests,
+	writeAnswers,
+	type ConfigPanelActions,
+} from '../views/configRequestPanel';
+
+// =========================================================================
+// A workspace holding exactly what the engine writes
+// =========================================================================
+
+/** Artifacts in the shape `exerciser` produces them, keyed by filename. */
+function workspace(files: Record<string, unknown>): string {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'vinv-e2e-'));
+	fs.mkdirSync(path.join(root, '.vinv', 'exercise'), { recursive: true });
+	for (const [name, doc] of Object.entries(files)) {
+		fs.writeFileSync(
+			path.join(root, '.vinv', 'exercise', name),
+			JSON.stringify(doc, null, 2),
+			'utf8',
+		);
+	}
+	return root;
+}
+
+/** A cluster exactly as `issues.build_clusters` emits one. */
+function cluster(over: Record<string, unknown> = {}): Record<string, unknown> {
+	return {
+		signature: 'a1b2c3d4e5f6',
+		kind: 'function-crash',
+		title: 'demo.pure:divide — ZeroDivisionError: division by zero',
+		endpoint_id: 'demo.pure:divide',
+		method: 'CALL',
+		path: 'demo.pure:divide',
+		exemplar: { strategy: 'function/boundary', error: 'division by zero' },
+		...over,
+	};
+}
+
+/**
+ * An `issues.json` exactly as `issues.publish` writes one.
+ *
+ * It carries `cluster_count` AND `clusters`, and the extension reads the first.
+ * Building the fixture by hand with only `clusters` is how a reader-side test
+ * passes against a document the writer never produced — so this is the one
+ * place the shape is written down.
+ */
+function issuesDoc(clusters: Record<string, unknown>[]): Record<string, unknown> {
+	return {
+		source: 'exerciser',
+		generated_at: '2026-07-28T00:00:00Z',
+		ingested_by: 'campaign',
+		cluster_count: clusters.length,
+		clusters,
+	};
+}
+
+/** A campaign summary as `run_campaign` persists it. */
+function campaignResult(over: Record<string, unknown> = {}): Record<string, unknown> {
+	return {
+		status: 'ok',
+		own_packages_unimportable: [],
+		diagnostics: [],
+		interpreter: { python: '/usr/bin/python3', handed_off: false, target_installed: true },
+		repo: '/repo',
+		actions: 12,
+		plays_run: 8,
+		inconclusive_plays: 0,
+		issues_merged: 1,
+		violations: 1,
+		stopped: 'budget-exhausted',
+		...over,
+	};
+}
+
+// =========================================================================
+// Stage 1 — the scheduler reaches the oracles on a library workspace
+// =========================================================================
+
+function svc(over: Partial<ServiceState> = {}): ServiceState {
+	return { name: 'api', phase: 'green', setupAttempts: 0, fixEpisodes: {}, ...over };
+}
+
+suite('end to end: a workspace with nothing to serve still gets exercised', () => {
+	test('discovery → exercise → done, with the live-session stages settled', () => {
+		const libraries = [svc({ phase: 'library' }), svc({ name: 'b', phase: 'gave-up' })];
+		let ledger = settleUnreachableStages(libraries, initialPipelineLedger());
+
+		// insights and probes read a traced session; there is none, so they are
+		// DECIDED rather than left looking like outstanding work.
+		assert.strictEqual(ledger.insights, 'skipped');
+		assert.strictEqual(ledger.probes, 'skipped');
+
+		// The one stage that needs no port is the one that runs.
+		assert.deepStrictEqual(planPipelineAction(true, libraries, ledger), { kind: 'exercise' });
+		ledger = applyStageOutcome(ledger, 'exercise', 'done');
+		assert.deepStrictEqual(planPipelineAction(true, libraries, ledger), { kind: 'done' });
+	});
+
+	test('a green service still drains insights and probes first', () => {
+		const green = [svc({ phase: 'green' })];
+		const ledger = settleUnreachableStages(green, initialPipelineLedger());
+		assert.deepStrictEqual(planPipelineAction(true, green, ledger), { kind: 'insights' });
+	});
+});
+
+// =========================================================================
+// Stage 2 — the verdict describes the run
+// =========================================================================
+
+suite('end to end: what the run concluded reaches the surface', () => {
+	test('a clean campaign reads as clean', () => {
+		const root = workspace({
+			'campaign_result.json': campaignResult(),
+			'issues.json': issuesDoc([]),
+		});
+		assert.match(engineVerdict(root, 0), /no issues found/);
+	});
+
+	test('an environment failure is never rendered as a clean run', () => {
+		const root = workspace({
+			'campaign_result.json': campaignResult({
+				status: 'environment',
+				own_packages_unimportable: ['demo'],
+				diagnostics: ["8/8 plays could not import the repo's own package(s) demo"],
+			}),
+			'issues.json': { clusters: [] },
+		});
+		const verdict = engineVerdict(root, 0);
+		assert.match(verdict, /could not import/);
+		assert.doesNotMatch(verdict, /no issues found/);
+	});
+
+	test('the RUN outranks the last play', () => {
+		// `functions.json` is rewritten by every crash play with a single target,
+		// so its status describes one arm. Reading it as the run's verdict was the
+		// bug; `campaign_result.json` is the run.
+		const root = workspace({
+			'functions.json': { status: 'environment', diagnostics: ['one target failed'] },
+			'campaign_result.json': campaignResult(),
+			'issues.json': issuesDoc([]),
+		});
+		assert.doesNotMatch(engineVerdict(root, 0), /one target failed/);
+	});
+
+	test('a direct `exerciser functions` run still has a verdict', () => {
+		const root = workspace({
+			'functions.json': { status: 'environment', diagnostics: ['nothing imported'] },
+		});
+		assert.match(engineVerdict(root, 0), /nothing imported/);
+	});
+
+	test('the state the UI renders is built from the same artifacts', () => {
+		const root = workspace({ 'issues.json': issuesDoc([cluster()]) });
+		const issues = JSON.parse(
+			fs.readFileSync(path.join(root, '.vinv', 'exercise', 'issues.json'), 'utf8'),
+		) as ExerciseIssuesDoc;
+		// The reader takes `cluster_count`, so the writer has to emit it — asserted
+		// here rather than assumed, because a fixture carrying only `clusters`
+		// passes a reader test while the real document would not.
+		assert.strictEqual(issues.cluster_count, 1);
+		assert.strictEqual(issues.clusters.length, 1);
+		const state = exerciseStateFromArtifacts(null, issues, 'done', engineVerdict(root, 1));
+		assert.strictEqual(state.issues, 1);
+		assert.strictEqual(state.phase, 'done');
+	});
+});
+
+// =========================================================================
+// Stage 3 — findings reach the dispatch path
+// =========================================================================
+
+suite('end to end: a finding becomes an episode', () => {
+	test('an engine cluster is dispatchable and becomes an episode', () => {
+		const c = cluster();
+		assert.ok(isDispatchableKind(String(c.kind)), 'a crash cluster must dispatch');
+		const episodes = issueEpisodesFromClusters([c as never]);
+		assert.strictEqual(episodes.length, 1);
+		assert.ok(
+			JSON.stringify(episodes[0]).includes('demo.pure:divide'),
+			'the episode must name the target the engine found',
+		);
+	});
+
+	test('error-shaped and assert-shaped clusters are separated', () => {
+		const crash = cluster();
+		const violation = cluster({ kind: 'invariant-violation', signature: 'ffff0000' });
+		assert.strictEqual(isAssertShapedKind(String(crash.kind)), false);
+		assert.strictEqual(isAssertShapedKind(String(violation.kind)), true);
+	});
+});
+
+// =========================================================================
+// Stage 4 — the agent channel round trip
+// =========================================================================
+
+/** A channel file exactly as `agent_loop.AgentChannel.save` writes one. */
+function channelDoc(topic: string, key: string, subject: string): Record<string, unknown> {
+	return {
+		version: 1,
+		topic,
+		questions: {
+			[key]: {
+				key,
+				topic,
+				subject,
+				prompt: `Give a value for \`${subject}\`.`,
+				reply_schema: '{"value": "<string>"|null, "is_secret": true|false}',
+				context: { variable: subject, modules: ['demo.settings'], tried: ['vinv'] },
+				answer: null,
+			},
+		},
+	};
+}
+
+suite('end to end: the engine asks and the harness answers', () => {
+	test('pending questions across topics go out in ONE prompt and come back', async () => {
+		const root = workspace({
+			'agent_config.json': channelDoc('config', 'config:DEMO_REGION', 'DEMO_REGION'),
+			'agent_contract.json': channelDoc('contract', 'contract:demo.x:fn', 'demo.x:fn'),
+		});
+
+		const pending = pendingQuestions(readChannels(root));
+		assert.strictEqual(pending.length, 2, 'both topics are pending');
+
+		const prompts: string[] = [];
+		const report = await drainAgentChannels(root, async (_name, prompt) => {
+			prompts.push(prompt);
+			return {
+				ok: true,
+				stdout:
+					'Here you go:\n```json\n' +
+					JSON.stringify({
+						answers: {
+							'config:DEMO_REGION': { value: 'eu-west-1', is_secret: false },
+							'contract:demo.x:fn': { contract: { n: 'int' }, baseline: { n: 3 } },
+						},
+					}) +
+					'\n```',
+			};
+		});
+
+		assert.strictEqual(prompts.length, 1, 'one run per drain, not one per question');
+		assert.ok(prompts[0].includes('DEMO_REGION') && prompts[0].includes('demo.x:fn'));
+		assert.strictEqual(report.answered, 2);
+		assert.deepStrictEqual(report.topics, ['config', 'contract']);
+
+		// Written back where the ENGINE reads them.
+		const doc = JSON.parse(
+			fs.readFileSync(path.join(root, '.vinv', 'exercise', 'agent_config.json'), 'utf8'),
+		) as { questions: Record<string, { answer: unknown }> };
+		assert.deepStrictEqual(doc.questions['config:DEMO_REGION'].answer, {
+			value: 'eu-west-1',
+			is_secret: false,
+		});
+		assert.strictEqual(pendingQuestions(readChannels(root)).length, 0);
+	});
+
+	test('an existing answer is never overwritten', async () => {
+		const root = workspace({
+			'agent_config.json': channelDoc('config', 'config:A', 'A'),
+		});
+		applyAnswers(readChannels(root), { 'config:A': { value: 'human-corrected' } });
+
+		await drainAgentChannels(root, async () => ({
+			ok: true,
+			stdout: JSON.stringify({ answers: { 'config:A': { value: 'model-guess' } } }),
+		}));
+
+		const doc = JSON.parse(
+			fs.readFileSync(path.join(root, '.vinv', 'exercise', 'agent_config.json'), 'utf8'),
+		) as { questions: Record<string, { answer: { value: string } }> };
+		assert.strictEqual(doc.questions['config:A'].answer.value, 'human-corrected');
+	});
+
+	test('a failed harness leaves the queue pending and says why', async () => {
+		const root = workspace({ 'agent_config.json': channelDoc('config', 'config:A', 'A') });
+		const report = await drainAgentChannels(root, async () => ({
+			ok: false,
+			stdout: '',
+			detail: 'not signed in',
+		}));
+		assert.strictEqual(report.answered, 0);
+		assert.strictEqual(report.ok, false);
+		assert.match(report.detail, /not signed in/);
+		assert.strictEqual(pendingQuestions(readChannels(root)).length, 1);
+	});
+
+	test('an unparseable reply is not a fabricated answer', async () => {
+		const root = workspace({ 'agent_config.json': channelDoc('config', 'config:A', 'A') });
+		const report = await drainAgentChannels(root, async () => ({
+			ok: true,
+			stdout: 'I am not going to answer that.',
+		}));
+		assert.strictEqual(report.answered, 0);
+		assert.strictEqual(pendingQuestions(readChannels(root)).length, 1);
+	});
+
+	test('the prompt never instructs the model to invent a credential', () => {
+		const questions = pendingQuestions(
+			readChannels(workspace({ 'agent_config.json': channelDoc('config', 'c:K', 'API_KEY') })),
+		);
+		assert.match(buildPrompt(questions), /Never invent a credential/);
+	});
+
+	test('a reply wrapped in prose still parses', () => {
+		assert.deepStrictEqual(parseAnswers('blah {"answers": {"a": 1}} trailing'), { a: 1 });
+		assert.deepStrictEqual(parseAnswers('nothing here'), {});
+	});
+});
+
+// =========================================================================
+// Stage 5 — the last rung: a human
+// =========================================================================
+
+suite('end to end: what nothing could synthesise reaches a person', () => {
+	const requestsDoc = {
+		version: 1,
+		repo: '/repo',
+		requests: [
+			{
+				variable: 'DEMO_REGION',
+				secret: false,
+				description: 'Which region the client talks to.',
+				example: 'eu-west-1',
+				blocked_modules: ['demo.settings'],
+				blocked_count: 1,
+				tried: ['vinv'],
+				reason: 'ValidationError: DEMO_REGION field required',
+				status: 'awaiting-user',
+			},
+			{
+				variable: 'OPENAI_API_KEY',
+				secret: true,
+				description: 'Provider credential.',
+				example: null,
+				blocked_modules: ['demo.llm'],
+				blocked_count: 1,
+				tried: [],
+				reason: 'KeyError: OPENAI_API_KEY',
+				status: 'awaiting-user',
+			},
+		],
+	};
+
+	test('the engine question renders, and answering it writes where the engine reads', async () => {
+		const root = workspace({ 'config_requests.json': requestsDoc });
+		const requests = readConfigRequests(root);
+		assert.deepStrictEqual(
+			requests.map((r) => r.variable),
+			['DEMO_REGION', 'OPENAI_API_KEY'],
+		);
+
+		const html = getConfigPanelHtml('vscode-resource:', buildModel(root));
+		assert.ok(html.includes('DEMO_REGION'));
+		assert.ok(html.includes('type="password"'), 'a secret must not render as plain text');
+		assert.ok(html.includes('nonce-'), 'scripts run under a nonce, not unsafe-inline');
+
+		let reran = 0;
+		const errors: string[] = [];
+		const actions: ConfigPanelActions = {
+			save: (answers) => writeAnswers(root, answers),
+			rerun: async () => {
+				reran += 1;
+			},
+			showError: (message) => errors.push(message),
+		};
+		const outcome = await handlePanelMessage(
+			{ type: 'submit', values: { DEMO_REGION: 'eu-west-1', OPENAI_API_KEY: 'sk-typed' } },
+			requests,
+			actions,
+		);
+		assert.strictEqual(outcome.saved, 2);
+		assert.strictEqual(reran, 1, 'answering has to take effect');
+		assert.deepStrictEqual(errors, [], 'a clean save reports nothing');
+
+		const answers = JSON.parse(fs.readFileSync(configAnswersPath(root), 'utf8')) as {
+			answers: Record<string, string>;
+		};
+		assert.deepStrictEqual(answers.answers, {
+			DEMO_REGION: 'eu-west-1',
+			OPENAI_API_KEY: 'sk-typed',
+		});
+	});
+
+	test('the question file never carries the answer', () => {
+		const root = workspace({ 'config_requests.json': requestsDoc });
+		writeAnswers(root, { OPENAI_API_KEY: 'sk-typed-secret' });
+		const questions = fs.readFileSync(
+			path.join(root, '.vinv', 'exercise', 'config_requests.json'),
+			'utf8',
+		);
+		assert.ok(!questions.includes('sk-typed-secret'), 'the credential is in the QUESTION file');
+	});
+
+	test('a blank field is not a value', () => {
+		const root = workspace({ 'config_requests.json': requestsDoc });
+		assert.deepStrictEqual(buildAnswers(readConfigRequests(root), { DEMO_REGION: '   ' }), {});
+	});
+
+	test('an answer to something nobody asked for is dropped', () => {
+		const root = workspace({ 'config_requests.json': requestsDoc });
+		assert.deepStrictEqual(
+			buildAnswers(readConfigRequests(root), { NOT_ASKED: 'x', DEMO_REGION: 'ok' }),
+			{ DEMO_REGION: 'ok' },
+		);
+	});
+
+	test('the target repo\'s own error text cannot become markup', () => {
+		const root = workspace({
+			'config_requests.json': {
+				version: 1,
+				requests: [
+					{
+						variable: 'X',
+						secret: false,
+						description: '<img src=x onerror=alert(1)>',
+						blocked_modules: [],
+						blocked_count: 0,
+						tried: [],
+						reason: '</pre><script>alert(2)</script>',
+						status: 'awaiting-user',
+					},
+				],
+			},
+		});
+		const html = getConfigPanelHtml('vscode-resource:', buildModel(root));
+		assert.ok(!html.includes('<img src=x'), 'a description became markup');
+		assert.ok(!html.includes('<script>alert(2)'), "the repo's error text became markup");
+		assert.ok(html.includes('&lt;script&gt;'), 'and it is still shown, escaped');
+	});
+
+	test('nothing being asked renders as nothing being asked', () => {
+		const root = workspace({ 'config_requests.json': { version: 1, requests: [] } });
+		const html = getConfigPanelHtml('vscode-resource:', buildModel(root));
+		assert.ok(html.includes('Nothing to configure'));
+	});
+});

--- a/extension/src/test/opportunityBoard.test.ts
+++ b/extension/src/test/opportunityBoard.test.ts
@@ -410,7 +410,14 @@ function writeSession(root: string, dir: string, lines: string[], iso: string): 
 	fs.utimesSync(f, new Date(iso), new Date(iso));
 }
 
-suite('opportunity board (sweeps route through the analyzer)', () => {
+suite('opportunity board (sweeps route through the analyzer)', function () {
+	// The `setup` below writes a ~700-line trace session before EVERY test in
+	// this suite, because each test mutates the board and must not inherit the
+	// previous one's writes. That is the right isolation and it is real
+	// filesystem work, past mocha's 2s default often enough on Windows to make
+	// the suite look intermittently broken — reported as "ensure done() is
+	// called" on a hook that is not even async.
+	this.timeout(30_000);
 	let root: string;
 
 	setup(() => {

--- a/extension/src/test/pipeline.test.ts
+++ b/extension/src/test/pipeline.test.ts
@@ -17,6 +17,7 @@ import {
 	initialPipelineLedger,
 	initialServiceState,
 	planPipelineAction,
+	settleUnreachableStages,
 	type PipelineLedger,
 	type ServiceState,
 } from '../harness/autoPilotMachine';
@@ -95,6 +96,31 @@ suite('pipeline machine: scheduling', () => {
 		// Never 'insights' or 'probes' — they have no traced session to read.
 		assert.notDeepStrictEqual(planPipelineAction(true, libraries, ledger), { kind: 'insights' });
 		assert.notDeepStrictEqual(planPipelineAction(true, libraries, ledger), { kind: 'probes' });
+	});
+
+	test('a stage no service will ever feed is settled, not left pending forever', () => {
+		// Leaving them 'pending' reached 'done' with two stages that read, to
+		// anything showing the ledger, as work still to come.
+		const libraries = [svc({ phase: 'library' }), svc({ name: 'b', phase: 'gave-up' })];
+		const settled = settleUnreachableStages(libraries, initialPipelineLedger());
+		assert.strictEqual(settled.insights, 'skipped');
+		assert.strictEqual(settled.probes, 'skipped');
+		// The one stage that CAN run on a library repo is untouched.
+		assert.strictEqual(settled.exercise, 'pending');
+		assert.deepStrictEqual(planPipelineAction(true, libraries, settled), { kind: 'exercise' });
+	});
+
+	test('settling is idempotent and never overwrites a stage that ran', () => {
+		const green = [svc({ phase: 'green' })];
+		const ledger = initialPipelineLedger();
+		// A green service means both stages are reachable — nothing is settled.
+		assert.deepStrictEqual(settleUnreachableStages(green, ledger), ledger);
+
+		const libraries = [svc({ phase: 'library' })];
+		const ran = applyStageOutcome(initialPipelineLedger(), 'insights', 'done');
+		const settled = settleUnreachableStages(libraries, ran);
+		assert.strictEqual(settled.insights, 'done');
+		assert.deepStrictEqual(settleUnreachableStages(libraries, settled), settled);
 	});
 
 	test('skipped and failed stages are terminal for the run', () => {

--- a/extension/src/test/pipeline.test.ts
+++ b/extension/src/test/pipeline.test.ts
@@ -77,12 +77,24 @@ suite('pipeline machine: scheduling', () => {
 		assert.deepStrictEqual(planPipelineAction(true, services, ledger), { kind: 'done' });
 	});
 
-	test('no green service means nothing to analyze — straight to done', () => {
+	test('a workspace of libraries still exercises — nothing to serve is not nothing to drive', () => {
+		// insights and probes read what a live traced session recorded, so with
+		// nothing green they are correctly skipped. The exercise stage drives code
+		// in workers off the source and the index: no port, no traffic, no service.
+		// Gating it on `anyGreen` made Vinv a no-op on every library repo.
+		let ledger = initialPipelineLedger();
+		const libraries = [svc({ phase: 'library' }), svc({ name: 'b', phase: 'gave-up' })];
+		assert.deepStrictEqual(planPipelineAction(true, libraries, ledger), { kind: 'exercise' });
+		ledger = applyStageOutcome(ledger, 'exercise', 'done');
+		assert.deepStrictEqual(planPipelineAction(true, libraries, ledger), { kind: 'done' });
+	});
+
+	test('without a green service insights and probes stay skipped', () => {
 		const ledger = initialPipelineLedger();
-		assert.deepStrictEqual(
-			planPipelineAction(true, [svc({ phase: 'library' }), svc({ name: 'b', phase: 'gave-up' })], ledger),
-			{ kind: 'done' },
-		);
+		const libraries = [svc({ phase: 'library' })];
+		// Never 'insights' or 'probes' — they have no traced session to read.
+		assert.notDeepStrictEqual(planPipelineAction(true, libraries, ledger), { kind: 'insights' });
+		assert.notDeepStrictEqual(planPipelineAction(true, libraries, ledger), { kind: 'probes' });
 	});
 
 	test('skipped and failed stages are terminal for the run', () => {

--- a/extension/src/test/rewardAndOpe.test.ts
+++ b/extension/src/test/rewardAndOpe.test.ts
@@ -75,6 +75,32 @@ function judgeReport(over: Partial<import('../harness/rewardSignals').JudgeRepor
 	};
 }
 
+/**
+ * A virtual environment on THIS platform, returning its interpreter's path.
+ *
+ * `discoverPythonCandidates` looks for `Scripts/python.exe` on Windows and
+ * `bin/python` elsewhere — correctly, because that is where the two layouts put
+ * it. A fixture that only ever builds the POSIX one therefore tests nothing on
+ * Windows: discovery finds no interpreter, and every assertion about ordering
+ * and precedence fails for a reason that has nothing to do with the rule being
+ * tested. Same shape as the POSIX-only fixtures that were failing on the engine
+ * side of this repo.
+ *
+ * `marker: false` builds the trap the shape rule has to reject — a `bin/python`
+ * with no PEP 405 `pyvenv.cfg` beside it, which is not an environment.
+ */
+function makeVenv(root: string, name: string, opts: { marker?: boolean } = {}): string {
+	const isWin = process.platform === 'win32';
+	const binDir = path.join(root, name, isWin ? 'Scripts' : 'bin');
+	fs.mkdirSync(binDir, { recursive: true });
+	const python = path.join(binDir, isWin ? 'python.exe' : 'python');
+	fs.writeFileSync(python, '', { mode: 0o755 });
+	if (opts.marker !== false) {
+		fs.writeFileSync(path.join(root, name, 'pyvenv.cfg'), 'home = /usr\n');
+	}
+	return python;
+}
+
 suite('Acceptance-test extraction', () => {
 	test('takes the LAST python-acceptance fence and requires a real test', () => {
 		const stdout = [
@@ -489,29 +515,28 @@ suite('Test-interpreter resolution', () => {
 			// The live failure: the workspace's only env was named `.venv-smol`,
 			// so resolution fell through to a bare python3 with none of the repo's
 			// dependencies installed.
-			for (const name of ['.venv-smol', 'venv311', 'node_modules', 'src']) {
-				fs.mkdirSync(path.join(ws, name, 'bin'), { recursive: true });
-				fs.writeFileSync(path.join(ws, name, 'bin', 'python'), '');
-			}
 			// Only the real environments carry PEP 405's marker; node_modules and
-			// src have a `bin/python` shim and nothing else, which is exactly the
+			// src have an interpreter shim and nothing else, which is exactly the
 			// case a shape-only rule would wrongly accept.
-			for (const name of ['.venv-smol', 'venv311']) {
-				fs.writeFileSync(path.join(ws, name, 'pyvenv.cfg'), 'home = /usr\n');
-			}
+			const smol = makeVenv(ws, '.venv-smol');
+			const venv311 = makeVenv(ws, 'venv311');
+			makeVenv(ws, 'node_modules', { marker: false });
+			makeVenv(ws, 'src', { marker: false });
+
 			const found = discoverPythonCandidates(ws);
 			assert.ok(
-				found.includes(path.join(ws, '.venv-smol', 'bin', 'python')),
+				found.includes(smol),
 				`a non-standard venv name must be discovered: ${found.join(', ')}`,
 			);
-			assert.ok(found.includes(path.join(ws, 'venv311', 'bin', 'python')));
+			assert.ok(found.includes(venv311));
 			// A `bin/python` shim without PEP 405's marker is not an environment,
 			// so `node_modules/bin/python` and `src/bin/python` stay out.
 			assert.ok(!found.some((c) => c.includes(`${path.sep}node_modules${path.sep}`)));
-			assert.ok(!found.some((c) => c.includes(`${path.sep}src${path.sep}bin`)));
+			assert.ok(!found.some((c) => c.includes(`${path.sep}src${path.sep}`)));
 			// PATH names come last, so a real env always outranks them.
-			assert.ok(found.indexOf('python3') > found.indexOf(path.join(ws, '.venv-smol', 'bin', 'python')));
-			assert.strictEqual(resolveTestPython(ws), path.join(ws, '.venv-smol', 'bin', 'python'));
+			const pathName = process.platform === 'win32' ? 'python' : 'python3';
+			assert.ok(found.indexOf(pathName) > found.indexOf(smol));
+			assert.strictEqual(resolveTestPython(ws), smol);
 			// Alphabetical among the non-preferred names — never readdir order.
 			assert.deepStrictEqual(discoverPythonCandidates(ws), found);
 		} finally {
@@ -521,15 +546,23 @@ suite('Test-interpreter resolution', () => {
 
 	test('an explicit override and .venv keep priority over discovered envs', () => {
 		const ws = fs.mkdtempSync(path.join(os.tmpdir(), 'vinv-venvorder-'));
+		// Captured and restored: this used to be SET and never cleared, so every
+		// later test in the run saw an override pointing at a path that does not
+		// exist. A test that leaks an environment variable is a test that decides
+		// whether the ones after it pass.
+		const overrideBefore = process.env.VINV_TEST_PYTHON;
 		try {
-			for (const name of ['.venv', 'zz-venv']) {
-				fs.mkdirSync(path.join(ws, name, 'bin'), { recursive: true });
-				fs.writeFileSync(path.join(ws, name, 'bin', 'python'), '');
-			}
-			assert.strictEqual(discoverPythonCandidates(ws)[0], path.join(ws, '.venv', 'bin', 'python'));
+			const preferred = makeVenv(ws, '.venv');
+			makeVenv(ws, 'zz-venv');
+			assert.strictEqual(discoverPythonCandidates(ws)[0], preferred);
 			process.env.VINV_TEST_PYTHON = '/custom/python';
 			assert.strictEqual(discoverPythonCandidates(ws)[0], '/custom/python');
 		} finally {
+			if (overrideBefore === undefined) {
+				delete process.env.VINV_TEST_PYTHON;
+			} else {
+				process.env.VINV_TEST_PYTHON = overrideBefore;
+			}
 			fs.rmSync(ws, { recursive: true, force: true });
 		}
 	});
@@ -1207,10 +1240,7 @@ suite('Virtual-env discovery is structural, not name-based', () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), 'vinv-envshape-'));
 		try {
 			for (const name of ['sandbox', '.direnv', 'toolchain']) {
-				const bin = path.join(root, name, 'bin');
-				fs.mkdirSync(bin, { recursive: true });
-				fs.writeFileSync(path.join(bin, 'python'), '#!/bin/sh\n', { mode: 0o755 });
-				fs.writeFileSync(path.join(root, name, 'pyvenv.cfg'), 'home = /usr\n');
+				makeVenv(root, name);
 			}
 			// A directory that merely LOOKS like source must not be offered.
 			fs.mkdirSync(path.join(root, 'mypkg'), { recursive: true });

--- a/extension/src/test/webviewWiring.test.ts
+++ b/extension/src/test/webviewWiring.test.ts
@@ -112,7 +112,13 @@ suite('Webview button wiring', () => {
 	});
 
 	suite('openPathInEditor', () => {
-		test('opens a real file and reports success', async () => {
+		test('opens a real file and reports success', async function () {
+			// This is the only test in the suite that opens a document in the REAL
+			// editor — `openTextDocument` plus `showTextDocument` — so it pays for
+			// the text-model and editor-layout machinery starting up, once, here.
+			// Past mocha's 2s default on a cold Windows editor, and it was being
+			// reported as a hang rather than as the slow first call it is.
+			this.timeout(30_000);
 			const ws = makeWorkspace();
 			try {
 				const ok = await openPathInEditor(ws.existing, { label: 'context pack' });

--- a/extension/src/views/configRequestPanel.ts
+++ b/extension/src/views/configRequestPanel.ts
@@ -126,7 +126,23 @@ export function writeAnswers(
 	}
 	const merged = { ...existing, ...answers };
 	fs.mkdirSync(path.dirname(target), { recursive: true });
-	fs.writeFileSync(target, JSON.stringify({ version: 1, answers: merged }, null, 2), 'utf8');
+	// OWNER-ONLY. This is the one file in `.vinv/` whose entire content is
+	// credentials a human typed, and the default 0644 makes it readable by every
+	// account on the machine — the standard other tools hold plaintext secrets to
+	// is 0600 (`~/.aws/credentials`, `~/.netrc`, which ssh and curl refuse when
+	// it is group-readable). `mode` on writeFileSync only applies when the file
+	// is CREATED, so an existing file is chmod-ed explicitly; both are no-ops on
+	// Windows, which is why they are not a substitute for `.vinv/` being
+	// gitignored.
+	fs.writeFileSync(target, JSON.stringify({ version: 1, answers: merged }, null, 2), {
+		encoding: 'utf8',
+		mode: 0o600,
+	});
+	try {
+		fs.chmodSync(target, 0o600);
+	} catch {
+		// A filesystem without POSIX modes is not a reason to fail the save.
+	}
 	return Object.keys(answers).length;
 }
 

--- a/extension/src/views/configRequestPanel.ts
+++ b/extension/src/views/configRequestPanel.ts
@@ -32,6 +32,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { randomBytes } from 'crypto';
 import * as vscode from 'vscode';
 
 import { VINV_BASE_CSS, VINV_FONT_MONO, VINV_FONT_SERIF } from './webviewTheme';
@@ -202,6 +203,13 @@ export async function handlePanelMessage(
 
 /** The panel's HTML, in the Vinv design system. */
 export function getConfigPanelHtml(cspSource: string, model: ConfigPanelModel): string {
+	// A nonce rather than `'unsafe-inline'` for scripts. The panel renders strings
+	// this process did not author — a variable name and description from a model,
+	// and the TARGET REPO's own error text under "why Vinv is asking". Escaping is
+	// what stops those becoming markup and it is applied at every interpolation;
+	// the nonce is the second wall, so a missed one is not immediately executable.
+	// Styles keep `'unsafe-inline'`: the stylesheet is a literal in this file.
+	const nonce = randomBytes(16).toString('base64');
 	const rows = model.requests
 		.map((r) => {
 			const kind = r.secret ? 'password' : 'text';
@@ -248,7 +256,7 @@ export function getConfigPanelHtml(cspSource: string, model: ConfigPanelModel): 
 
 	return `<!DOCTYPE html><html><head>
 <meta http-equiv="Content-Security-Policy"
-      content="default-src 'none'; style-src ${cspSource} 'unsafe-inline'; script-src ${cspSource} 'unsafe-inline';">
+      content="default-src 'none'; style-src ${cspSource} 'unsafe-inline'; script-src 'nonce-${nonce}';">
 <style>
 ${VINV_BASE_CSS}
 body { font-family: ${VINV_FONT_MONO}; padding: 18px 20px; }
@@ -281,7 +289,7 @@ button.primary:hover { background: var(--accent-hover); }
 <div class="sub">${escapeHtml(model.repoLabel)} — Vinv derived everything it could from this
 repository and its own failures. These are what it could not.</div>
 ${body}
-<script>
+<script nonce="${nonce}">
 const vscode = acquireVsCodeApi();
 const form = document.getElementById('form');
 if (form) {

--- a/extension/src/views/configRequestPanel.ts
+++ b/extension/src/views/configRequestPanel.ts
@@ -1,0 +1,314 @@
+/**
+ * The human end of configuration escalation.
+ *
+ * The engine tries hard not to need this. It reads what the repo publishes
+ * (`.env`, `.env.example`), then induces the rest from the target's own failure
+ * — supply a value, read the complaint, escalate the shape, retry. What reaches
+ * here is only what neither of those could produce: a value with real-world
+ * meaning that no ladder can invent, or a credential, which nothing may
+ * synthesise ever.
+ *
+ * Those land in `.vinv/exercise/config_requests.json` already described — what
+ * the variable is, an example of a well-formed value, whether it is secret,
+ * which modules it blocks, and what the harness already tried. This renders
+ * that as a form, writes `config_answers.json`, and re-runs. Nothing here
+ * decides anything; the engine did the deciding and this is the field it could
+ * not fill.
+ *
+ * Two rules the UI has to keep:
+ *
+ *  - a secret is typed into a masked field and written ONLY to
+ *    `config_answers.json` — never echoed back into the panel's model, never
+ *    logged, never put in a status line. `config_requests.json` carries the
+ *    question and never the answer.
+ *  - a request the engine has stopped asking for disappears. The file is
+ *    rewritten every run, including empty, so a stale prompt for a variable
+ *    that is now satisfied cannot persist.
+ *
+ * The pure parts — reading the model, validating, building the answers document
+ * — are exported and unit-tested without a webview, matching the convention in
+ * `exerciseRunner`/`flowPanel`.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+import { VINV_BASE_CSS, VINV_FONT_MONO, VINV_FONT_SERIF } from './webviewTheme';
+
+/** One variable the engine could not supply, as `envconfig` describes it. */
+export interface ConfigRequest {
+	variable: string;
+	secret: boolean;
+	description: string;
+	example?: string | null;
+	blocked_modules: string[];
+	blocked_count: number;
+	tried: string[];
+	reason: string;
+	status: string;
+}
+
+export interface ConfigRequestsDoc {
+	version?: number;
+	repo?: string;
+	answers_path?: string;
+	requests?: ConfigRequest[];
+}
+
+export function configRequestsPath(workspaceRoot: string): string {
+	return path.join(workspaceRoot, '.vinv', 'exercise', 'config_requests.json');
+}
+
+export function configAnswersPath(workspaceRoot: string): string {
+	return path.join(workspaceRoot, '.vinv', 'exercise', 'config_answers.json');
+}
+
+/**
+ * What the engine is currently asking for, or an empty list.
+ *
+ * An unreadable or absent file means nothing is being asked — not an error. The
+ * engine writes this file on every run, so its absence means no run has got far
+ * enough to ask, and a panel showing nothing is the correct rendering of that.
+ */
+export function readConfigRequests(workspaceRoot: string): ConfigRequest[] {
+	try {
+		const doc = JSON.parse(
+			fs.readFileSync(configRequestsPath(workspaceRoot), 'utf8'),
+		) as ConfigRequestsDoc;
+		const requests = doc.requests;
+		return Array.isArray(requests) ? requests.filter((r) => r && r.variable) : [];
+	} catch {
+		return [];
+	}
+}
+
+/**
+ * Keep only answers to variables actually being asked for, with a real value.
+ *
+ * A blank field means "I don't know either" and must not be written: an empty
+ * string is a VALUE, and the engine would dutifully export it, satisfy the
+ * variable's presence check, and fail somewhere less obvious. Leaving it unset
+ * keeps the induction ladder and the escalation working on it.
+ */
+export function buildAnswers(
+	requests: ConfigRequest[],
+	submitted: Record<string, string>,
+): Record<string, string> {
+	const asked = new Set(requests.map((r) => r.variable));
+	const answers: Record<string, string> = {};
+	for (const [name, raw] of Object.entries(submitted)) {
+		if (!asked.has(name)) {continue;}
+		const value = typeof raw === 'string' ? raw.trim() : '';
+		if (!value) {continue;}
+		answers[name] = value;
+	}
+	return answers;
+}
+
+/**
+ * Merge new answers into whatever is already on disk and write it.
+ *
+ * Merged rather than replaced: a user answering two variables today and one
+ * tomorrow must not lose the first two, and the engine reads this file whole.
+ */
+export function writeAnswers(
+	workspaceRoot: string,
+	answers: Record<string, string>,
+): number {
+	const target = configAnswersPath(workspaceRoot);
+	let existing: Record<string, string> = {};
+	try {
+		const doc = JSON.parse(fs.readFileSync(target, 'utf8')) as { answers?: Record<string, string> };
+		if (doc.answers && typeof doc.answers === 'object') {existing = doc.answers;}
+	} catch {
+		existing = {};
+	}
+	const merged = { ...existing, ...answers };
+	fs.mkdirSync(path.dirname(target), { recursive: true });
+	fs.writeFileSync(target, JSON.stringify({ version: 1, answers: merged }, null, 2), 'utf8');
+	return Object.keys(answers).length;
+}
+
+/** The model the webview renders. Secrets carry no value, only the question. */
+export interface ConfigPanelModel {
+	requests: ConfigRequest[];
+	repoLabel: string;
+}
+
+export function buildModel(workspaceRoot: string): ConfigPanelModel {
+	return {
+		requests: readConfigRequests(workspaceRoot),
+		repoLabel: path.basename(workspaceRoot),
+	};
+}
+
+/** Actions the panel performs, injected so the wiring is testable. */
+export interface ConfigPanelActions {
+	/** Persist answers; returns how many landed. */
+	save: (answers: Record<string, string>) => number;
+	/** Re-run the pipeline so the answers take effect. */
+	rerun: () => Promise<void>;
+	showError: (message: string) => void;
+}
+
+/**
+ * The message arm, separated from the panel so it can be driven directly.
+ *
+ * Returns what happened so a caller (and a test) can assert on it rather than
+ * inferring from side effects.
+ */
+export async function handlePanelMessage(
+	message: { type?: string; values?: Record<string, string> },
+	requests: ConfigRequest[],
+	actions: ConfigPanelActions,
+): Promise<{ saved: number; reran: boolean }> {
+	if (message?.type !== 'submit') {return { saved: 0, reran: false };}
+	const answers = buildAnswers(requests, message.values ?? {});
+	if (Object.keys(answers).length === 0) {
+		actions.showError('Nothing to save — fill in at least one value.');
+		return { saved: 0, reran: false };
+	}
+	let saved = 0;
+	try {
+		saved = actions.save(answers);
+	} catch (err) {
+		actions.showError(
+			`Could not write the answers: ${err instanceof Error ? err.message : String(err)}`,
+		);
+		return { saved: 0, reran: false };
+	}
+	// Re-running is the whole point — an answer that sits on disk until someone
+	// remembers to press play is the same stall in a different place.
+	await actions.rerun();
+	return { saved, reran: true };
+}
+
+/** The panel's HTML, in the Vinv design system. */
+export function getConfigPanelHtml(cspSource: string, model: ConfigPanelModel): string {
+	const rows = model.requests
+		.map((r) => {
+			const kind = r.secret ? 'password' : 'text';
+			const badge = r.secret
+				? '<span class="badge secret">secret</span>'
+				: '<span class="badge">value</span>';
+			const example = r.example
+				? `<div class="hint">example: <code>${escapeHtml(r.example)}</code></div>`
+				: '';
+			const blocked = r.blocked_count
+				? `<div class="hint">blocks ${r.blocked_count} module${r.blocked_count === 1 ? '' : 's'}: <code>${escapeHtml(r.blocked_modules.slice(0, 3).join(', '))}</code></div>`
+				: '';
+			const tried = r.tried?.length
+				? `<div class="hint dim">already tried: ${escapeHtml(r.tried.join(', '))}</div>`
+				: '';
+			return `
+			<div class="field">
+				<label for="f-${escapeHtml(r.variable)}">
+					<span class="name">${escapeHtml(r.variable)}</span>${badge}
+				</label>
+				<div class="desc">${escapeHtml(r.description)}</div>
+				${example}${blocked}${tried}
+				<input id="f-${escapeHtml(r.variable)}" data-var="${escapeHtml(r.variable)}"
+				       type="${kind}" autocomplete="off" spellcheck="false"
+				       placeholder="${r.secret ? 'paste the value — it is written only to .vinv, never shown again' : 'value'}" />
+				<details class="why"><summary>why Vinv is asking</summary>
+					<pre>${escapeHtml(r.reason)}</pre>
+				</details>
+			</div>`;
+		})
+		.join('\n');
+
+	const body = model.requests.length
+		? `<form id="form">${rows}
+			<div class="actions">
+				<button type="submit" class="primary">Save &amp; re-run</button>
+			</div>
+		 </form>`
+		: `<div class="empty">
+				<p>Nothing to configure.</p>
+				<p class="dim">Vinv resolved this repository's environment on its own,
+				   or no run has needed configuration yet.</p>
+			</div>`;
+
+	return `<!DOCTYPE html><html><head>
+<meta http-equiv="Content-Security-Policy"
+      content="default-src 'none'; style-src ${cspSource} 'unsafe-inline'; script-src ${cspSource} 'unsafe-inline';">
+<style>
+${VINV_BASE_CSS}
+body { font-family: ${VINV_FONT_MONO}; padding: 18px 20px; }
+h1 { font-family: ${VINV_FONT_SERIF}; font-style: italic; font-size: 22px; margin: 0 0 4px; }
+.sub { color: var(--muted); font-size: 12px; margin-bottom: 18px; }
+.field { border: 1px solid var(--line); padding: 12px 14px; margin-bottom: 14px; }
+label { display: flex; align-items: center; gap: 8px; }
+.name { font-weight: 600; letter-spacing: .02em; }
+.badge { font-size: 10px; text-transform: uppercase; letter-spacing: .08em;
+         border: 1px solid var(--line-strong); padding: 1px 6px; color: var(--muted); }
+.badge.secret { border-color: var(--accent-fg); color: var(--accent-fg); }
+.desc { color: var(--ink-soft); font-size: 12.5px; margin: 6px 0; }
+.hint { color: var(--muted); font-size: 11.5px; }
+.hint.dim, .dim { color: var(--muted-2); }
+input { width: 100%; box-sizing: border-box; margin-top: 8px; padding: 7px 9px;
+        font-family: ${VINV_FONT_MONO}; font-size: 12.5px; border: 1px solid var(--line-strong);
+        background: var(--bg-2); color: var(--ink); border-radius: 0; }
+input:focus { outline: 2px solid var(--accent-fg); outline-offset: -2px; }
+.why { margin-top: 8px; }
+.why summary { cursor: pointer; font-size: 11.5px; color: var(--muted); }
+.why pre { white-space: pre-wrap; font-size: 11px; color: var(--muted);
+           border-left: 2px solid var(--line); padding-left: 8px; margin: 6px 0 0; }
+.actions { margin-top: 16px; }
+button.primary { font-family: ${VINV_FONT_MONO}; font-size: 12.5px; padding: 8px 16px;
+                 background: var(--accent); color: #ffffff; border: none; cursor: pointer; }
+button.primary:hover { background: var(--accent-hover); }
+.empty { color: var(--muted); font-size: 13px; }
+</style></head><body>
+<h1>Vinv needs a few values</h1>
+<div class="sub">${escapeHtml(model.repoLabel)} — Vinv derived everything it could from this
+repository and its own failures. These are what it could not.</div>
+${body}
+<script>
+const vscode = acquireVsCodeApi();
+const form = document.getElementById('form');
+if (form) {
+	form.addEventListener('submit', (e) => {
+		e.preventDefault();
+		const values = {};
+		for (const input of document.querySelectorAll('input[data-var]')) {
+			values[input.getAttribute('data-var')] = input.value;
+		}
+		vscode.postMessage({ type: 'submit', values });
+	});
+}
+</script></body></html>`;
+}
+
+function escapeHtml(text: string): string {
+	return String(text ?? '')
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;');
+}
+
+/**
+ * Open the panel for a workspace. Returns undefined when nothing is being asked.
+ */
+export function openConfigRequestPanel(
+	workspaceRoot: string,
+	actions: ConfigPanelActions,
+): vscode.WebviewPanel | undefined {
+	const model = buildModel(workspaceRoot);
+	if (model.requests.length === 0) {return undefined;}
+
+	const panel = vscode.window.createWebviewPanel(
+		'vinv.configRequests',
+		'Vinv — configure this project',
+		vscode.ViewColumn.Active,
+		{ enableScripts: true, retainContextWhenHidden: true },
+	);
+	panel.webview.html = getConfigPanelHtml(panel.webview.cspSource, model);
+	panel.webview.onDidReceiveMessage(async (message) => {
+		const outcome = await handlePanelMessage(message, model.requests, actions);
+		if (outcome.saved > 0) {panel.dispose();}
+	});
+	return panel;
+}


### PR DESCRIPTION
<!--
Thanks for contributing to Vinv. Keep the diff reviewable and one logical
change per PR. See CONTRIBUTING.md (and AGENTS.md if an agent wrote any of this).
-->

## What & why

<!-- What does this change do, and why does it matter? Link the issue it closes, if any. -->

Closes #

## How it was verified

<!-- Check what you actually ran for the area you touched. Don't claim — run it. -->

- [ ] Python lint — `uv run ruff check` and `uv run ruff format --check` in the package I touched
- [ ] Python tests — `uv run pytest` in the package I touched (or repo root)
- [ ] Rust — `cargo test` in `index/` (if the index changed)
- [ ] Extension — `npm run check && npm run bundle` in `extension/` (if the extension changed)
- [ ] End-to-end honesty contract — `python tests/e2e/planted_bug_golden/run.py` stays green
- [ ] Manual testing (describe below)

<!-- Notes on manual testing / anything a reviewer should look at hardest: -->

## Ground rules (product promises — must stay true)

- [ ] No new runtime network calls (beyond the one-time embedding-model download / optional prebuilt index artifacts)
- [ ] No telemetry
- [ ] No new required configuration or env var (feature-level keys route through the user's coding-agent harness)
- [ ] Tracer stays zero-edit (users never modify their own code to use Vinv)

## AI-assisted?

<!-- If an agent wrote part of this, say so and flag where reviewers should look hardest.
     You own the diff regardless — see CONTRIBUTING.md → "Working with AI coding agents". -->
