### PR TITLE
fix: stop reporting unverified inferences as findings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,18 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
       - name: Sync workspace
-        run: uv sync
+        # --locked: a bare `uv sync` may silently RE-RESOLVE and rewrite uv.lock,
+        # so a dependency drift lands green. Fail instead when the committed lock
+        # and the resolved set disagree.
+        run: uv sync --locked
+      - name: Every third-party import is declared
+        # Four instances of one defect shipped past review: real code with a real
+        # consumer and an absent (or uv-only) declaration — otel-libs,
+        # hypothesis-jsonschema, jsdom, core's litellm redirect. Two more
+        # (tiktoken, certifi) were found by this check on its first run, where
+        # `count_tokens` had been silently falling back to `len // 4`. Nothing
+        # fails loudly in that shape, which is why it needs a machine.
+        run: uv run python scripts/check-declared-deps.py
       - name: Run engine test suites
         run: |
           for pkg in contracts core tracelens identification handbook bringup goal embedder exerciser; do
@@ -31,6 +42,13 @@ jobs:
               echo "::endgroup::"
             fi
           done
+      - name: Index retrieval-eval suite
+        # `index` is a Rust crate with a PYTHON eval suite, so it fell between
+        # the two jobs: it is not in the loop above (no index/tests dir) and
+        # rust-index runs only `cargo test`. 30 tests, ~8s, gated by nothing
+        # until now — found because two full-validation runs disagreed by
+        # exactly 30 and the difference turned out to be this directory.
+        run: uv run pytest index/eval -q
 
   rust-index:
     name: rust index (${{ matrix.os }})
@@ -49,19 +67,41 @@ jobs:
         run: cargo test --manifest-path index/Cargo.toml
 
   extension:
-    name: extension (typecheck + bundle)
+    name: extension (typecheck + bundle + tests)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          # 22, not 20, BECAUSE of the Tests step below: `npm test` runs
+          # `vscode-test`, which IS @vscode/test-cli's binary, and both
+          # @vscode/test-cli 0.0.15 and @vscode/test-electron 3.1.0 declare a
+          # HARD `engines.node: ">=22"` with no node-20 branch (verified by
+          # enumerating engines across the installed tree: those two are the only
+          # hard ones; the other 11 that want 22+ are permissive or dual).
+          # `npm ci` would NOT have caught it — engine-strict defaults to false,
+          # so EBADENGINE is a warning and the failure would have surfaced at
+          # runtime instead. The typecheck and bundle steps are fine on 20; this
+          # bump is for the step that actually boots Electron.
+          node-version: 22
       - name: Install
         run: npm ci --prefix extension
       - name: Typecheck
         run: npm run check --prefix extension
       - name: Bundle
         run: npm run bundle --prefix extension
+      - name: Tests
+        # NOTHING ran the extension suite before this step — grepping the whole
+        # workflow directory for `npm test`, `vscode-test` or `xvfb` returned
+        # nothing, so ~700 tests were gated only by whoever ran them locally.
+        # That is why the harness breakage (@vscode/test-electron 2.5.2 spawning
+        # Contents/MacOS/Electron, which VS Code 1.110+ renamed to Code) went
+        # unnoticed: CI never invoked it.
+        #
+        # xvfb-run is required, not optional: vscode-test launches a real VS Code
+        # (Electron) instance and exits non-zero with no DISPLAY on a headless
+        # runner. This is the standard invocation for VS Code extension CI.
+        run: xvfb-run -a npm test --prefix extension
 
   e2e:
     name: planted-bug golden e2e
@@ -74,6 +114,8 @@ jobs:
         with:
           workspaces: index
       - name: Sync workspace
-        run: uv sync
+        # --locked here too: a lock guard on only one of the two syncing jobs
+        # lets drift in through the other.
+        run: uv sync --locked
       - name: Run e2e
         run: uv run python tests/e2e/planted_bug_golden/run.py

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,12 @@ dist/
 models/
 *.gguf
 *.safetensors
+# tiktoken downloads its BPE encoding (~1.6MB) into a cache dir that
+# token_utils.py points at its OWN package directory, so the blob lands inside
+# the source tree rather than under a temp or home path. It appears the first
+# time anything calls count_tokens — i.e. for every developer and every CI run
+# now that tiktoken is a declared dependency of core[agents].
+.tiktoken_cache/
 
 # Local build output, logs, and stray virtualenvs
 /_winbuild/
@@ -53,5 +59,6 @@ nuitka-crash-report.xml
 
 # Local editor / agent config (not part of the public release).
 /.claude/
+/.cursor/
 .vscode/
 

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -13,23 +13,63 @@ readme = "README.md"
 requires-python = ">=3.12,<3.15"
 license = { text = "Apache-2.0" }
 dependencies = [
-    "pydantic>=2.10.5",
-    "dspy-ai>=3.1.0",
-    # Satisfied by the in-tree OpenAI-SDK shim (vendor/litellm_stub), not BerriAI.
-    "litellm",
-    "openai>=1.59.0",
-    "pexpect>=4.9",
-    "httpx>=0.24.0",
-    "pyyaml>=6.0.0",
-    "websocket-client>=1.8.0",
-    # dspy imports jsonschema at module load (adapters/types/tool.py).
-    "jsonschema>=4.0.0",
+    "pydantic>=2.10.5,<3.0.0",
+    "pexpect>=4.9,<5.0",
+    "httpx>=0.27.0,<0.29.0",
+    "pyyaml>=6.0.1,<7.0.0",
+    "websocket-client>=1.8.0,<2.0.0",
 ]
 
 [project.optional-dependencies]
+# The DSPy-driven agent runtime. NOT a base dependency: measured, `import core`
+# and its whole public API (BaseSwarmAgent, TerminalExecutorAgent,
+# ensure_dspy_lm_configured) work with dspy and litellm absent — 17 of core's 21
+# dspy imports are already lazy, and nothing on the `core/__init__.py` path hits
+# the 4 module-level ones. Vinv itself never needs this: every agent run is
+# delegated to an external harness CLI, and `core.llm.ensure_dspy_lm_configured()`
+# RAISES rather than configuring a model, so no in-process LLM call is reachable.
+#
+# Keeping these out of the base install is what fixes the litellm substitution
+# hazard. The shim is redirected via `[tool.uv.sources]`, which is uv-only and
+# absent from wheel metadata, so a plain `pip install vinv-core` used to resolve
+# BerriAI litellm from PyPI against an unpinned `"litellm"` — silently swapping in
+# a different package for the only audience core is published for. Now:
+#   pip install vinv-core            -> no dspy, no litellm. Hazard gone.
+#   pip install vinv-core[agents]    -> real dspy + real BerriAI litellm, which is
+#                                       CORRECT for an embedder who must configure
+#                                       `dspy.settings.lm` with their own model.
+#   uv sync (this monorepo)          -> the in-tree shim, for core's own tests.
+agents = [
+    "dspy-ai>=3.1.0,<4.0.0",
+    # In this workspace only, satisfied by the in-tree OpenAI-SDK shim
+    # (vendor/litellm_stub) via [tool.uv.sources]; elsewhere by BerriAI.
+    # dspy hard-requires litellm>=1.64.0 — see the shim's pyproject for why its
+    # version string is load-bearing.
+    "litellm",
+    # Never imported by core directly — reaches it only through dspy/the shim.
+    # Ceiling is <3.0.0, not <2.0.0: 2.x is what this workspace already resolved
+    # and tests green against, and the shim's imports (OpenAI/AsyncOpenAI,
+    # APIStatusError, types.chat) are stable across that major. A <2.0.0 cap would
+    # silently DOWNGRADE a working install, which is a regression, not a fix.
+    "openai>=1.59.0,<3.0.0",
+    # dspy imports jsonschema at module load (adapters/types/tool.py).
+    "jsonschema>=4.20.0,<5.0.0",
+    # Accurate tokenization for the context compressor. Soft-imported in
+    # components/context_compressor/token_utils.py and declared NOWHERE until
+    # now, so `count_tokens` silently fell back to `len // 4` — a 4-chars-per-token
+    # guess — for feasibility checks, chunk sizing and the reference budget. For
+    # code, which is punctuation-dense, that estimate is badly off, and the only
+    # signal was a debug-level log line. certifi is used by the same function as
+    # the SSL fallback when tiktoken downloads its encoding.
+    "tiktoken>=0.7.0,<1.0.0",
+    "certifi>=2024.2.2",
+]
 dev = [
     "pytest>=8.0.0,<10.0.0",
     "ruff>=0.6.0,<0.9.0",
+    # test_litellm_transport / test_scratchpad_blackboard / test_offload_gc_live
+    # exercise the dspy path, so the tests need the extra they cover.
+    "vinv-core[agents]",
 ]
 
 [project.urls]

--- a/core/tests/test_context_recalibration.py
+++ b/core/tests/test_context_recalibration.py
@@ -28,19 +28,17 @@ SRC = Path(__file__).resolve().parents[1] / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
+from core.components.context_compressor import unified_compression as uc  # noqa: E402
 from core.components.context_compressor.model_context_registry import (  # noqa: E402
     ModelContextRegistry,
 )
 from core.components.context_compressor.token_utils import count_tokens  # noqa: E402
-from core.components.context_compressor import unified_compression as uc  # noqa: E402
 
 
 @pytest.fixture(autouse=True)
 def fresh_registry(tmp_path, monkeypatch):
     """Reset the singleton and sandbox the persisted catalog per test."""
-    monkeypatch.setenv(
-        "VINV_ENGINE_MODEL_LIMITS_PATH", str(tmp_path / "learned_model_limits.json")
-    )
+    monkeypatch.setenv("VINV_ENGINE_MODEL_LIMITS_PATH", str(tmp_path / "learned_model_limits.json"))
     ModelContextRegistry._instance = None
     yield
     ModelContextRegistry._instance = None
@@ -49,6 +47,7 @@ def fresh_registry(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 # Overflow detection (provider-agnostic)
 # ---------------------------------------------------------------------------
+
 
 class TestOverflowDetection:
     def test_openai_400_message(self):
@@ -83,6 +82,7 @@ class TestOverflowDetection:
 # ---------------------------------------------------------------------------
 # Number extraction from provider messages
 # ---------------------------------------------------------------------------
+
 
 class TestOverflowNumberParsing:
     def test_openai_incident_numbers(self):
@@ -133,11 +133,13 @@ class TestOverflowNumberParsing:
 # Registry learning
 # ---------------------------------------------------------------------------
 
+
 class TestRegistryLearning:
     def test_learns_limit_and_inflation(self):
         reg = ModelContextRegistry()
-        reg.record_overflow("m1", estimated_tokens=155000, reported_tokens=277851,
-                            reported_limit=272000)
+        reg.record_overflow(
+            "m1", estimated_tokens=155000, reported_tokens=277851, reported_limit=272000
+        )
         assert reg.observed_input_limit("m1") == 272000
         assert reg.effective_input_limit("m1") == 272000
         assert reg.token_inflation("m1") == pytest.approx(277851 / 155000)
@@ -186,6 +188,7 @@ class TestCatalogPersistence:
 
     def test_catalog_is_valid_json_with_model_names(self, tmp_path):
         import json
+
         reg = ModelContextRegistry()
         reg.record_overflow("claude-x", 100000, 210000, 200000)
         data = json.loads((tmp_path / "learned_model_limits.json").read_text())
@@ -202,6 +205,7 @@ class TestCatalogPersistence:
 # ---------------------------------------------------------------------------
 # Recalibrating map/reduce (no truncation, resplit on overflow)
 # ---------------------------------------------------------------------------
+
 
 def _make_compressor(monkeypatch, fallback_limit: int = 200000):
     monkeypatch.setenv("VINV_ENGINE_MODEL_FALLBACK_LIMIT", str(fallback_limit))
@@ -256,9 +260,13 @@ class TestPerCallBudgetFloor:
 
         # ~700K tokens across 10 chunks of 70K; final target only 2000 tokens.
         content = "\n".join(f"L{i} " + "x " * 50 for i in range(70000))
-        asyncio.run(comp._map_reduce_recalibrating(
-            content=content, max_tokens=2000, model_id="m-floor",
-        ))
+        asyncio.run(
+            comp._map_reduce_recalibrating(
+                content=content,
+                max_tokens=2000,
+                model_id="m-floor",
+            )
+        )
 
         assert seen_budgets, "compression must have been called"
         for input_tokens, budget in seen_budgets:
@@ -291,13 +299,17 @@ class TestPerCallBudgetFloor:
 
         content = "\n".join(f"R{i} " + "y " * 40 for i in range(40000))  # ~440K tokens
         target = 10000
-        result = asyncio.run(comp._map_reduce_recalibrating(
-            content=content, max_tokens=target, model_id="m-converge",
-        ))
-        result_tokens = count_tokens(result)
-        assert result_tokens <= int(target * 1.5), (
-            f"tree failed to converge: {result_tokens} tokens vs target {target}"
+        result = asyncio.run(
+            comp._map_reduce_recalibrating(
+                content=content,
+                max_tokens=target,
+                model_id="m-converge",
+            )
         )
+        result_tokens = count_tokens(result)
+        assert result_tokens <= int(
+            target * 1.5
+        ), f"tree failed to converge: {result_tokens} tokens vs target {target}"
 
 
 class TestMapRecalibration:
@@ -314,9 +326,11 @@ class TestMapRecalibration:
             if count_tokens(content) > provider_capacity:
                 calls["overflows"] += 1
                 raise uc._ContextOverflow(
-                    count_tokens(content), provider_capacity + 100,
+                    count_tokens(content),
+                    provider_capacity + 100,
                     # Learned limit small enough that 25% fill → feasible chunks
-                    provider_capacity * 4, RuntimeError("maximum context length"),
+                    provider_capacity * 4,
+                    RuntimeError("maximum context length"),
                 )
             # "Compression": keep the first line of the chunk (marker survives).
             return content.split("\n", 1)[0]
@@ -331,9 +345,13 @@ class TestMapRecalibration:
         lines = [f"MARK-{i} " + "x " * 40 for i in range(4000)]
         content = "\n".join(lines)
 
-        result = asyncio.run(comp._map_reduce_recalibrating(
-            content=content, max_tokens=1000, model_id="m-test",
-        ))
+        result = asyncio.run(
+            comp._map_reduce_recalibrating(
+                content=content,
+                max_tokens=1000,
+                model_id="m-test",
+            )
+        )
 
         assert calls["overflows"] >= 1, "first round must overflow (default capacity too big)"
         assert result, "must produce output after recalibration"
@@ -351,7 +369,9 @@ class TestMapRecalibration:
         async def fake_compress_direct(content, max_tokens, **kwargs):
             if count_tokens(content) > provider_capacity:
                 raise uc._ContextOverflow(
-                    count_tokens(content), None, None,
+                    count_tokens(content),
+                    None,
+                    None,
                     RuntimeError("context window exceeded"),
                 )
             return content.split("\n", 1)[0]
@@ -365,9 +385,13 @@ class TestMapRecalibration:
         lines = [f"ROW-{i} " + "y " * 30 for i in range(3000)]
         content = "\n".join(lines)
 
-        result = asyncio.run(comp._map_reduce_recalibrating(
-            content=content, max_tokens=800, model_id="m-blind",
-        ))
+        result = asyncio.run(
+            comp._map_reduce_recalibrating(
+                content=content,
+                max_tokens=800,
+                model_id="m-blind",
+            )
+        )
         assert result
         assert "ROW-0" in result
 
@@ -378,16 +402,23 @@ class TestMapRecalibration:
 
         async def always_overflow(content, max_tokens, **kwargs):
             raise uc._ContextOverflow(
-                count_tokens(content), None, None, RuntimeError("context window"),
+                count_tokens(content),
+                None,
+                None,
+                RuntimeError("context window"),
             )
 
         monkeypatch.setattr(comp, "_compress_direct", always_overflow)
 
         content = "\n".join("z " * 50 for _ in range(2000))
         with pytest.raises(uc.InfeasibleCompressionError):
-            asyncio.run(comp._map_reduce_recalibrating(
-                content=content, max_tokens=100, model_id="m-dead",
-            ))
+            asyncio.run(
+                comp._map_reduce_recalibrating(
+                    content=content,
+                    max_tokens=100,
+                    model_id="m-dead",
+                )
+            )
 
 
 async def _identity_compress(content, max_tokens, **kwargs):
@@ -414,14 +445,18 @@ class TestReducePacking:
         monkeypatch.setattr(comp, "_synthesize_chunks", fake_synthesize)
 
         parts = [f"part-{i} " + "w " * 400 for i in range(12)]  # ~400 tokens each
-        result = asyncio.run(comp._reduce_recalibrating(
-            parts, max_tokens=500, model_id="m-pack",
-        ))
+        result = asyncio.run(
+            comp._reduce_recalibrating(
+                parts,
+                max_tokens=500,
+                model_id="m-pack",
+            )
+        )
         assert result
         assert seen_group_sizes, "synthesis must have been called"
-        assert all(s <= 2000 for s in seen_group_sizes), (
-            f"a reduce group exceeded per-request capacity: {seen_group_sizes}"
-        )
+        assert all(
+            s <= 2000 for s in seen_group_sizes
+        ), f"a reduce group exceeded per-request capacity: {seen_group_sizes}"
 
     def test_reduce_overflow_recalibrates_and_repacks(self, monkeypatch):
         monkeypatch.setenv("VINV_ENGINE_MODEL_FALLBACK_LIMIT", "8000")
@@ -433,7 +468,9 @@ class TestReducePacking:
             group_tokens = sum(count_tokens(p) for p in parts)
             if group_tokens > provider_capacity:
                 raise uc._ContextOverflow(
-                    group_tokens, group_tokens + 50, provider_capacity * 4,
+                    group_tokens,
+                    group_tokens + 50,
+                    provider_capacity * 4,
                     RuntimeError("maximum context length"),
                 )
             return parts[0][:200]
@@ -441,9 +478,13 @@ class TestReducePacking:
         monkeypatch.setattr(comp, "_synthesize_chunks", fake_synthesize)
 
         parts = [f"seg-{i} " + "v " * 300 for i in range(10)]
-        result = asyncio.run(comp._reduce_recalibrating(
-            parts, max_tokens=400, model_id="m-reduce",
-        ))
+        result = asyncio.run(
+            comp._reduce_recalibrating(
+                parts,
+                max_tokens=400,
+                model_id="m-reduce",
+            )
+        )
         assert result
         assert ModelContextRegistry().observed_input_limit("m-reduce") == provider_capacity * 4
 
@@ -460,9 +501,13 @@ class TestReducePacking:
         monkeypatch.setattr(comp, "_synthesize_chunks", broken_synthesize)
 
         parts = [f"keep-{i} " + "u " * 100 for i in range(6)]
-        result = asyncio.run(comp._reduce_recalibrating(
-            parts, max_tokens=50, model_id="m-stall",
-        ))
+        result = asyncio.run(
+            comp._reduce_recalibrating(
+                parts,
+                max_tokens=50,
+                model_id="m-stall",
+            )
+        )
         for i in range(6):
             assert f"keep-{i}" in result, "verbatim join must preserve every part"
 
@@ -512,6 +557,7 @@ class TestDirectCompressOverflowSignal:
 # Artifact-backed observations for massive outputs (grep, don't compress)
 # ---------------------------------------------------------------------------
 
+
 class TestLogArtifact:
     def test_full_content_preserved_on_disk(self, tmp_path, monkeypatch):
         from core.components.context_compressor import log_artifact
@@ -522,7 +568,7 @@ class TestLogArtifact:
         lines[40000] = "Traceback (most recent call last):"
         content = "\n".join(lines)
 
-        digest = log_artifact.store_and_digest(content, "terminal-cmd", 5000)
+        log_artifact.store_and_digest(content, "terminal-cmd", 5000)
 
         artifacts = list(tmp_path.glob("*.log"))
         assert len(artifacts) == 1
@@ -555,9 +601,9 @@ class TestLogArtifact:
         budget = 8000
         digest = log_artifact.store_and_digest(content, "flood", budget)
         # Head/tail/diagnostics are line-derived; allow modest overhead.
-        assert count_tokens(digest) <= budget * 2, (
-            f"digest {count_tokens(digest)} tokens far exceeds budget {budget}"
-        )
+        assert (
+            count_tokens(digest) <= budget * 2
+        ), f"digest {count_tokens(digest)} tokens far exceeds budget {budget}"
 
     def test_incident_scale_17M_tokens_no_llm_needed(self, tmp_path, monkeypatch):
         """The incident's 17.5M-token capture becomes a bounded digest with
@@ -565,10 +611,21 @@ class TestLogArtifact:
         from core.components.context_compressor import log_artifact
 
         monkeypatch.setenv("VINV_ENGINE_ARTIFACT_DIR", str(tmp_path))
-        # ~17.5M tokens ≈ 70M chars (token ≈ chars/4, consistently).
+        # 70M chars of filler. The assertion is a SCALE floor, not a token count:
+        # this test is about handling an incident-scale capture with zero LLM
+        # calls, and the exact token total is tokenizer-dependent scaffolding.
+        #
+        # It previously asserted >= 17.5M on the stated assumption "token ≈
+        # chars/4, consistently" — which was the CHARACTER FALLBACK's arithmetic,
+        # not the tokenizer's. tiktoken was soft-imported and declared in no
+        # manifest, so count_tokens silently returned len // 4 and the assumption
+        # held by construction. With the real BPE tokenizer declared and present,
+        # long runs of one character compress into multi-char tokens and the same
+        # 70M chars measure ~11M tokens. Both are incident scale; the floor is set
+        # below the tokenizer-sensitive range so it holds either way.
         block = ("x" * 69 + "\n") * 1000  # 70K chars
         content = block * 1000  # 70M chars
-        assert count_tokens(content) >= 17_000_000
+        assert count_tokens(content) >= 10_000_000
 
         digest = log_artifact.store_and_digest(content, "monster", 50000)
         assert count_tokens(digest) <= 100000
@@ -580,19 +637,25 @@ class TestLogArtifact:
 # different windows, different failure shapes — same guarantees.
 # ---------------------------------------------------------------------------
 
+
 class TestStressConditions:
     @pytest.mark.parametrize(
         "window,provider_message",
         [
-            (272000, "This model's maximum context length is {limit} tokens. "
-                     "However, your messages resulted in {count} tokens."),
+            (
+                272000,
+                "This model's maximum context length is {limit} tokens. "
+                "However, your messages resulted in {count} tokens.",
+            ),
             (200000, "prompt is too long: {count} tokens > {limit} maximum"),
-            (131072, "input length exceeds the maximum of {limit} tokens "
-                     "(requested {count})"),
+            (131072, "input length exceeds the maximum of {limit} tokens " "(requested {count})"),
         ],
     )
     def test_any_provider_error_shape_recalibrates(
-        self, monkeypatch, window, provider_message,
+        self,
+        monkeypatch,
+        window,
+        provider_message,
     ):
         comp = _make_compressor(monkeypatch, fallback_limit=1000000)  # wrong prior
         provider_content_capacity = window // 4
@@ -600,9 +663,7 @@ class TestStressConditions:
         async def fake_compress_direct(content, max_tokens, **kwargs):
             tokens = count_tokens(content)
             if tokens > provider_content_capacity:
-                err = RuntimeError(
-                    provider_message.format(limit=window, count=tokens + 500)
-                )
+                err = RuntimeError(provider_message.format(limit=window, count=tokens + 500))
                 reported, limit = uc._parse_overflow_numbers(err)
                 raise uc._ContextOverflow(tokens, reported, limit, err)
             return content.split("\n", 1)[0]
@@ -614,18 +675,24 @@ class TestStressConditions:
         monkeypatch.setattr(comp, "_synthesize_chunks", fake_synthesize)
 
         content = "\n".join(f"E{i} " + "z " * 60 for i in range(30000))  # ~500K tokens
-        result = asyncio.run(comp._map_reduce_recalibrating(
-            content=content, max_tokens=5000, model_id=f"m-{window}",
-        ))
+        result = asyncio.run(
+            comp._map_reduce_recalibrating(
+                content=content,
+                max_tokens=5000,
+                model_id=f"m-{window}",
+            )
+        )
         assert result
         assert ModelContextRegistry().observed_input_limit(f"m-{window}") == window
 
     def test_learned_numbers_prevent_repeat_failures_next_process(
-        self, monkeypatch, tmp_path,
+        self,
+        monkeypatch,
+        tmp_path,
     ):
         """After one overflow, a NEW process must plan feasible chunks
         immediately from the persisted catalog — before any failure."""
-        comp = _make_compressor(monkeypatch, fallback_limit=1000000)
+        _make_compressor(monkeypatch, fallback_limit=1000000)
         reg = ModelContextRegistry()
         reg.record_overflow("gpt-5.4-nano", 250000, 277851, 272000)
 
@@ -647,7 +714,8 @@ class TestStressConditions:
         big = "\n".join(f"install line {i}" for i in range(20000))
         big += "\nERROR: dependency conflict detected\nfinal line"
         result = _bounded_output(
-            {"status": "success", "output": big}, "terminal-cmd",
+            {"status": "success", "output": big},
+            "terminal-cmd",
         )
 
         assert result["output"] != big, "raw megabytes must not pass through"
@@ -659,6 +727,7 @@ class TestStressConditions:
 
     def test_terminal_small_output_passes_through(self, monkeypatch):
         from core.components.tools.terminal.terminal_tools import _bounded_output
+
         small = {"status": "success", "output": "ok\n"}
         assert _bounded_output(dict(small), "terminal-cmd") == small
 
@@ -672,8 +741,12 @@ class TestStressConditions:
 
         monkeypatch.setattr(comp, "_compress_direct", never_called)
         content = "\n".join("c " * 50 for _ in range(20000))
-        result = asyncio.run(comp._map_reduce_recalibrating(
-            content=content, max_tokens=100, model_id="m-cancel",
-            cancel_event=cancel,
-        ))
+        result = asyncio.run(
+            comp._map_reduce_recalibrating(
+                content=content,
+                max_tokens=100,
+                model_id="m-cancel",
+                cancel_event=cancel,
+            )
+        )
         assert result == content  # cancelled before any work — lossless

--- a/core/vendor/litellm_stub/pyproject.toml
+++ b/core/vendor/litellm_stub/pyproject.toml
@@ -1,4 +1,30 @@
 # In-tree replacement for BerriAI litellm: OpenAI SDK only (DSPy + Vinv Engine call sites).
+#
+# WHY THIS EXISTS AT ALL. `core` imports dspy at module load
+# (core/__init__.py -> components/agents/base_agent.py), and dspy 3.2.1 hard-requires
+# `litellm>=1.64.0`. Vinv itself never makes an in-process LLM call — every agent run is
+# delegated to an external harness CLI, and core.llm.ensure_dspy_lm_configured() RAISES
+# HarnessOnlyLLMError rather than configuring a cloud LM — so the real BerriAI package
+# would be a large transitive tree carried purely to satisfy an import. This shim stands
+# in for it: measured against dspy 3.2.1, it covers every litellm attribute dspy actually
+# references (the only two textual "gaps" are a docs URL and a string literal in an
+# allowlist), and `import dspy` succeeds against it.
+#
+# THE VERSION STRING IS LOAD-BEARING — DO NOT "CORRECT" IT. `1.81.13+...` is what makes
+# dspy's `litellm>=1.64.0` requirement resolve. Changing it to an honest low number (0.1.0,
+# 1.0.0) silently fails that constraint and the resolver pulls BerriAI litellm alongside
+# this package, whose `litellm/` directory then collides with it. Bump the numeric part only
+# to track the BerriAI release whose API surface this shim mirrors.
+#
+# KNOWN LIMITATION (see docs/dependency-and-capability-design.md). The substitution is a
+# `tool.uv.sources` redirect in core/pyproject.toml, which is uv-only and is NOT recorded in
+# built wheel metadata. So it applies in the monorepo venv — exactly where core's agents
+# never run — and does NOT apply to `pip install vinv-core`, which is the only audience core
+# is published for (core/README.md documents embedding it). Those users get BerriAI litellm
+# from PyPI against an unpinned `"litellm"` requirement. The substitution therefore works
+# only where it is unnecessary and is absent everywhere it is needed. Fixing that changes
+# what a published package installs for third parties, so it is a product decision, not a
+# drive-by edit.
 [project]
 name = "litellm"
 version = "1.81.13+vinv_engine.openai"

--- a/docs/dependency-and-capability-design.md
+++ b/docs/dependency-and-capability-design.md
@@ -1,0 +1,560 @@
+# Dependency & capability management — audit and design
+
+Status: proposal. Covers every path by which Vinv acquires a third-party library,
+for itself and for the projects and agents it drives.
+
+The OTel skew that prompted this is one instance of a general defect, so the
+audit is organised by *regime* (how intent is expressed and enforced) rather than
+by package.
+
+---
+
+## Part 1 — Audit
+
+Four regimes coexist. They share no policy, no verification, and in two cases
+they write to the same directory without knowing about each other.
+
+| # | Regime | Where | Intent expressed as | Verified? |
+|---|--------|-------|--------------------|-----------|
+| R1 | Engine deps | root `pyproject.toml` + `uv.lock` | declarative manifest | partially |
+| R2 | Target-project deps | `bringup/…/prompts/*.txt` | **English prose run by an LLM** | no |
+| R3 | Zero-install injection | `tracelens/…/launcher/run.py` | `sys.path` append | no |
+| R4 | Capability injection | `extension/src/mcp/`, soft-imports | mixed | no |
+
+### R1 — Engine dependencies: uv workspace, one lockfile
+
+Nine members under `[tool.uv.workspace]`, one `uv.lock`, cross-member refs via
+`tool.uv.sources = { workspace = true }`. The shape is right and modern. The
+enforcement around it is not.
+
+**No lock enforcement in CI.** `.github/workflows/test.yml:24`, `:77` and
+`lint.yml:55` all run a bare `uv sync`. Bare sync is free to re-resolve and
+rewrite `uv.lock`; nothing fails when the committed lock and the resolved set
+disagree. A dependency drift lands green.
+
+**No shared constraint policy.** Members were each pinned by hand, and they
+disagree. Measured across all nine manifests:
+
+| Package | Divergence |
+|---|---|
+| `pydantic` | `>=2.0.0,<3.0.0` (contracts, tracelens) vs **uncapped** `>=2.10.5` (core) |
+| `jsonschema` | `>=4.20.0,<5.0.0` (contracts, tracelens) vs **uncapped** `>=4.0.0` (core) |
+| `pyyaml` | `>=6.0.1,<7.0.0` (tracelens) vs **uncapped** `>=6.0.0` (core) |
+| `httpx` | `>=0.27.0,<0.29.0` (tracelens[demo]) vs **uncapped** `>=0.24.0` (core) |
+| `pytest` | `>=9.0.3,<10.0.0` (tracelens[dev]) vs `>=8.0.0,<10.0.0` (root + 8 members) |
+
+Fourteen requirements carry no upper bound at all, concentrated in `core`
+(`dspy-ai`, `openai`, `litellm`, `pexpect`, `websocket-client`, `pydantic`,
+`httpx`, `jsonschema`, `pyyaml`) and `embedder` (`torch`, `huggingface-hub`,
+`einops`). Every one of those is a silent-major-bump waiting for the next
+`uv lock`. The root `pytest>=8.0.0` is already counterfactual — tracelens's
+`>=9.0.3` wins the resolution, so root's declared floor describes a version the
+workspace never installs.
+
+**The `litellm` shim does not survive a non-uv install.** `core/pyproject.toml`
+declares a bare, unpinned `"litellm"` and redirects it locally:
+
+```toml
+dependencies = ["litellm", ...]
+[tool.uv.sources]
+litellm = { path = "vendor/litellm_stub", editable = true }
+```
+
+`tool.uv.sources` is uv-only and is **not** recorded in built wheel metadata. Any
+`pip install vinv-core` therefore resolves **BerriAI `litellm` from PyPI** — a
+different package with a large transitive tree — in place of the in-tree
+OpenAI-only shim. The stub's version string, `1.81.13+vinv_engine.openai`, makes
+the substitution look plausible in `pip show` output rather than obvious. This is
+a correctness and supply-chain hazard, not a style issue.
+
+**Dead declaration.** `tracelens`'s `otel-libs` extra
+(`tracelens/pyproject.toml:31-39`) is installed by nothing in the repo — not
+`install.sh`, not CI, not the extension, not bringup.
+
+**No policy document.** `docs/` has none; `AGENTS.md` says only `uv sync`.
+
+### R2 — Target-project dependencies: an LLM as the package resolver
+
+This is where the OTel skew lives. `bringup` renders shell into a prompt and an
+LLM agent executes it against the *target service's* venv:
+`bringup/src/bringup/runner.py:135-158` defines `_OTEL_PIN_SPECS`;
+`prompts/otel_pin_block.txt` and `prompts/tracelens_install_editable.txt` carry
+the instructions.
+
+Five structural problems, in order of severity.
+
+**1. Two writers to one venv, with incompatible semantics and no arbitration.**
+`uv sync` is a *converging, exact* reconciler — it prunes extraneous packages by
+default. bringup's path is an *imperative, additive* one-shot
+(`pip install --force-reinstall`, `uv pip install --reinstall`). Last writer wins
+and neither can observe the other.
+
+This is directly observable in this workspace right now:
+
+```
+opentelemetry_instrumentation_urllib3-0.49b2.dist-info    INSTALLER=uv  REQUESTED=yes
+opentelemetry_instrumentation_logging-0.49b2.dist-info    INSTALLER=uv  REQUESTED=yes
+opentelemetry_instrumentation_starlette-0.49b2.dist-info  INSTALLER=uv  REQUESTED=yes
+```
+
+None of those three appear anywhere in `uv.lock`. They are agent-injected
+packages living inside a lock-managed venv: invisible to `uv lock`, `uv sync` and
+CI, and scheduled for silent deletion by the next exact sync — which will remove
+instrumentation coverage with no error and no log line.
+
+**2. The pin's sanity check runs upstream of the step that breaks it.** Step 3
+asserts two versions (`opentelemetry-api`, `opentelemetry-instrumentation`) and
+two imports. Step 4 then runs
+`python -m opentelemetry.instrumentation.bootstrap -a install`, which installs
+*more* contrib packages afterwards. The check cannot see them. That ordering is
+exactly how `0.65b0` contrib landed on a `0.49b2` base and produced
+
+```
+ImportError: cannot import name 'HTTP_DURATION_HISTOGRAM_BUCKETS_NEW'
+             from 'opentelemetry.instrumentation._semconv'
+```
+
+**3. `bootstrap -a install` is unpinnable by construction.** It resolves "latest
+compatible" against the target venv at run time and accepts no version argument.
+Any design that calls it has given up determinism at that point. OpenTelemetry's
+own guidance is to pin core and contrib together as a set — core `1.X.0` with
+contrib `0.(X+21)b0` — which is a statement about a *set*, and `bootstrap` cannot
+express a set.
+
+**4. Prose is not a resolver.** `otel_pin_block.txt` is a six-row installer table
+(Poetry / uv / PDM / Pipenv / conda / plain venv) in natural language, with
+"switch installers, do not abort" instructions. The branches differ in real
+semantics — `--force-reinstall` vs `--reinstall`, `--no-deps` present in one step
+and explicitly absent in the next. An LLM choosing among them *is* the dependency
+resolver, and it is nondeterministic.
+
+**5. One correction to the original diagnosis.** The venv is currently
+**coherent** at `1.28.2` / `0.49b2`, and the ImportError does not reproduce —
+`opentelemetry.instrumentation.{requests,httpx,urllib3,starlette}` all import
+cleanly, and `HTTP_DURATION_HISTOGRAM_BUCKETS_NEW` is absent from `_semconv`
+because every package is on the older pair. The skew was transient: a
+re-resolution pulled the whole set *down* to satisfy tracelens's
+`opentelemetry-instrumentation>=0.48b0,<0.50.0`.
+
+That healing is the other half of the bug. It silently discarded bringup's
+`1.44.0`/`0.65b0` intent — and the comment at `runner.py:130-134` states that
+contrib `<0.64b0` crashes every request on FastAPI ≥0.137. So the workspace is
+now sitting on the version pair bringup itself considers broken, arrived at by
+accident, with nothing reporting the reversal.
+
+### R3 — Zero-install injection: already built, better, and bypassed
+
+`tracelens` already implements foreign-venv capture with **no installs into the
+target**:
+
+- `run.py:552` `_capture_dependency_roots()` — resolves the directories holding
+  tracelens's own OTel / PyYAML / wrapt / `importlib_metadata` via `find_spec` on
+  the *current* interpreter.
+- `run.py:668-680` — hands them to the target interpreter as
+  `TRACELENS_CAPTURE_DEP_ROOTS` and re-execs into the target's own python.
+- `run.py:588` `_install_capture_dep_fallback()` — child side, **appends** each
+  root to `sys.path`.
+- `child_bootstrap.py:114` — writes a `sitecustomize.py` into a private dir and
+  prepends it to `PYTHONPATH`, so every inheriting child process is covered.
+
+This is the same mechanism the OpenTelemetry Operator uses (init container copies
+instrumentation into a shared volume, `PYTHONPATH` points at it) and the same one
+`ddtrace` uses for single-step instrumentation. The repo has the industry-standard
+primitive, and bringup ignores it in favour of mutating the target venv.
+
+**But R3 carries the identical failure class, latent.** `opentelemetry` is a
+**native namespace package** — verified: no `__init__.py` in site-packages, and
+`opentelemetry.__path__` is a `_NamespacePath`. Namespace packages **merge their
+`__path__` across every `sys.path` entry**. So with append-precedence and a target
+venv holding a *partial* OTel install:
+
+- `opentelemetry.sdk` resolves from the target venv (earlier on the path), and
+- `opentelemetry.instrumentation.requests` resolves from the injected root (later),
+
+giving a mixed-version import *inside one namespace* — the exact
+`HTTP_DURATION_HISTOGRAM_BUCKETS_NEW` failure, reachable through the "clean" path.
+The docstring's claim that "the target's own copy always wins" is true
+per-**module** but not per-**distribution**, and for a namespace package that
+distinction is the whole bug.
+
+### R4 — Capability injection: how tools reach the agents
+
+Two sub-cases with opposite quality.
+
+**MCP tool injection is the best-designed component in the system.**
+`extension/src/mcp/mcpRegistrar.ts` builds one neutral `McpServerSpec`
+(`command`/`args`/`env`), then adapts it per client dialect (Cursor / Claude Code
+`mcpServers`, VS Code `servers`, Codex). Detection is folder-based, writes are
+idempotent merges that never touch other servers' config, every `write()` has a
+matching `remove()`, `LEGACY_KEYS` handles migration from renamed servers, and
+machine-specific absolute paths are deliberately confined to per-machine config
+so they never land in a repo-tracked `.mcp.json`. Declarative, reversible,
+verified. **This is the pattern the rest of the system should copy.**
+
+**The verification/test tools the agents use are the opposite.** Nothing declares
+them, so "optional" currently means three unrelated things with no runtime
+distinction:
+
+| Tool | Documented as | Declared in a manifest | In `uv.lock` | Installed | Reality |
+|---|---|---|---|---|---|
+| `hypothesis-jsonschema` | **"Adopted"** (`generators.py:10`) | **no** | no | **no** | arm permanently dead |
+| `hypothesis` | required by that arm | root **dev group only** | yes | dev only | dev ≠ user behaviour |
+| `CrossHair` | "kept optional/unwired" | no | no | no | comment only |
+| `dowhy`, `pyrca` | `tracelens[rca]` extra | yes | no | no | extra never installed |
+| `evidently` | `tracelens[drift]` extra | yes | no | no | extra never installed |
+| `z3-solver` | evaluated, **declined with rationale** | n/a | n/a | n/a | **correct** |
+
+The `hypothesis-jsonschema` case is the sharpest. `generators.py` calls it
+*adopted*, `hypothesis_valid_available()` gates a real generator arm on it,
+`plan.py:216` consumes that arm — and the package is declared in no
+`pyproject.toml`, absent from `uv.lock`, and not importable (`ModuleNotFoundError`
+confirmed). The arm has never run in any install that has ever existed. Its own
+tests (`exerciser/tests/test_generators.py:16`) branch on availability, so they
+pass while covering nothing.
+
+Downstream this is worse than a missing feature. `exerciser`'s Thompson-sampling
+bandit explores `(target × technique × oracle)`; a technique whose capability is
+absent stays in the action space and gets pulled, so the bandit spends real budget
+learning that a package nobody installed finds no bugs.
+
+`z3-solver` is the counter-example and the template:
+`extension/src/harness/rewardSignals.ts:25-32` records that the WASM build works
+in the extension host, what it would be used for (assertion-vacuity screening),
+why that is already subsumed by the executable fail-on-pre gate, and that it
+remains the vetted path if real constraint solving is ever needed. A decision,
+a rationale, and zero cost. It is the only tool in the table whose status is
+unambiguous — and it is unambiguous because someone wrote it down, not because
+any mechanism enforced it.
+
+### Root cause, in one sentence
+
+Every regime except the MCP registrar expresses dependency intent as **imperative
+instructions executed at a moment** rather than **declarative state reconciled
+against a lock** — so intent is unverifiable, unpinnable, and destroyed by the
+next writer.
+
+---
+
+## Part 2 — Design
+
+### What "robust anywhere" has to mean
+
+The design target is not "works on my machine after a `uv sync`". It is: the same
+bytes, with the same behaviour, against a target project that may be managed by
+pip / Poetry / PDM / Pipenv / conda / uv, in a venv that may have no `pip` at
+all, possibly PEP 668 externally-managed, possibly on a read-only filesystem,
+possibly in a container, possibly offline, on any Python 3.9–3.14 — **without
+writing a single byte into the target's environment, and with no LLM anywhere in
+the resolution path.**
+
+### Six principles
+
+1. **One resolver, one lockfile, zero prose.** Anything a machine must install is
+   declared in a manifest a resolver reads. No installer tables in prompts.
+2. **Never write to a venv you do not own.** The target project's environment is
+   read-only. Injection happens through the import system, not the installer.
+3. **Ship capability as a sealed set, never as individual packages.** A bundle is
+   atomic: all of it from one root, or none of it.
+4. **Precedence is decided per bundle, not per module.** A namespace must never be
+   satisfied from two roots at once.
+5. **Capability availability is a reported value, not a silent absence.**
+6. **Every declaration is verified by a test that fails when the declaration is
+   wrong.**
+
+### (a) One dependency policy at the workspace root
+
+Add root-level constraints. uv reads `constraint-dependencies` from the workspace
+root and applies them across every member, so members keep their own ranges while
+the root becomes the single arbiter of shared ceilings:
+
+```toml
+# root pyproject.toml
+[tool.uv]
+required-version = ">=0.9,<1.0"          # the resolver itself is a dependency
+constraint-dependencies = [
+    "pydantic>=2.10.5,<3.0.0",
+    "jsonschema>=4.20.0,<5.0.0",
+    "PyYAML>=6.0.1,<7.0.0",
+    "httpx>=0.27.0,<0.29.0",
+    "click>=8.1.0,<9.0.0",
+    "pytest>=9.0.3,<10.0.0",
+    "ruff>=0.6.0,<0.9.0",
+]
+```
+
+Alongside it:
+
+- **Cap the fourteen uncapped requirements.** `torch` and `dspy-ai` especially —
+  an unbounded floor on either is an unbounded blast radius.
+- **Make the `litellm` shim honest.** Rename the vendored distribution to
+  `vinv-litellm-shim` (still providing the `litellm` *import* package) and depend
+  on it under that name. The substitution then survives every install path, not
+  just uv's, and `pip install vinv-core` can no longer silently pull BerriAI.
+- **CI: `uv sync --locked` everywhere, plus `uv lock --check`.** Drift fails the
+  build instead of landing green.
+- **Delete `otel-libs`** — it is superseded by (b).
+
+### (b) The capability bundle — replaces R2 entirely
+
+A **bundle** is a directory tree built by uv, from a locked manifest, at build
+time, and injected read-only at run time.
+
+```
+capabilities/
+  otel-capture/      pyproject.toml + uv.lock   # the ONLY place OTel versions are written
+  propertygen/       pyproject.toml + uv.lock   # hypothesis, hypothesis-jsonschema
+  symbolic/          pyproject.toml + uv.lock   # z3-solver, crosshair-tool
+```
+
+Each manifest carries exact pins, a `requires-python` floor, and — new — the
+top-level import namespaces the bundle **owns**:
+
+```toml
+[project]
+name = "vinv-capability-otel-capture"
+requires-python = ">=3.9"
+dependencies = [
+    "opentelemetry-api==1.44.0",
+    "opentelemetry-sdk==1.44.0",
+    "opentelemetry-semantic-conventions==0.65b0",
+    "opentelemetry-instrumentation==0.65b0",
+    "opentelemetry-instrumentation-fastapi==0.65b0",
+    # …the full contrib set, explicitly. No `bootstrap -a install`.
+]
+
+[tool.vinv.capability]
+owns = ["opentelemetry"]        # this bundle is the sole source for this namespace
+```
+
+Build (once, per release, offline-capable):
+
+```bash
+uv sync --locked --project capabilities/otel-capture \
+        --python 3.9 --target capabilities/otel-capture/.bundle
+```
+
+`--target` produces a flat, relocatable tree with `.dist-info` intact, so
+entry-point discovery — which OTel depends on heavily — keeps working.
+
+**Injection, with the three-way rule that fixes the namespace bug.** Replace the
+`sys.path` append with a `MetaPathFinder` scoped to the bundle's owned namespaces.
+At injection, for each owned namespace, compare what the *target* provides against
+the bundle's own requirement set:
+
+| Target provides | Action |
+|---|---|
+| **none** of the namespace | **prepend the bundle** — the whole namespace comes from one root, coherent by construction |
+| **all** of the bundle's requirements, satisfying its version set | **stand down** — use the target's own copy, report which |
+| **some** of it | **hard, named error** — never a silent merge |
+
+Today's append-and-hope collapses all three into the middle case, and the middle
+case is the bug. Deciding per *bundle* rather than per *module* is what makes a
+namespace package safe to inject.
+
+**`bootstrap -a install` disappears.** The contrib set becomes a declared,
+locked list. The genuinely dynamic question — *which* instrumentors to activate
+for this particular service — is answered at run time by
+`probe_contrib_instrumenters()`, which already exists at `otel_setup.py:64`. That
+is the correct split: **discovery stays dynamic, installation becomes static.**
+
+**Multi-Python and native wheels.** The OTel bundle is pure Python, so one tree
+covers 3.9–3.14. Bundles with native wheels (`z3-solver`) build per
+`(python-tag, platform-tag)` and resolve at inject time; a missing combination
+yields *capability unavailable, with a reason* — never a broken import.
+
+### (c) Capability manifest and honest reporting
+
+This is the fix for the z3 / CrossHair / `hypothesis-jsonschema` class. One
+machine-readable registry, one entry per tool:
+
+```toml
+[capability.hypothesis-jsonschema]
+bundle    = "propertygen"
+provides  = "generator-arm:hypothesis_valid"
+probe     = "hypothesis_jsonschema"
+status    = "adopted"                 # adopted | deferred | rejected
+rationale = "property-based valid instances drawn from the JSON schema"
+
+[capability.crosshair]
+status    = "deferred"
+provides  = "function-level symbolic execution over pure typed functions"
+rationale = "orthogonal to exercising HTTP endpoints against a live traced service"
+
+[capability.z3-solver]
+status    = "rejected"
+rationale = "assertion-vacuity screening is subsumed by the executable fail-on-pre gate"
+```
+
+Enforced by CI, so a declaration that stops being true fails the build:
+
+- `status = "adopted"` ⇒ the probe must import **and** an eval must show the arm
+  actually producing output. This is precisely the check that would have caught
+  `hypothesis-jsonschema` on day one.
+- `status = "deferred"` / `"rejected"` ⇒ a rationale is mandatory, and CI asserts
+  **no code path references it**. This promotes the z3 comment from prose to a
+  checked contract.
+
+At run time, every engine emits a `capabilities` block into its run record —
+bundle, resolved version, and `active | standing-down | unavailable(reason)`. Two
+consumers change behaviour on it:
+
+- **The bandit excludes arms whose capability is unavailable from the action
+  space**, instead of sampling them and silently no-op'ing.
+- **The context pack surfaces the block to the harness agent**, so the agent knows
+  whether it has a solver rather than guessing.
+
+### (d) Prompts describe intent, never commands
+
+bringup's job becomes "start this service, unmodified." No installer table, no
+version pins in prose, no `--force-reinstall`, no fallback-installer ladder. If a
+bundle cannot be injected, bringup fails with a named error identifying the bundle
+and the conflict. The ~8 KB of installer prose across `otel_pin_block.txt` and
+`tracelens_install_editable.txt` collapses to roughly one instruction: run the
+service under `tracelens run`.
+
+This also removes the LLM from the resolution path, which is the single largest
+source of nondeterminism in the current system.
+
+### (e) Close the engine-pin loop in the extension
+
+`ENGINE_REF` pinning (`extension/src/engines/pinned.ts`) is already the right
+idea: extension version ⇒ engine commit, 1:1. Two gaps:
+
+- The engines checkout should be synced with `uv sync --locked` at the stamped
+  ref, not a bare `uv sync` (`install.ts:195`, `:204`).
+- `enginesSynced()` should verify the **lock hash**, not merely that a venv
+  exists — otherwise a moved lock yields a different engine set than the vsix was
+  cut against, which is R1's drift problem wearing R4's clothes.
+
+### Migration order
+
+Cheapest first; each step is independently shippable and independently valuable.
+
+| # | Step | Cost | Buys |
+|---|---|---|---|
+| 1 | `uv sync --locked` + `uv lock --check` in all three workflows | hours | stops **new** drift immediately |
+| 2 | Root `constraint-dependencies`; cap the 14 uncapped; rename the litellm shim | ~1 day | removes the silent-major-bump and wrong-litellm classes |
+| 3 | Extract `capabilities/otel-capture`; delete `_OTEL_PIN_SPECS`, both prompt install sections, and the `bootstrap -a install` step | ~3 days | **kills the reported bug at the root** |
+| 4 | Bundle `MetaPathFinder` with the own / stand-down / conflict rule, replacing the `sys.path` append | ~2 days | closes the latent namespace-merge hazard in R3 |
+| 5 | Capability manifest + CI probes + run-record reporting + bandit action-space filter | ~3 days | no more silently-degraded agents |
+| 6 | `propertygen` and `symbolic` bundles; wire `hypothesis-jsonschema` for real; resolve CrossHair to adopted-or-rejected | ~2 days | the declared test-tool surface becomes the real one |
+
+Steps 1 and 2 are pure hygiene and worth doing regardless. Step 3 is the one that
+makes the OTel failure structurally impossible rather than currently absent.
+
+### Properties achieved
+
+- Zero writes to any environment Vinv does not own.
+- Identical bytes on every machine; the bundle is built once and locked.
+- Works against pip-less venvs, Poetry / PDM / conda / uv, PEP 668
+  externally-managed environments, read-only filesystems, containers, CI, and
+  offline.
+- No LLM in the resolution path.
+- A version set can be **verified as a set**, before use, with a named error on
+  conflict instead of an `ImportError` mid-request.
+- Missing capability is reported and routed around, never silently absent.
+
+---
+
+## Sources
+
+- [Versioning and stability for OpenTelemetry clients](https://opentelemetry.io/docs/specs/otel/versioning-and-stability/)
+- [Dependency pinning between packages post 1.0 — opentelemetry-python discussion #1754](https://github.com/open-telemetry/opentelemetry-python/discussions/1754)
+- [opentelemetry-python-contrib CHANGELOG](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CHANGELOG.md)
+- [Injecting auto-instrumentation — OpenTelemetry Operator](https://opentelemetry.io/docs/platforms/kubernetes/operator/automatic/)
+- [Understanding how Python auto-instrumentation works — operator issue #1267](https://github.com/open-telemetry/opentelemetry-operator/issues/1267)
+- [dd-trace-py: user sitecustomize directory proposal (#1344)](https://github.com/DataDog/dd-trace-py/issues/1344)
+- [uv — Resolution (constraints, overrides, build constraints)](https://docs.astral.sh/uv/concepts/resolution/)
+- [uv — Locking and syncing (`--locked`, `--exact` / `--inexact`)](https://docs.astral.sh/uv/concepts/projects/sync/)
+- [uv — Using workspaces](https://docs.astral.sh/uv/concepts/projects/workspaces/)
+- [Should `uv sync` remove extraneous packages? (#4358)](https://github.com/astral-sh/uv/issues/4358)
+- [PEP 723 inline script metadata in uv](https://deepwiki.com/astral-sh/uv/12.1-pep-723-inline-script-metadata)
+
+---
+
+## Part 3 — Addendum: findings from running Vinv on Vinv
+
+Added after auditing the live `.vinv` state and captures in this workspace.
+
+### 3.1 `core` is unused by this repo — deliberately, not accidentally
+
+Measured: `core` is **18,389 lines across 69 files**, declares **no console script**,
+is depended on by **no workspace member**, is imported by **nothing**, and the
+extension never spawns it. Its git history is the initial public release plus
+only mechanical commits (lint, `[project.urls]`, Python-version policy).
+
+That is not accidental dead code. `core/README.md` has an `// 01 · embed the
+agent runtime (optional)` section, `core/__init__.py` exports `BaseSwarmAgent`
+and `TerminalExecutorAgent`, and `core/src/core/llm.py` states the contract
+explicitly: the open-source build is **harness-only**, and
+`ensure_dspy_lm_configured()` *raises* `HarnessOnlyLLMError` rather than
+configuring a cloud LM, so "no code path can silently reintroduce network LLM
+calls." Verified live: it raises.
+
+So `core` is a published embeddable library that this monorepo does not consume.
+It should not be deleted on dead-code grounds. But it is the origin of most of
+the constraint problems in Part 1: every uncapped/divergent shared requirement
+flagged there (`pydantic`, `jsonschema`, `httpx`, `pyyaml`, plus `dspy-ai`,
+`openai`, `pexpect`, `websocket-client`) is declared by `core` — a package
+nothing in the repo installs for its own use.
+
+### 3.2 Why `litellm` is present, and the exact inversion in its substitution
+
+Vinv makes **no in-process LLM call**: every agent run is delegated to an
+external harness CLI (`claude`, `codex`, `cursor-agent`, `gemini`), and the LLM
+boundary actively refuses to configure a model. `litellm` is therefore unused
+for Vinv's own agent work.
+
+It is nevertheless not removable as things stand: `core` imports `dspy` at module
+load, and **dspy 3.2.1 hard-requires `litellm>=1.64.0`**. The in-tree shim
+(`core/vendor/litellm_stub`, 588 lines) exists to satisfy that import without
+BerriAI's transitive tree, and it does the job — measured against dspy 3.2.1 it
+covers every litellm attribute dspy actually references, and `import dspy`
+succeeds against it. Two apparent gaps (`litellm.ai`, `litellm.types`) are a
+docs URL and a string literal in an allowlist, not real uses.
+
+Two things about it are worth recording:
+
+1. **The shim's version string is load-bearing.** `1.81.13+vinv_engine.openai` is
+   what makes dspy's `litellm>=1.64.0` resolve. An "honest" low version silently
+   fails the constraint and the resolver pulls BerriAI litellm alongside the
+   shim, whose `litellm/` directory then collides with it.
+2. **The substitution is inverted.** It is a `tool.uv.sources` redirect, which is
+   uv-only and absent from wheel metadata. So it applies in the monorepo venv —
+   exactly where `core`'s agents never run — and does **not** apply to
+   `pip install vinv-core`, the only audience `core` is published for. Those
+   users get BerriAI litellm against an unpinned `"litellm"`. The substitution
+   works only where it is unnecessary and is missing everywhere it is needed.
+
+Options, all of which change what a published package installs for third parties
+and so need a product decision rather than a drive-by edit:
+
+| Option | Effect | Cost |
+|---|---|---|
+| Depend on real `litellm`, pinned; delete the shim | correct on every install path | large transitive tree for embedders |
+| Pin `litellm=={shim version}` in `core` | `pip install vinv-core` fails **loudly** instead of silently swapping packages | breaks pip installs until the embedder opts in |
+| Move `core` out of the default workspace install | monorepo stops carrying core's deps at all | embedders opt in explicitly |
+| Drop `dspy-ai` from `core` | removes the root cause | rewrite of the agent runtime |
+
+Recommendation: option 3 then 2 — stop the monorepo carrying deps for a package
+it does not use, and make the remaining mismatch loud rather than silent.
+
+### 3.3 The defect class behind the wasted episodes
+
+Both live false positives share one shape: **the product asserting an unverified
+inference as a finding.**
+
+- A raised exception was reported as a defect without checking whether a caller
+  caught it. The embedder's EADDRINUSE single-instance lock — caught at
+  `cli.py:91`, returns 0 — was clustered, dispatched, and scored −1.00. Fixed:
+  containment is now derived from the capture (`traceStore.containmentVerdict`),
+  excluded from `current_errors`, and carried as `contained` / `contained_by` so
+  consumers can *label* it rather than silently drop it.
+- The same class, found concurrently in the graph UI: `isDead(n)` is `!n.rt`
+  ("no trace mapped"), which on a repo at 35/7577 traced symbols renders as a
+  99%-dead-code claim, and prints "never executed in captured traces" directly
+  above "CALLED BY · 23".
+
+The general rule this suggests, and which the capability manifest in Part 2 (c)
+applies to tools: **never present an absence of evidence as evidence of a
+defect.** Report the absence, name what would settle it, and route around it.

--- a/exerciser/pyproject.toml
+++ b/exerciser/pyproject.toml
@@ -15,6 +15,18 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# The property-based generator arm. `generators.py` documents
+# hypothesis-jsonschema as ADOPTED and `plan.py` consumes the
+# `hypothesis_valid` candidates it produces — but until this extra existed the
+# package was declared in no manifest at all, so `hypothesis_valid_available()`
+# returned False in every install that has ever shipped and the arm was dead
+# code. Optional by design (the in-tree generator in `schema.py` remains the
+# guaranteed source for every input class), declared so it is installable and
+# so CI can prove the arm actually runs.
+propertygen = [
+    "hypothesis>=6.100.0,<7.0.0",
+    "hypothesis-jsonschema>=0.23.0,<0.24.0",
+]
 dev = [
     "pytest>=8.0.0,<10.0.0",
     "ruff>=0.6.0,<0.9.0",

--- a/extension/.vscode-test.mjs
+++ b/extension/.vscode-test.mjs
@@ -1,5 +1,23 @@
 import { defineConfig } from '@vscode/test-cli';
 
+/**
+ * Electron cannot start its own sandbox on a headless Linux runner.
+ *
+ * GitHub's `ubuntu-latest` is Ubuntu 24.04, which restricts unprivileged user
+ * namespaces through AppArmor (`kernel.apparmor_restrict_unprivileged_userns`).
+ * Chromium's SUID sandbox needs exactly that capability, so a VS Code launched
+ * under xvfb dies before the extension host starts — the failure is a
+ * namespace/sandbox error, not a test failure, and it takes the whole suite
+ * with it. `--disable-gpu` is the matching concern: there is no GPU behind
+ * xvfb, and the GPU process retries and logs noisily without it.
+ *
+ * Scoped to Linux rather than to CI: the constraint is the platform's, and a
+ * developer running these tests on a headless Linux box hits the identical
+ * wall. macOS and Windows keep the real sandbox, so nothing local is weakened.
+ */
+const headlessLinuxArgs =
+	process.platform === 'linux' ? ['--no-sandbox', '--disable-gpu'] : [];
+
 export default defineConfig({
 	files: 'out/test/**/*.test.js',
 	// A dedicated profile lets `npm test` run while a desktop VS Code is open.
@@ -9,5 +27,6 @@ export default defineConfig({
 	launchArgs: [
 		'--user-data-dir',
 		process.env.VSCODE_TEST_USER_DATA_DIR ?? '.vscode-test/user-data',
+		...headlessLinuxArgs,
 	],
 });

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,28 +1,80 @@
 {
 	"name": "VinvAI",
-	"version": "0.1.0",
+	"version": "0.1.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "VinvAI",
-			"version": "0.1.0",
+			"version": "0.1.5",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@types/mocha": "^10.0.10",
 				"@types/node": "22.x",
 				"@types/vscode": "^1.75.0",
 				"@vscode/test-cli": "^0.0.15",
-				"@vscode/test-electron": "^2.5.2",
+				"@vscode/test-electron": "^3.1.0",
 				"@vscode/vsce": "^3.9.2",
 				"esbuild": "^0.28.1",
 				"eslint": "^9.39.3",
+				"jsdom": "^29.1.1",
 				"typescript": "^5.9.3",
 				"typescript-eslint": "^8.56.1"
 			},
 			"engines": {
 				"vscode": "^1.75.0"
 			}
+		},
+		"node_modules/@asamuzakjp/css-color": {
+			"version": "5.1.11",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+			"integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@asamuzakjp/generational-cache": "^1.0.1",
+				"@csstools/css-calc": "^3.2.0",
+				"@csstools/css-color-parser": "^4.1.0",
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@asamuzakjp/dom-selector": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+			"integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@asamuzakjp/generational-cache": "^1.0.1",
+				"@asamuzakjp/nwsapi": "^2.3.9",
+				"bidi-js": "^1.0.3",
+				"css-tree": "^3.2.1",
+				"is-potential-custom-element-name": "^1.0.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@asamuzakjp/generational-cache": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+			"integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@asamuzakjp/nwsapi": {
+			"version": "2.3.9",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+			"integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@azu/format-text": {
 			"version": "1.0.2",
@@ -242,6 +294,159 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/@bramus/specificity": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+			"integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"css-tree": "^3.0.0"
+			},
+			"bin": {
+				"specificity": "bin/cli.js"
+			}
+		},
+		"node_modules/@csstools/color-helpers": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+			"integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"engines": {
+				"node": ">=20.19.0"
+			}
+		},
+		"node_modules/@csstools/css-calc": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+			"integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/@csstools/css-color-parser": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+			"integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@csstools/color-helpers": "^6.1.0",
+				"@csstools/css-calc": "^3.3.0"
+			},
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/@csstools/css-parser-algorithms": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+			"integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/@csstools/css-syntax-patches-for-csstree": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+			"integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"peerDependencies": {
+				"css-tree": "^3.2.1"
+			},
+			"peerDependenciesMeta": {
+				"css-tree": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@csstools/css-tokenizer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+			"integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.19.0"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -876,6 +1081,24 @@
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/@exodus/bytes": {
+			"version": "1.15.1",
+			"resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+			"integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"@noble/hashes": "^1.8.0 || ^2.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@noble/hashes": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@humanfs/core": {
@@ -1930,9 +2153,9 @@
 			}
 		},
 		"node_modules/@vscode/test-electron": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
-			"integrity": "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.1.0.tgz",
+			"integrity": "sha512-CRqv5u+YYoseuNVJ6Tyo4k0sF0mx4qnKMihRB0PjsUF8Dc0WKtCXo6CNL6nWWm5esfFQsQA/pejMj4ZbpJVLTw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1943,7 +2166,7 @@
 				"semver": "^7.6.2"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=22"
 			}
 		},
 		"node_modules/@vscode/vsce": {
@@ -2380,6 +2603,16 @@
 			],
 			"license": "MIT",
 			"optional": true
+		},
+		"node_modules/bidi-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+			"integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"require-from-string": "^2.0.2"
+			}
 		},
 		"node_modules/binaryextensions": {
 			"version": "6.11.0",
@@ -2928,6 +3161,20 @@
 				"url": "https://github.com/sponsors/fb55"
 			}
 		},
+		"node_modules/css-tree": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+			"integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mdn-data": "2.27.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+			}
+		},
 		"node_modules/css-what": {
 			"version": "6.2.2",
 			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
@@ -2939,6 +3186,30 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/fb55"
+			}
+		},
+		"node_modules/data-urls": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+			"integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"whatwg-mimetype": "^5.0.0",
+				"whatwg-url": "^16.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
+		"node_modules/data-urls/node_modules/whatwg-mimetype": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+			"integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
 			}
 		},
 		"node_modules/debug": {
@@ -2971,6 +3242,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/decimal.js": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/decompress-response": {
 			"version": "6.0.0",
@@ -4040,6 +4318,19 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/html-encoding-sniffer": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+			"integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@exodus/bytes": "^1.6.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
 		"node_modules/html-escaper": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -4326,6 +4617,13 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/is-potential-custom-element-name": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/is-unicode-supported": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -4483,6 +4781,93 @@
 			},
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/jsdom": {
+			"version": "29.1.1",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+			"integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@asamuzakjp/css-color": "^5.1.11",
+				"@asamuzakjp/dom-selector": "^7.1.1",
+				"@bramus/specificity": "^2.4.2",
+				"@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+				"@exodus/bytes": "^1.15.0",
+				"css-tree": "^3.2.1",
+				"data-urls": "^7.0.0",
+				"decimal.js": "^10.6.0",
+				"html-encoding-sniffer": "^6.0.0",
+				"is-potential-custom-element-name": "^1.0.1",
+				"lru-cache": "^11.3.5",
+				"parse5": "^8.0.1",
+				"saxes": "^6.0.0",
+				"symbol-tree": "^3.2.4",
+				"tough-cookie": "^6.0.1",
+				"undici": "^7.25.0",
+				"w3c-xmlserializer": "^5.0.0",
+				"webidl-conversions": "^8.0.1",
+				"whatwg-mimetype": "^5.0.0",
+				"whatwg-url": "^16.0.1",
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"canvas": "^3.0.0"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/jsdom/node_modules/entities": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+			"integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/jsdom/node_modules/lru-cache": {
+			"version": "11.5.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+			"integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/jsdom/node_modules/parse5": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+			"integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"entities": "^8.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
+		},
+		"node_modules/jsdom/node_modules/whatwg-mimetype": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+			"integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
 			}
 		},
 		"node_modules/json-buffer": {
@@ -4838,6 +5223,13 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
+		},
+		"node_modules/mdn-data": {
+			"version": "2.27.1",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+			"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+			"dev": true,
+			"license": "CC0-1.0"
 		},
 		"node_modules/mdurl": {
 			"version": "2.0.0",
@@ -5951,6 +6343,19 @@
 				"node": ">=11.0.0"
 			}
 		},
+		"node_modules/saxes": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+			"integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"xmlchars": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=v12.22.7"
+			}
+		},
 		"node_modules/secretlint": {
 			"version": "10.2.2",
 			"resolved": "https://registry.npmjs.org/secretlint/-/secretlint-10.2.2.tgz",
@@ -6195,6 +6600,16 @@
 				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
 			}
 		},
+		"node_modules/source-map-js": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/spdx-correct": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
@@ -6423,6 +6838,13 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/symbol-tree": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/table": {
 			"version": "6.9.0",
@@ -6759,6 +7181,26 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
+		"node_modules/tldts": {
+			"version": "7.4.9",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+			"integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tldts-core": "^7.4.9"
+			},
+			"bin": {
+				"tldts": "bin/cli.js"
+			}
+		},
+		"node_modules/tldts-core": {
+			"version": "7.4.9",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+			"integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/tmp": {
 			"version": "0.2.7",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
@@ -6780,6 +7222,32 @@
 			},
 			"engines": {
 				"node": ">=8.0"
+			}
+		},
+		"node_modules/tough-cookie": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+			"integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"tldts": "^7.0.5"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/tr46": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+			"integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"punycode": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=20"
 			}
 		},
 		"node_modules/ts-api-utils": {
@@ -7019,6 +7487,29 @@
 				"url": "https://bevry.me/fund"
 			}
 		},
+		"node_modules/w3c-xmlserializer": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+			"integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/webidl-conversions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+			"integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=20"
+			}
+		},
 		"node_modules/whatwg-encoding": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
@@ -7041,6 +7532,21 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/whatwg-url": {
+			"version": "16.0.1",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+			"integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@exodus/bytes": "^1.11.0",
+				"tr46": "^6.0.0",
+				"webidl-conversions": "^8.0.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
 		"node_modules/which": {
@@ -7195,6 +7701,16 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/xml-name-validator": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+			"integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/xml2js": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
@@ -7218,6 +7734,13 @@
 			"engines": {
 				"node": ">=4.0"
 			}
+		},
+		"node_modules/xmlchars": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/y18n": {
 			"version": "5.0.8",

--- a/extension/package.json
+++ b/extension/package.json
@@ -278,6 +278,11 @@
 				"icon": "$(history)"
 			},
 			{
+				"command": "vinv-vs.openConfigRequests",
+				"title": "Fill In Values Vinv Needs",
+				"category": "Vinv"
+			},
+			{
 				"command": "vinv-vs.configureProject",
 				"title": "Configure Project",
 				"category": "Vinv",
@@ -551,10 +556,11 @@
 		"@types/node": "22.x",
 		"@types/vscode": "^1.75.0",
 		"@vscode/test-cli": "^0.0.15",
-		"@vscode/test-electron": "^2.5.2",
+		"@vscode/test-electron": "^3.1.0",
 		"@vscode/vsce": "^3.9.2",
 		"esbuild": "^0.28.1",
 		"eslint": "^9.39.3",
+		"jsdom": "^29.1.1",
 		"typescript": "^5.9.3",
 		"typescript-eslint": "^8.56.1"
 	},

--- a/extension/src/commands/index.ts
+++ b/extension/src/commands/index.ts
@@ -5,6 +5,8 @@ import { openDebugPanel } from '../debug/debugPanel';
 import { SessionsProvider, type SessionTimeRange } from '../views/sessionsView';
 import { ServicesProvider } from '../views/servicesView';
 import { openConfigureForm } from '../config/configureProject';
+import { openConfigRequestPanel, writeAnswers } from '../views/configRequestPanel';
+import { runExercisePass } from '../harness/exerciseRunner';
 import { openTracelensTerminal, openIndexTerminal } from '../tracelens/tracelens';
 import { runDiscovery, stopDiscovery } from '../index/discovery';
 import { readServices, isServiceStarted, readStartCommands } from '../bringup/bringup';
@@ -229,6 +231,28 @@ export function registerCommands(
 				return;
 			}
 			await openFindings(folder.uri.fsPath);
+		}),
+		// The values the exerciser could not derive. This panel used to open only
+		// as a side effect of an exercise pass, so closing the tab — or getting a
+		// credential wrong — meant re-running the whole pipeline to be asked again.
+		vscode.commands.registerCommand('vinv-vs.openConfigRequests', async () => {
+			const folder = vscode.workspace.workspaceFolders?.[0];
+			if (!folder) {
+				void vscode.window.showErrorMessage('Open a workspace folder to configure it.');
+				return;
+			}
+			const root = folder.uri.fsPath;
+			const panel = openConfigRequestPanel(root, {
+				save: (answers) => writeAnswers(root, answers),
+				rerun: async () => void (await runExercisePass(context, root)),
+				showError: (message) => void vscode.window.showErrorMessage(message),
+				notify: (message) => void vscode.window.showInformationMessage(`Vinv: ${message}`),
+			});
+			if (!panel) {
+				void vscode.window.showInformationMessage(
+					'Vinv: nothing to configure — Vinv resolved this project on its own.',
+				);
+			}
 		}),
 		vscode.commands.registerCommand('vinv-vs.configureProject', () => openConfigureForm(context)),
 		vscode.commands.registerCommand('vinv-vs.runTracelens', () => openTracelensTerminal(context)),

--- a/extension/src/graph/indexGraph.ts
+++ b/extension/src/graph/indexGraph.ts
@@ -10,7 +10,13 @@
  */
 import * as fs from 'fs';
 import * as path from 'path';
-import { cmpSessionMark, readSessionTag, type SessionMark } from '../runtime/traceStore';
+import {
+	cmpSessionMark,
+	containmentVerdict,
+	mergeContainment,
+	readSessionTag,
+	type SessionMark,
+} from '../runtime/traceStore';
 
 /** One symbol chunk as stored in .vinv/index/chunks.jsonl (text omitted). */
 export interface GraphNode {
@@ -95,6 +101,29 @@ export interface FailureExemplar {
 	 *    unverified. Never silently dropped: claiming "fixed" requires a run.
 	 */
 	superseded: null | 'code_changed' | 'not_reproduced';
+	/**
+	 * Did this exception ESCAPE the call stack, or did a caller absorb it?
+	 *
+	 *  - true  — CONTAINED: an observed ancestor of the raising frame exited
+	 *    `ok`, so the exception was caught and handled. The raise is control
+	 *    flow, not a failure.
+	 *  - false — PROPAGATED: every observed ancestor also exited with an error,
+	 *    so nothing absorbed it.
+	 *  - null  — UNKNOWN: no ancestor exit was observed (no parent link, or the
+	 *    chain is the request root). Callers must treat null as PROPAGATED —
+	 *    when unsure, keep it on the defect list.
+	 *
+	 * Derived purely from the capture: `status` on the exit rows of the frames
+	 * named in `caller_chain`. Nothing here is inferred from source.
+	 */
+	contained: boolean | null;
+	/**
+	 * The observed ancestor frame that absorbed this exception (the innermost
+	 * one that exited `ok`), or null when it escaped / is unknown. Lets a
+	 * consumer say "caught by _cmd_serve" rather than silently dropping a
+	 * failure a user may have seen flagged red yesterday.
+	 */
+	contained_by: string | null;
 }
 
 /**
@@ -825,6 +854,18 @@ function absorbRawCaptures(
 		// failing exit.
 		const lastArgs = new Map<string, { schema: string | null; summary: Record<string, unknown> | null }>();
 		const parentOf = new Map<string, string | null>(); // req\0thread\0comp → parent comp
+		// Exit outcome per frame, for containment: an error that an ancestor
+		// absorbed (that ancestor exited `ok`) is handled control flow, not a
+		// defect. Populated on exit rows; read in the post-pass below, because a
+		// caller's exit is written AFTER the callee's as the stack unwinds.
+		const exitOkOf = new Map<string, boolean>(); // req\0thread\0comp → exited ok
+		/**
+		 * The (request, thread, component) key shape shared by `lastArgs`,
+		 * `parentOf` and `exitOkOf`. Must stay byte-identical to the inline
+		 * `reqKey` those maps are written with — same NUL separator.
+		 */
+		const keyOf = (req: string, thread: number, comp: string): string =>
+			`${req}\u0000${thread}\u0000${comp}`;
 		const errorExits: Array<{
 			component: string;
 			request_id: string;
@@ -870,6 +911,10 @@ function absorbRawCaptures(
 			}
 			const ms = Number(ev.duration_ms ?? 0) || 0;
 			const errType = ev.error_type && ev.error_type !== 'None' ? ev.error_type : null;
+			// A frame that exits without an error type absorbed whatever its
+			// callees raised. Recorded for every exit, not just clean ones, so a
+			// re-raising parent reads as `false` rather than unknown.
+			exitOkOf.set(reqKey, !errType);
 			const callArgs = lastArgs.get(reqKey) ?? null;
 			for (const row of rowsFor(ev.component)) {
 				const cur = overlay[row] ?? {
@@ -971,6 +1016,20 @@ function absorbRawCaptures(
 				chain.push(cursor);
 				cursor = parentOf.get(`${err.request_id}\u0000${err.thread_id}\u0000${cursor}`);
 			}
+			// Containment: walk the same observed chain and ask whether any
+			// ancestor exited `ok`. If one did, it caught this exception — the
+			// raise never escaped, so it is control flow rather than a defect
+			// (the embedder's EADDRINUSE single-instance lock is the canonical
+			// case: make_server exits error, _cmd_serve exits ok, main exits ok).
+			// Stays `null` when NO ancestor exit was observed at all, which
+			// consumers must read as propagated: unknown is never "handled".
+			const ancestorOk = chain.map((ancestor) =>
+				exitOkOf.get(keyOf(err.request_id, err.thread_id, ancestor)),
+			);
+			const contained = containmentVerdict(ancestorOk);
+			// Innermost ancestor that exited ok — the frame whose except: caught it.
+			const containedBy =
+				contained === true ? (chain[ancestorOk.indexOf(true)] ?? null) : null;
 			const args = err.args;
 			const failKey = `${err.error_type} ${err.error_message ?? ''}`;
 			for (const row of rowsFor(err.component)) {
@@ -988,6 +1047,12 @@ function absorbRawCaptures(
 				);
 				if (match) {
 					match.count += 1;
+					// Merge containment across occurrences of the same failure
+					// identity: it is only "handled" if EVERY observed occurrence
+					// was absorbed. One escape makes the whole identity a defect,
+					// and an unknown never upgrades a known escape.
+					match.contained = mergeContainment(match.contained, contained);
+					match.contained_by = match.contained === true ? (match.contained_by ?? containedBy) : null;
 					// Prefer an exemplar that carries a traceback over one without.
 					if (!match.error_stack && err.error_stack) {
 						match.error_stack = err.error_stack;
@@ -1010,7 +1075,24 @@ function absorbRawCaptures(
 						count: 1,
 						capture_epoch: mark.epoch,
 						superseded: null,
+						contained,
+						contained_by: containedBy,
 					});
+				}
+				// current_errors means "is this FAILING now" — it drives the graph's
+				// red rings, the "failing:" digest, the ⚠N row labels, the status bar
+				// and the Fix-with-Coding-Agent button. An exception a caller caught is
+				// not failing, so discount it from this session's tally here, where
+				// containment is finally known. Lifetime `errors` deliberately keeps the
+				// raw observed count: "it raised N times" stays a true fact.
+				if (contained === true) {
+					const sr = sessionRows.get(row);
+					if (sr) {
+						sr.errors = Math.max(0, sr.errors - 1);
+						if (!cur.failures.some((f) => f.contained !== true && `${f.error_type} ${f.error_message ?? ''}` === failKey)) {
+							sr.failKeys.delete(failKey);
+						}
+					}
 				}
 			}
 		}

--- a/extension/src/harness/autoTrigger.ts
+++ b/extension/src/harness/autoTrigger.ts
@@ -37,7 +37,11 @@ import {
 	type OptimizeOpportunity,
 	type OptimizeRunResult,
 } from './exerciseOptimize';
-import { readAndClearRequests, restoreEpisodeRequests } from './requestQueue';
+import {
+	readAndClearRequests,
+	recordRequestOutcome,
+	restoreEpisodeRequests,
+} from './requestQueue';
 import {
 	collectMemoryTrends,
 	collectRuntimeErrorClusters,
@@ -287,11 +291,27 @@ export function registerEpisodeRequestTrigger(context: vscode.ExtensionContext):
 				// every request after it; restoring only the current item silently
 				// discarded the tail whenever the harness was already occupied.
 				restoreEpisodeRequests(root, requests.slice(index));
+				// Deferred, NOT consumed — the file is back on the queue. Recorded so a
+				// caller can tell "waiting for the harness" from "silently dropped".
+				for (const deferred of requests.slice(index)) {
+					recordRequestOutcome(root, {
+						request_id: deferred.id,
+						kind: deferred.kind,
+						outcome: 'harness_busy',
+						reason: 'an episode was already running — the request was restored to the queue and will be retried',
+					});
+				}
 				return;
 			}
 			switch (request.kind) {
 				case 'fix': {
 					if (!request.issue) {
+						recordRequestOutcome(root, {
+							request_id: request.id,
+							kind: request.kind,
+							outcome: 'invalid',
+							reason: "kind 'fix' requires issue text, and none was supplied",
+						});
 						break;
 					}
 					const service = request.service;
@@ -318,21 +338,32 @@ export function registerEpisodeRequestTrigger(context: vscode.ExtensionContext):
 						// none for a free-text defect.
 						successCriteria: criteriaFor(intent, service),
 					});
+					// A 'fix' request always reaches runEpisode — reaching here means it
+					// did, so this is observed, not assumed. The episode's own verdict
+					// lives in the episode ledger; this only records that it dispatched.
+					recordRequestOutcome(root, {
+						request_id: request.id,
+						kind: request.kind,
+						outcome: 'dispatched',
+						reason: `episode dispatched (${service ? 'service-fix' : 'general'}, intent ${intent})`,
+					});
 					break;
 				}
 				case 'runtime-errors':
-					await offerEpisodeForRuntimeErrors(context, root);
+					await offerEpisodeForRuntimeErrors(context, root, request.id);
 					break;
 				case 'hotspots':
 					// Chat-requested sweeps ride the same verdict engine as the
 					// panel: frozen probes, episode-bound verdict, real revert.
-					await runVerifiedHotspotEpisode(context, root);
+					// `request.id` makes the sweep record its own outcome, so a
+					// no-plan reason survives past the toast (see requestQueue).
+					await runVerifiedHotspotEpisode(context, root, undefined, request.id);
 					break;
 				case 'memory-trends':
-					await offerEpisodeForMemoryTrends(context, root);
+					await offerEpisodeForMemoryTrends(context, root, request.id);
 					break;
 				case 'cache-candidates':
-					await runVerifiedCacheSweep(context, root);
+					await runVerifiedCacheSweep(context, root, request.id);
 					break;
 			}
 		}
@@ -428,6 +459,12 @@ function runtimeErrorTask(clusters: ErrorCluster[]): EpisodeTask {
 export async function offerEpisodeForRuntimeErrors(
 	context: vscode.ExtensionContext,
 	workspaceRoot: string,
+	/**
+	 * Set when this came from a QUEUED chat request, so a run that dispatches
+	 * nothing records WHY instead of returning silently. Absent for the
+	 * automatic/panel paths, which are not queued requests.
+	 */
+	requestId?: string,
 ): Promise<void> {
 	let clusters: ErrorCluster[] = [];
 	try {
@@ -437,9 +474,35 @@ export async function offerEpisodeForRuntimeErrors(
 			loadRuntimeOverlay(workspaceRoot, nodes),
 		).clusters;
 	} catch {
+		// UNREADABLE STORE — emphatically not the same as "no errors". Recorded
+		// as such so a caller cannot read a missing index as a clean bill of
+		// health; unknown stays unknown.
+		if (requestId) {
+			recordRequestOutcome(workspaceRoot, {
+				request_id: requestId,
+				kind: 'runtime-errors',
+				outcome: 'no_plan',
+				reason:
+					'the index store or runtime overlay could not be read, so whether any '
+					+ 'function is raising errors is UNKNOWN — this is not a report of zero errors',
+			});
+		}
 		return;
 	}
 	if (clusters.length === 0) {
+		// A genuine, informative answer — and after the containment gate this is
+		// the EXPECTED result on a healthy repo, so returning silently would
+		// leave a caller unable to tell success from a dropped request.
+		if (requestId) {
+			recordRequestOutcome(workspaceRoot, {
+				request_id: requestId,
+				kind: 'runtime-errors',
+				outcome: 'no_plan',
+				reason:
+					'no function raised an unhandled error in the captured traces — exceptions '
+					+ 'a caller absorbed and deliberate 4xx rejections are excluded by design',
+			});
+		}
 		return;
 	}
 	await offerOrDispatch(
@@ -904,17 +967,41 @@ async function offerPreparedOptimization(
 export async function offerEpisodeForMemoryTrends(
 	context: vscode.ExtensionContext,
 	workspaceRoot: string,
+	/**
+	 * Set when this came from a QUEUED chat request, so a run that dispatches
+	 * nothing records WHY instead of returning silently. Absent for the
+	 * automatic/panel paths, which are not queued requests.
+	 */
+	requestId?: string,
 ): Promise<void> {
 	let suspects: ReturnType<typeof collectMemoryTrends> = [];
 	try {
 		suspects = collectMemoryTrends(workspaceRoot, loadNodes(indexStoreDir(workspaceRoot)));
 	} catch {
+		if (requestId) {
+			recordRequestOutcome(workspaceRoot, {
+				request_id: requestId,
+				kind: 'memory-trends',
+				outcome: 'no_plan',
+				reason:
+					'the index store or capture series could not be read, so leak trends are '
+					+ 'UNKNOWN — this is not a report of zero leaks',
+			});
+		}
 		return;
 	}
 	if (suspects.length === 0) {
-		void vscode.window.showInformationMessage(
-			'Vinv: No memory-leak trends — needs 3+ capture sessions where a symbol keeps retaining memory. Run services across several sessions to build the series.',
-		);
+		const why =
+			'Vinv: No memory-leak trends — needs 3+ capture sessions where a symbol keeps retaining memory. Run services across several sessions to build the series.';
+		void vscode.window.showInformationMessage(why);
+		if (requestId) {
+			recordRequestOutcome(workspaceRoot, {
+				request_id: requestId,
+				kind: 'memory-trends',
+				outcome: 'no_plan',
+				reason: why,
+			});
+		}
 		return;
 	}
 	const fmt = (b: number): string =>
@@ -977,6 +1064,13 @@ export async function runVerifiedHotspotEpisode(
 	context: vscode.ExtensionContext,
 	workspaceRoot: string,
 	row?: number,
+	/**
+	 * Set when this sweep came from a QUEUED chat request. The queue drains
+	 * atomically, so without recording an outcome a sweep that dispatches
+	 * nothing leaves no trace and the reason reaches only a transient toast.
+	 * Absent for panel clicks, which are not queued requests.
+	 */
+	requestId?: string,
 ): Promise<void> {
 	let prep: OptimizationPrep;
 	try {
@@ -989,7 +1083,16 @@ export async function runVerifiedHotspotEpisode(
 	}
 	const plan = prep.plan;
 	if (!plan) {
-		void vscode.window.showInformationMessage(noPlanMessage(prep, 'hotspots'));
+		const why = noPlanMessage(prep, 'hotspots');
+		void vscode.window.showInformationMessage(why);
+		if (requestId) {
+			recordRequestOutcome(workspaceRoot, {
+				request_id: requestId,
+				kind: 'hotspots',
+				outcome: 'no_plan',
+				reason: why,
+			});
+		}
 		return;
 	}
 	// A memory opportunity is judged in BYTES; everything else in ms. The
@@ -1012,6 +1115,13 @@ export async function runVerifiedHotspotEpisode(
 export async function runVerifiedCacheSweep(
 	context: vscode.ExtensionContext,
 	workspaceRoot: string,
+	/**
+	 * Set when this sweep came from a QUEUED chat request. The queue drains
+	 * atomically, so without recording an outcome a sweep that dispatches
+	 * nothing leaves no trace and the reason reaches only a transient toast.
+	 * Absent for panel clicks, which are not queued requests.
+	 */
+	requestId?: string,
 ): Promise<void> {
 	let prep: OptimizationPrep;
 	try {
@@ -1021,7 +1131,16 @@ export async function runVerifiedCacheSweep(
 	}
 	const plan = prep.plan;
 	if (!plan) {
-		void vscode.window.showInformationMessage(noPlanMessage(prep, 'cache_candidates'));
+		const why = noPlanMessage(prep, 'cache_candidates');
+		void vscode.window.showInformationMessage(why);
+		if (requestId) {
+			recordRequestOutcome(workspaceRoot, {
+				request_id: requestId,
+				kind: 'cache-candidates',
+				outcome: 'no_plan',
+				reason: why,
+			});
+		}
 		return;
 	}
 	const deps = buildWorkspaceDeps(workspaceRoot, {});

--- a/extension/src/harness/episodeLoop.ts
+++ b/extension/src/harness/episodeLoop.ts
@@ -1107,6 +1107,16 @@ export async function runEpisode(
 	let lastObjectiveFail = false;
 	let lastPackPath = '';
 	let lastEvidence = '';
+	/**
+	 * The agent's last disputed premise, kept for the outcome digest.
+	 *
+	 * A dispute produces no verification evidence by construction — the agent
+	 * declined to treat the issue as real — so `lastEvidence` stays empty and the
+	 * episode recorded the digest "no evidence". That is false: the dispute IS
+	 * the evidence, and the trajectory prints it two lines below the digest that
+	 * denies it exists.
+	 */
+	let lastDispute = '';
 	// The last attempt's full reward breakdown — logged at episode_end so the
 	// ledger carries the multi-signal reward, not only the shaped scalar.
 	let lastBreakdown: RewardBreakdown | undefined;
@@ -1678,6 +1688,7 @@ export async function runEpisode(
 						continue;
 					}
 					if (directives.dispute !== undefined && !isQuestion) {
+						lastDispute = directives.dispute;
 						progress.report({ message: `attempt ${attempts}: agent disputes the premise — negotiating…` });
 						const verdict = await breakStall(
 							task.title,
@@ -2374,9 +2385,20 @@ export async function runEpisode(
 				verified,
 				aborted,
 				reward,
+				// Carried so the trajectory can say whether anything executable
+				// stood behind the number: `reward` is renormalized over available
+				// components, so it alone cannot distinguish a verified pass from an
+				// episode where no check could run.
+				verification_weight: lastBreakdown?.verificationWeight,
 				// The digest line is the first evidence line WHOLE; the pack path
 				// points at the complete artifact for anything the line elides.
-				evidence: lastEvidence.split('\n')[0] || (verified ? 'verified' : 'no evidence'),
+				evidence:
+					lastEvidence.split('\n')[0] ||
+					(verified
+						? 'verified'
+						: lastDispute
+							? `agent disputed the premise: ${lastDispute.split('\n')[0]}`
+							: 'no evidence'),
 				pack_path: lastPackPath || undefined,
 				// Full issue + service enable post-completion dispute (the issue
 				// signature locates this episode's test set; re-dispatch needs both).

--- a/extension/src/harness/episodePolicyUpdater.ts
+++ b/extension/src/harness/episodePolicyUpdater.ts
@@ -439,7 +439,30 @@ export function computeUpdatedPolicy(
 			best = a;
 		}
 	}
-	next.preferred_arm = best;
+	// PROMOTION GATES. `min_promotion_n` and `promotion_delta` were declared,
+	// defaulted and range-VALIDATED in episodeTelemetry.ts but never read here,
+	// so this was a bare argmax over posterior means. With a 1/1 prior a single
+	// verified episode moves one arm's mean to 0.667 while every other arm sits
+	// at 0.5, so ONE objective success promoted an arm — observed live on this
+	// machine: episodes_seen 17, exactly 1 objective observation in the
+	// posteriors, preferred_arm 4.
+	//
+	// That matters because `preferred_arm` is not merely reported: qna/answer.ts
+	// decodes bit 2 of it to pick Ask-Vinv's per-symbol snippet budget. (Episode
+	// arm SELECTION is Thompson sampling + decaying epsilon, which handles n=1
+	// correctly on its own — this gate is for the greedy readers.)
+	//
+	// Rule: keep the incumbent unless the challenger has at least
+	// `min_promotion_n` objective observations AND beats the incumbent's
+	// posterior mean by at least `promotion_delta`.
+	const incumbent =
+		current.preferred_arm >= 0 && current.preferred_arm < armCount ? current.preferred_arm : 0;
+	const challengerN = armCounts[best] ?? 0;
+	const beatsIncumbent = means[best] - means[incumbent] >= current.promotion_delta;
+	next.preferred_arm =
+		best === incumbent || (challengerN >= current.min_promotion_n && beatsIncumbent)
+			? best
+			: incumbent;
 
 	// Attempt budget: smallest budget covering the learned quantile of
 	// attempts-to-success (objective successes only), PLUS one attempt of

--- a/extension/src/harness/exerciseRunner.ts
+++ b/extension/src/harness/exerciseRunner.ts
@@ -602,6 +602,7 @@ function askUserForRemainingConfig(
 				);
 			},
 			showError: (message) => void vscode.window.showErrorMessage(message),
+			notify: (message) => void vscode.window.showInformationMessage(`Vinv: ${message}`),
 		});
 	} catch {
 		// A panel that cannot open must never fail the exercise pass. The requests

--- a/extension/src/harness/opportunityBoard.ts
+++ b/extension/src/harness/opportunityBoard.ts
@@ -53,6 +53,7 @@ import {
 	collectCacheCandidates,
 	collectRequestSpans,
 	collectSymbolTimings,
+	lifetimeFrames,
 } from './runtimeAnalysis';
 import {
 	computeOptimizationCandidates,
@@ -772,6 +773,10 @@ export function rankedOpportunityCandidates(workspaceRoot: string): Optimization
 		cacheByRow,
 		spans,
 		calibration,
+		// collectCacheCandidates already drops these, but the per-call, fanout and
+		// staircase kinds are derived from `timings` inside the analyzer — without
+		// this the board still posts a serve loop as "unexpectedly slow".
+		lifetimeRows: new Set(lifetimeFrames(workspaceRoot, nodes).keys()),
 		// The board's own list budget — the eviction bound (LIVE_POSTED_CAP)
 		// derives from this cap, so it is passed explicitly rather than trusting
 		// the analyzer's default to stay in sync.
@@ -837,6 +842,59 @@ export interface BoardSyncResult {
 }
 
 /**
+ * Retire POSTED entries the analyzer can no longer produce because a soundness
+ * gate now rejects them outright.
+ *
+ * This is deliberately NOT the expiry path. Expiry means "the evidence moved" —
+ * a signature absent from fresh candidates accrues misses and retires after
+ * three capture sessions, which is the right patience for noisy evidence. These
+ * entries are different in kind: they were WRONG TO POST, and a gate now says so
+ * structurally. Waiting three sessions would leave them dispatchable in the
+ * meantime, and the board is a persisted ledger — so a gate that only filters new
+ * postings does not stop a user running the stale one.
+ *
+ * The live case this closes: `main` and `_cmd_serve` sat on the board at
+ * "~25101ms is cacheable" — memoize a server's CLI entry point — with misses 0
+ * and status posted, still dispatchable after BOTH the cache gate
+ * (collectCacheCandidates) and the per-call gate (computeOptimizationCandidates)
+ * had shipped.
+ *
+ * Retired, never deleted: the entry keeps its evidence and gains a `resolution`
+ * saying which gate rejected it, so the board still explains why an opportunity
+ * a user may have seen yesterday is gone.
+ */
+export function retireStructurallyInvalid(
+	workspaceRoot: string,
+	invalidRows: ReadonlySet<number>,
+	reason: string,
+): OpportunityEntry[] {
+	if (invalidRows.size === 0) {
+		return [];
+	}
+	const board = readBoardFile(workspaceRoot);
+	const changed: OpportunityEntry[] = [];
+	for (const entry of board.entries.values()) {
+		// Only entries that are still ACTIONABLE need retiring; terminal and
+		// in-flight ones are not offered to a dispatcher.
+		if (entry.status !== 'posted' || !invalidRows.has(entry.row)) {
+			continue;
+		}
+		changed.push(
+			transition(board, entry, {
+				status: 'expired',
+				misses: 0,
+				resolution: reason,
+				note: 'withdrawn: a soundness gate now rejects this evidence, so it is no longer dispatchable',
+			}),
+		);
+	}
+	if (changed.length > 0) {
+		appendEntries(workspaceRoot, changed);
+	}
+	return changed;
+}
+
+/**
  * The one produce-and-reconcile cycle every surface runs: derive the ranked
  * candidates, resolve dispatched entries from episode outcomes, advance
  * expiry against the fresh evidence, and post whatever the evidence newly
@@ -854,6 +912,23 @@ export function syncOpportunityBoard(
 		candidates = rankedOpportunityCandidates(workspaceRoot);
 	} catch {
 		evidenceKnown = false;
+	}
+	// Withdraw anything the CURRENT gates reject before reconciling, so a stale
+	// posting cannot stay dispatchable while expiry counts out three sessions.
+	// Only when the evidence is readable: an unreadable store must not be read
+	// as "no frame is a lifetime frame" and retire nothing (or everything).
+	if (evidenceKnown) {
+		try {
+			const storeDir = indexStoreDir(workspaceRoot);
+			const nodes = loadNodes(storeDir);
+			retireStructurallyInvalid(
+				workspaceRoot,
+				new Set(lifetimeFrames(workspaceRoot, nodes).keys()),
+				'its duration measures process/request lifetime, not work — a soundness gate now excludes it',
+			);
+		} catch {
+			// Unreadable store: leave the board alone rather than retire on a guess.
+		}
 	}
 	const freshIds = evidenceKnown ? new Set(candidates.map(candidateSignature)) : null;
 	const reconcile = reconcileOpportunityBoard(

--- a/extension/src/harness/optimizationAnalysis.ts
+++ b/extension/src/harness/optimizationAnalysis.ts
@@ -309,6 +309,21 @@ interface ComputeInputs {
 	/** memory-leak suspects (collectMemoryTrends) — the memory dimension's
 	 * cross-session retention signal. Optional. */
 	memoryLeaks?: MemoryLeakSuspect[];
+	/**
+	 * Rows whose duration is a request/process LIFETIME rather than work
+	 * (`lifetimeFrames` in runtimeAnalysis — depth-0 roots and ~100% pass-through
+	 * frames). Every signal in this module is duration-derived, so a lifetime
+	 * frame is an outlier on all of them by construction: the embedder's
+	 * `_cmd_serve` posted as "10738.8ms per call (self) — 148428.8x the typical
+	 * symbol; unexpectedly slow for the work it does", which is exactly backwards
+	 * for a serve loop that is SUPPOSED to span the run.
+	 *
+	 * Gating `collectCacheCandidates` alone was not enough: the per-call, fanout
+	 * and staircase kinds are derived here from `timings`, not from `cacheByRow`,
+	 * so they stayed dispatchable through the opportunity board. Optional — an
+	 * absent set preserves the previous behaviour for callers without spans.
+	 */
+	lifetimeRows?: ReadonlySet<number>;
 }
 
 /** Human byte sizes for candidate reasons. */
@@ -712,10 +727,18 @@ export function computeOptimizationCandidates(inputs: ComputeInputs): Optimizati
 	}
 
 	const raw: OptimizationCandidate[] = [];
+	const lifetimeRows = inputs.lifetimeRows;
 	for (const [row, sess] of timings) {
 		const l = latest(sess);
 		const node = nodes[row];
 		if (!l || !node || l.total_ms <= 0 || l.calls <= 0) {
+			continue;
+		}
+		// A lifetime frame is not a candidate for ANY kind: it is an outlier on
+		// every duration signal precisely because it measures how long the request
+		// or process lived. Skipped whole rather than per-kind — there is no waste
+		// signal here that would be sound if the others are not.
+		if (lifetimeRows?.has(row)) {
 			continue;
 		}
 

--- a/extension/src/harness/requestQueue.ts
+++ b/extension/src/harness/requestQueue.ts
@@ -32,6 +32,92 @@ export interface EpisodeRequest {
 	service?: string;
 }
 
+/**
+ * Why a drained request produced what it produced.
+ *
+ * The queue is atomic and unconditional: `readAndClearRequests` removes the file
+ * before anything is attempted. That is correct for crash-safety, but it means a
+ * request that dispatches nothing leaves NO trace — and until this ledger, the
+ * only channel for the reason was `vscode.window.showInformationMessage`, a
+ * transient toast. So an MCP caller that queued a sweep observed: file created,
+ * file drained, silence forever, with no way even in principle to learn the
+ * outcome. Worse than silence, because the request was consumed, so a retry is
+ * not idempotent — it is a second consumption with the same silent result.
+ *
+ * Observed live: `run_sweep hotspots` reported `Sweep 'hotspots' queued
+ * (episode-363c2c62-….json)`; `.vinv/requests/` was left empty (drained) and
+ * `.vinv/episodes.jsonl` never gained a line. `noPlanMessage` had computed one of
+ * three perfectly actionable reasons — all opportunities held on the board / no
+ * cache opportunities / no recoverable time, capture a trace first — and routed
+ * every one of them to a popup.
+ *
+ * The general rule this encodes: this codebase guards VERDICTS everywhere
+ * (verified, objective, contained, superseded) and had no persistence at all for
+ * NON-verdicts. "Nothing happened, and here is why" is evidence too.
+ */
+export type RequestOutcomeKind =
+	| 'dispatched' // an episode actually ran for this request
+	| 'no_plan' // nothing to work on; `reason` says why (never a guess)
+	| 'harness_busy' // deferred, restored to the queue — NOT consumed
+	| 'invalid'; // malformed request (e.g. kind 'fix' with no issue text)
+
+export interface RequestOutcome {
+	request_id: string;
+	kind: EpisodeRequestKind;
+	outcome: RequestOutcomeKind;
+	/** Human-readable cause. For 'no_plan' this is the text the toast carried. */
+	reason: string;
+	ts: string;
+}
+
+/** Append-only outcome ledger, beside the other durable reports. */
+export function requestOutcomesPath(workspaceRoot: string): string {
+	return path.join(workspaceRoot, '.vinv', 'reports', 'request-outcomes.jsonl');
+}
+
+/**
+ * Records what became of one drained request. Best-effort by design: a failure
+ * to write the ledger must never take down a dispatch that is otherwise fine.
+ */
+export function recordRequestOutcome(
+	workspaceRoot: string,
+	outcome: Omit<RequestOutcome, 'ts'> & { ts?: string },
+): void {
+	try {
+		const file = requestOutcomesPath(workspaceRoot);
+		fs.mkdirSync(path.dirname(file), { recursive: true });
+		const row: RequestOutcome = { ...outcome, ts: outcome.ts ?? new Date().toISOString() };
+		fs.appendFileSync(file, `${JSON.stringify(row)}\n`);
+	} catch {
+		// A missing ledger line is a reporting loss, not a dispatch failure.
+	}
+}
+
+/** Reads the outcome ledger, newest last. `[]` when absent or unreadable. */
+export function readRequestOutcomes(workspaceRoot: string): RequestOutcome[] {
+	let text: string;
+	try {
+		text = fs.readFileSync(requestOutcomesPath(workspaceRoot), 'utf8');
+	} catch {
+		return [];
+	}
+	const out: RequestOutcome[] = [];
+	for (const line of text.split('\n')) {
+		if (!line.trim()) {
+			continue;
+		}
+		try {
+			const row = JSON.parse(line) as RequestOutcome;
+			if (row && typeof row.request_id === 'string' && typeof row.outcome === 'string') {
+				out.push(row);
+			}
+		} catch {
+			continue; // a torn line must not hide the rest of the ledger
+		}
+	}
+	return out;
+}
+
 export function requestsDir(workspaceRoot: string): string {
 	return path.join(workspaceRoot, '.vinv', 'requests');
 }

--- a/extension/src/harness/rewardSignals.ts
+++ b/extension/src/harness/rewardSignals.ts
@@ -94,6 +94,25 @@ export interface RewardBreakdown {
 	 * ("right code, wrong goal") — callers must not mislabel one as the other.
 	 */
 	verifiedBlockCause: 'none' | 'hard_flag' | 'cheat' | 'criteria';
+	/**
+	 * How much EXECUTABLE verification weight was actually available (oracle +
+	 * tests + regression), before renormalization. 0 means nothing executable
+	 * ran: the reward then comes from the audit/adherence components alone.
+	 *
+	 * Why this is reported. The rubric renormalizes over AVAILABLE components,
+	 * which is the right MNAR handling — an unrunnable check is not a verdict,
+	 * and scoring it 0 would punish an agent for missing infrastructure. But it
+	 * makes `reward` non-comparable across episodes with different signal
+	 * availability: an episode where nothing could be checked and the diff was
+	 * clean scores 1.0, byte-identical to one where the oracle, the held-out
+	 * acceptance tests and the regression suite all passed. The trajectory
+	 * report is what a human reads to judge whether the loop is working, so the
+	 * two must be distinguishable. This does NOT change the verified bit —
+	 * `verdict: 'pass'` still requires a positive signal and `objective: true`
+	 * still requires the replay oracle, so the bandit was never trained on a
+	 * no-evidence success. It is a reporting-honesty field.
+	 */
+	verificationWeight: number;
 	reasons: string[];
 	directives: string[];
 }
@@ -578,6 +597,22 @@ export function composeRewardBreakdown(
 		);
 	}
 
+	// Executable-evidence weight BEFORE the adherence/audit components are
+	// counted: components[0..2] are oracle, tests and regression in push order.
+	const verificationWeight = components
+		.slice(0, 3)
+		.reduce((a, c) => a + (c?.weight ?? 0), 0);
+	if (verificationWeight === 0) {
+		reasons.push(
+			'evidence: NO executable verification ran (no oracle, no acceptance tests, no ' +
+			'regression) — this reward is the audit/adherence components alone and is NOT ' +
+			'comparable to a verified pass',
+		);
+		directives.push(
+			'get at least one executable check running — a clean diff nobody could verify ' +
+			'is not evidence of a fix',
+		);
+	}
 	const available = components.filter((c): c is { score: number; weight: number } => c !== null);
 	const totalWeight = available.reduce((a, c) => a + c.weight, 0);
 	const reward =
@@ -611,6 +646,7 @@ export function composeRewardBreakdown(
 		reward: Math.round(reward * 1000) / 1000,
 		verifiedEligible,
 		verifiedBlockCause,
+		verificationWeight,
 		reasons,
 		directives: [...new Set(directives)],
 	};

--- a/extension/src/harness/runtimeAnalysis.ts
+++ b/extension/src/harness/runtimeAnalysis.ts
@@ -73,13 +73,41 @@ export function isExpectedRejection(
 }
 
 /**
+ * Is this raised exception one a CALLER absorbed, rather than a failure that
+ * escaped? `contained === true` means the capture observed an ancestor frame
+ * exiting `ok` while this frame exited with an error — i.e. a `try/except`
+ * upstream handled it, deliberately, and the process carried on.
+ *
+ * This is the same false-positive class as `isExpectedRejection`, one level
+ * more general. The case that motivated it: the embedder binds its port as a
+ * machine-wide single-instance lock, so a second `serve` raises
+ * `OSError(EADDRINUSE)` inside `make_server`, and `_cmd_serve` catches it,
+ * prints "reusing it rather than loading a second copy of the model", and
+ * returns 0 (embedder/src/vinv_embedder/cli.py:91). The trace records exactly
+ * that shape — `make_server` exits error at depth 2, `_cmd_serve` exits ok at
+ * depth 1, `main` exits ok at depth 0 — yet it was clustered as a defect,
+ * dispatched as a fix episode, and the harness agent correctly disputed the
+ * premise ("the intentional single-instance bind lock, not an unhandled
+ * failure"). The episode aborted at reward -1.00. Handled control flow must
+ * never reach the episode queue.
+ *
+ * `null`/`undefined` (no ancestor exit observed) is NOT treated as handled —
+ * same "when unsure, keep it on the list" rule as everywhere else here.
+ */
+export function isHandledInternally(contained: boolean | null | undefined): boolean {
+	return contained === true;
+}
+
+/**
  * Scans the runtime overlay for symbols that raised DEFECTS. The returned
  * `signature` is order-independent and content-derived (file:name:errorTypes),
  * so "the same errors as last time" is a computable fact — the auto-trigger
  * uses it to dispatch each distinct failure picture exactly once.
  *
- * Deliberate 4xx rejections (see `isExpectedRejection`) are excluded: they
- * are the service saying "no" correctly, not the service breaking.
+ * Two classes of non-defect are excluded, both evidence-derived and both
+ * narrow: deliberate 4xx rejections (see `isExpectedRejection`) are the
+ * service saying "no" correctly, and exceptions an upstream frame caught (see
+ * `isHandledInternally`) never escaped at all. Everything else stays a defect.
  */
 export function collectRuntimeErrorClusters(
 	nodes: GraphNode[],
@@ -93,7 +121,9 @@ export function collectRuntimeErrorClusters(
 		.map(([row, rt]) => {
 			const current = rt.failures.filter((f) => f.superseded === null);
 			const defects = current.filter(
-				(f) => !isExpectedRejection(f.error_type, f.error_message),
+				(f) =>
+					!isExpectedRejection(f.error_type, f.error_message) &&
+					!isHandledInternally(f.contained),
 			);
 			// Older captures carry counts but no failure records — nothing to
 			// classify, so keep them defects (when unsure, keep on the list).
@@ -512,6 +542,109 @@ export function securityGuardReasons(
  * minus one representative call) and capped at the NEWEST session's total for
  * the symbol — you cannot reclaim more than the symbol currently costs.
  */
+/**
+ * Fraction of a request root's duration at or above which a frame's time IS the
+ * request/process lifetime rather than its own work.
+ *
+ * Not an absolute millisecond threshold — it is a ratio against THIS app's own
+ * request roots, so it holds for a 5ms service and a 5s batch alike (the same
+ * rule the rest of this module follows). Measured on the embedder capture, the
+ * separation is wide: `main` (depth 0), `do_GET` (depth 0) and `_cmd_serve` (the
+ * pass-through under main) all sit at 100.00% of their root, while the slowest
+ * frame that does REAL work — `EmbeddingEngine.load`, a sentence-transformer
+ * load — is 90.29%, and a request handler's `_send_json` is 55.69%. 0.99 keeps a
+ * ~9.7-point margin above the highest genuine worker.
+ */
+const LIFETIME_SHARE = 0.99;
+
+/**
+ * Rows whose observed duration measures PROCESS/REQUEST LIFETIME, not work —
+ * mapped to a human-readable reason.
+ *
+ * For a process or request root, `total_ms` is wall-clock lifetime: the program
+ * was running. Every duration-based heuristic misreads that, and the misreads
+ * are dispatchable. Observed live on this repo before this gate existed: the
+ * cache board offered `main` and `_cmd_serve` at "~25101ms is cacheable —
+ * recomputes identical inputs (1 of 2 calls repeat)", i.e. memoize the CLI entry
+ * point of a SERVER, and the hotspot board ranked the same two symbols #1 and #2
+ * at 31.2% each — 62.4% of "traced runtime" being "the process was running" —
+ * with a one-click optimize episode on both. The per-call rule read worst of all:
+ * "_cmd_serve 10738.8ms per call (self) — 148428.8x the typical symbol;
+ * unexpectedly slow for the work it does." A serve loop is SUPPOSED to take the
+ * whole run.
+ *
+ * None of the three existing soundness gates fires on these: functional
+ * dependence HOLDS (same argv, same exit 0, every time), no crypto/credential
+ * import is on the path, and `main` returns 0 rather than None.
+ *
+ * A row qualifies when it was observed at depth 0 (its duration is the lifetime
+ * by definition), or when its duration reaches LIFETIME_SHARE of the depth-0
+ * root of the same request — a pass-through frame that spans the whole run.
+ *
+ * Deliberately NOT "any once-per-request child of a root": in a web service most
+ * of a handler's real work is exactly that shape. On this capture that rule would
+ * have wrongly excluded `_send_json`, `queue_depth`, `ready` and `warming`, all
+ * legitimate optimization targets. The discriminator is the SHARE, not the
+ * parent.
+ *
+ * Excluded from cache candidates and from duration-ranked hotspots — the two
+ * surfaces that dispatch work. Coverage, the call tree and `why_did_this_run`
+ * keep them, because there lifetime is the correct and useful reading. Same
+ * discipline as the containment fix: stop CLASSIFYING it as waste, do not hide it.
+ */
+export function lifetimeFrames(
+	workspaceRoot: string,
+	nodes: GraphNode[],
+): Map<number, string> {
+	const rowsFor = buildComponentMatcher(nodes);
+	const out = new Map<number, string>();
+	// Per request: the depth-0 root's duration, and each component's total.
+	const rootMs = new Map<string, number>();
+	const compMs = new Map<string, Map<string, number>>();
+	const depthZero = new Set<string>();
+	for (const file of findTraceFiles(path.join(workspaceRoot, '.vinv', 'captures'))) {
+		for (const ev of eventsOf(file)) {
+			if (ev.event !== 'exit' || !ev.component) {
+				continue;
+			}
+			const rid = `${file}\u0000${ev.request_id ?? ''}`;
+			const ms = Number(ev.duration_ms ?? 0) || 0;
+			// depth is a string in raw captures — compare numerically.
+			if (Number(ev.depth ?? -1) === 0) {
+				depthZero.add(ev.component);
+				rootMs.set(rid, Math.max(rootMs.get(rid) ?? 0, ms));
+			}
+			const byComp = compMs.get(rid) ?? new Map<string, number>();
+			byComp.set(ev.component, (byComp.get(ev.component) ?? 0) + ms);
+			compMs.set(rid, byComp);
+		}
+	}
+	const mark = (component: string, reason: string): void => {
+		const rows = rowsFor(component);
+		if (rows.length === 1 && !out.has(rows[0])) {
+			out.set(rows[0], reason);
+		}
+	};
+	for (const component of depthZero) {
+		mark(component, 'runs at depth 0 — its duration is the request/process lifetime, not work');
+	}
+	for (const [rid, byComp] of compMs) {
+		const root = rootMs.get(rid);
+		if (!root || root <= 0) {
+			continue; // no depth-0 root observed for this request — no denominator
+		}
+		for (const [component, ms] of byComp) {
+			if (ms / root >= LIFETIME_SHARE) {
+				mark(
+					component,
+					`spans ${Math.round((ms / root) * 100)}% of its request root — a pass-through whose duration is the lifetime, not work`,
+				);
+			}
+		}
+	}
+	return out;
+}
+
 export function collectCacheCandidates(
 	workspaceRoot: string,
 	nodes: GraphNode[],
@@ -537,6 +670,12 @@ export function collectCacheCandidates(
 		newestSessionMs: number;
 	}
 	const perRow = new Map<number, Acc>();
+	// FOURTH soundness gate (see lifetimeFrames). The other three — functional
+	// dependence, the security guard, and the none-return rule — all PASS on a
+	// process entry point, which is how `main` and `_cmd_serve` came to be
+	// offered as memoization targets at "~25101ms is cacheable". Memoizing a
+	// server's CLI entry point means "do not start the process the second time".
+	const lifetime = lifetimeFrames(workspaceRoot, nodes);
 	for (const s of sessionTraces(workspaceRoot)) {
 		const sessionMs = new Map<number, number>();
 		// Pair enter→exit per (request, thread, component, depth) so each exit's
@@ -551,6 +690,9 @@ export function collectCacheCandidates(
 				continue;
 			}
 			const row = rows[0];
+			if (lifetime.has(row)) {
+				continue; // duration is lifetime, not work — nothing here is reclaimable
+			}
 			const pairKey = `${ev.request_id ?? ''}\u0000${ev.thread_id ?? ''}\u0000${ev.component}\u0000${ev.depth ?? ''}`;
 			if (ev.event === 'enter') {
 				const st = open.get(pairKey) ?? [];

--- a/extension/src/harness/session.ts
+++ b/extension/src/harness/session.ts
@@ -42,6 +42,19 @@ export interface EpisodeOutcome {
 	verified: boolean;
 	aborted: boolean;
 	reward: number;
+	/**
+	 * Executable-evidence weight behind `reward` (oracle + acceptance tests +
+	 * regression, before renormalization). 0 means NOTHING executable ran, so the
+	 * reward is the audit/adherence components alone.
+	 *
+	 * Persisted because `reward` is renormalized over the components that were
+	 * AVAILABLE — correct MNAR handling, since an unrunnable check is not a
+	 * verdict — which makes the bare number incomparable across episodes: a clean
+	 * verified pass and an episode where nothing could be checked both render
+	 * 1.00. Optional: records written before this field carry `undefined`, which
+	 * means UNKNOWN and must never be displayed as if it were verified.
+	 */
+	verification_weight?: number;
 	/** One-line evidence digest of the final verdict (what happened, why). */
 	evidence: string;
 	/** Path to the last context pack — the full-evidence artifact for this

--- a/extension/src/harness/trajectoryReport.ts
+++ b/extension/src/harness/trajectoryReport.ts
@@ -13,7 +13,7 @@
  * the audit trail of the closed loop.
  */
 import * as fs from 'fs';
-import type { SessionState } from './session';
+import type { EpisodeOutcome, SessionState } from './session';
 import { loadSession } from './session';
 import { episodeLedgerPath, type EpisodeEvent } from './episodeTelemetry';
 
@@ -41,6 +41,41 @@ export function readEpisodeEvents(ledgerPath = episodeLedgerPath()): EpisodeEven
 
 function fmtReward(r: number): string {
 	return (r >= 0 ? '+' : '') + r.toFixed(2);
+}
+
+/**
+ * Says what executable evidence stood behind a reward, because the number alone
+ * cannot.
+ *
+ * `reward` is renormalized over the rubric components that were AVAILABLE —
+ * correct handling, since a check that could not run is not a verdict and
+ * scoring it 0 would punish an agent for missing infrastructure. The cost is
+ * that a clean verified pass, an episode where nothing could be checked, and an
+ * episode whose acceptance tests were discarded as non-discriminating all print
+ * the same 1.00. This is the line a human reads to decide whether the loop
+ * works, so the qualifier travels with every reward we print.
+ *
+ * `undefined` is UNKNOWN (records predating the field) and is marked as such —
+ * never silently rendered as though it were verified.
+ */
+function rewardQualifier(h: EpisodeOutcome): string {
+	// An abort short-circuits scoring entirely: episodeReward returns a flat −1
+	// whatever the cause — the operator rejected a disputed premise, the run was
+	// cancelled, a revert fired. That is the SAME magnitude a proven regression
+	// or a human retraction earns, so the trajectory reads as though a cancelled
+	// run were as bad as shipped-and-reverted code. It also does not train the
+	// policy (aborted episodes are recorded objective:false), which is exactly
+	// the kind of thing the number alone cannot say.
+	if (h.aborted) {
+		return ' (fixed abort penalty — not a measured verdict, and not used for learning)';
+	}
+	if (h.verification_weight === undefined) {
+		return ' (verification evidence not recorded)';
+	}
+	if (h.verification_weight <= 0) {
+		return ' — UNVERIFIED: no oracle, tests or regression ran, so this is the audit components alone';
+	}
+	return ` (verification weight ${h.verification_weight.toFixed(2)})`;
 }
 
 /**
@@ -74,14 +109,37 @@ export function composeTrajectoryReport(
 	const fixed = session.history.filter((h) => h.verified);
 	const open = session.history.filter((h) => !h.verified && !h.aborted);
 	const aborted = session.history.filter((h) => h.aborted);
-	const totalReward = session.history.reduce((s, h) => s + h.reward, 0);
+	// An abort scores a FIXED −1 whatever the cause (operator rejected a disputed
+	// premise, run cancelled, revert fired) and is recorded objective:false, so it
+	// never trains the policy. Summing that penalty into a figure a human reads as
+	// performance made a cancelled run weigh exactly as much as shipped-and-
+	// reverted code. Measured verdicts only — but the exclusion is STATED, because
+	// silently dropping them trades a wrong number for a number that hides how
+	// much it left out.
+	const measured = session.history.filter((h) => !h.aborted);
+	const totalReward = measured.reduce((s, h) => s + h.reward, 0);
 	lines.push('## Scoreboard');
 	lines.push('');
 	lines.push(
 		`${session.history.length} episode(s) · ${fixed.length} verified fixed · ` +
 			`${open.length} unresolved · ${aborted.length} aborted · ` +
-			`cumulative reward ${fmtReward(totalReward)}`,
+			`cumulative reward ${fmtReward(totalReward)} across ${measured.length} measured verdict(s)` +
+			(aborted.length > 0
+				? `; ${aborted.length} aborted episode(s) excluded (fixed penalty, not a measured outcome)`
+				: ''),
 	);
+	// Summing rewards of differing provenance is the same incomparability one
+	// level up: an unverified 1.00 adds as much to the total as a verified one.
+	const unverified = session.history.filter((h) => h.verification_weight === 0).length;
+	if (unverified > 0) {
+		lines.push('');
+		lines.push(
+			`> ${unverified} of these episode(s) ran NO executable verification — no oracle, ` +
+				'no acceptance tests, no regression. Their reward reflects the audit components ' +
+				'alone and is not comparable to a verified pass, so the cumulative figure above ' +
+				'sums rewards of different provenance.',
+		);
+	}
 	lines.push('');
 
 	// Per-episode detail, oldest first (the trajectory reads top-down).
@@ -100,7 +158,8 @@ export function composeTrajectoryReport(
 		lines.push(`### ${h.title}`);
 		lines.push('');
 		lines.push(
-			`- **${status}** · ${h.ts} · arm #${h.arm_index} · ${h.attempts} attempt(s) · reward ${fmtReward(h.reward)}`,
+			`- **${status}** · ${h.ts} · arm #${h.arm_index} · ${h.attempts} attempt(s) · ` +
+				`reward ${fmtReward(h.reward)}${rewardQualifier(h)}`,
 		);
 		lines.push(`- Evidence: ${h.evidence}`);
 		if (h.pack_path) {
@@ -126,9 +185,32 @@ export function composeTrajectoryReport(
 	lines.push('');
 	lines.push('## Reward Trend');
 	lines.push('');
+	// A bare arrow chain invites reading a trend across numbers that may not share
+	// a denominator, so an unverified reward is marked inline rather than in a
+	// legend the reader has to go find.
 	lines.push(
-		'Reward per episode: ' + session.history.map((h) => fmtReward(h.reward)).join(' → '),
+		'Reward per episode: ' +
+			session.history
+				.map(
+					(h) =>
+						fmtReward(h.reward) +
+						(h.aborted ? '†' : h.verification_weight === 0 ? '*' : ''),
+				)
+				.join(' → '),
 	);
+	// A marked entry in the chain that is NOT in the cumulative figure above has to
+	// say so here, or the two numbers silently disagree.
+	if (session.history.some((h) => h.verification_weight === 0 && !h.aborted)) {
+		lines.push('');
+		lines.push('`*` = unverified: nothing executable ran behind that reward.');
+	}
+	if (aborted.length > 0) {
+		lines.push('');
+		lines.push(
+			'`†` = aborted: a fixed penalty rather than a measured verdict — excluded from ' +
+				'the cumulative figure above, and never used for learning.',
+		);
+	}
 	const policyUpdates = events.filter((e) => e.type === 'policy_updated');
 	if (policyUpdates.length > 0) {
 		const last = policyUpdates[policyUpdates.length - 1];

--- a/extension/src/mcp/indexServer.ts
+++ b/extension/src/mcp/indexServer.ts
@@ -59,6 +59,7 @@ import { discoverStores, describeProvenance } from '../graph/storeDiscovery';
 import { EVAL_EVERY, maybeRunOpeEvaluation } from './opeEvaluator';
 import {
 	enqueueEpisodeRequest,
+	readRequestOutcomes,
 	type EpisodeRequestKind,
 } from '../harness/requestQueue';
 import { composePlaybookSlice, PLAYBOOK_KINDS } from '../harness/contextPack';
@@ -218,6 +219,9 @@ const SESSION_TOOL = {
 	description:
 		'Read what Vinv has observed about this workspace at runtime, and drive its ' +
 		'automated fix/optimize runs ("episodes"), from chat. READ: ' +
+		'action="requests" (what became of each sweep/fix you QUEUED — a queued ' +
+		'sweep does not always dispatch, and this is the only durable record ' +
+		'of why one did not), ' +
 		'action="trajectory" (every episode so far — what was tried, whether it ' +
 		'verified, the reward, the standing goal, any disputes), ' +
 		'action="status" (one-paragraph session summary), ' +
@@ -252,6 +256,7 @@ const SESSION_TOOL = {
 					'memory_trends',
 					'cache_candidates',
 					'opportunities',
+					'requests',
 					'playbook',
 					'fix',
 					'run_sweep',
@@ -482,6 +487,12 @@ function sessionReadAction(action: string): string | null {
 			return null;
 	}
 }
+
+/** The request id inside a queue filename (`episode-<uuid>.json`). Derived
+ * from the path enqueue returned so the id reported to the caller and the id
+ * written to the outcome ledger can never drift apart. */
+const requestIdOf = (file: string): string =>
+	path.basename(file).replace(/^episode-/, '').replace(/\.json$/, '');
 
 const SWEEP_REQUEST_KINDS: Record<string, EpisodeRequestKind> = {
 	runtime_errors: 'runtime-errors',
@@ -733,10 +744,29 @@ async function handle(req: JsonRpcRequest): Promise<void> {
 						content: [{
 							type: 'text',
 							text:
-								`Sweep '${sweep}' queued (${path.basename(file)}). The Vinv ` +
+								`Sweep '${sweep}' queued as request ${requestIdOf(file)}. The Vinv ` +
 								'extension gathers the current evidence, seeds a context pack with the ' +
-								'affected symbols, and dispatches the episode — check progress with ' +
-								'action="trajectory".',
+								'affected symbols, and dispatches the episode. A queued sweep does NOT ' +
+								'always dispatch — it may find nothing to work on — so read ' +
+								'action="requests" for this request\'s recorded outcome, and ' +
+								'action="trajectory" for the episode once one exists.',
+						}],
+					});
+					return;
+				}
+				if (args.action === 'requests') {
+					// The other half of the queue's honesty: a drained request that
+					// dispatched nothing used to leave its reason in a transient toast.
+					const rows = readRequestOutcomes(workspaceRoot).slice(-25).reverse();
+					reply(req.id, {
+						content: [{
+							type: 'text',
+							text: rows.length === 0
+								? 'No queued-request outcomes recorded yet. (Requests queued before this ' +
+									'ledger existed left no record — that absence is not evidence they ran.)'
+								: ['Queued-request outcomes, newest first:', '']
+									.concat(rows.map((r) => `- [${r.outcome}] ${r.kind} ${r.request_id} @ ${r.ts}\n      ${r.reason}`))
+									.join('\n'),
 						}],
 					});
 					return;

--- a/extension/src/runtime/analysis.ts
+++ b/extension/src/runtime/analysis.ts
@@ -16,9 +16,12 @@
  */
 import {
 	cmpSessionMark,
+	containmentVerdict,
+	mergeContainment,
 	loadCorpus,
 	resolveSymbol,
 	TraceCorpus,
+	type ExitRow,
 	type SessionMark,
 } from './traceStore';
 import { valuesOf } from './valueProfiles';
@@ -282,9 +285,36 @@ export function toolCoverageOf(workspaceRoot: string, symbol?: string): Record<s
 			count: number;
 			capture_epoch: number | null;
 			superseded: null | 'code_changed' | 'not_reproduced';
+			/** Did a caller absorb it? See traceStore.containmentVerdict. */
+			contained: boolean | null;
+			/** Innermost ancestor that absorbed it; null when it escaped/unknown. */
+			contained_by: string | null;
 			lastSeen: SessionMark;
 		}
 		const failures = new Map<string, CoverageFailure>();
+		// Ancestor exit outcomes for containment: a parent's own exit row lives
+		// on its SymbolRecord, matched on (request_id, thread_id) so concurrent
+		// requests and threads never cross-contaminate. Innermost caller first.
+		const ancestorExits = (
+			x: ExitRow,
+		): { oks: Array<boolean | undefined>; chain: string[] } => {
+			const out: Array<boolean | undefined> = [];
+			const chain: string[] = [];
+			const seen = new Set<string>();
+			let cursor = x.parent_component;
+			while (cursor && out.length < 32 && !seen.has(cursor)) {
+				seen.add(cursor);
+				chain.push(cursor);
+				const pexit = corpus.bySymbol
+					.get(cursor)
+					?.exits.find(
+						(e) => e.request_id === x.request_id && e.thread_id === x.thread_id,
+					);
+				out.push(pexit ? pexit.status === 'ok' : undefined);
+				cursor = pexit?.parent_component ?? null;
+			}
+			return { oks: out, chain };
+		};
 		for (const x of rec.exits) {
 			if (x.status === 'error') {
 				error += 1;
@@ -297,6 +327,13 @@ export function toolCoverageOf(workspaceRoot: string, symbol?: string): Record<s
 					const cur = failures.get(key);
 					if (cur) {
 						cur.count += 1;
+						const anc = ancestorExits(x);
+						const verdict = containmentVerdict(anc.oks);
+						cur.contained = mergeContainment(cur.contained, verdict);
+						cur.contained_by =
+							cur.contained === true
+								? (cur.contained_by ?? anc.chain[anc.oks.indexOf(true)] ?? null)
+								: null;
 						if (!cur.error_stack && x.error_stack) {
 							cur.error_stack = x.error_stack;
 						}
@@ -313,6 +350,13 @@ export function toolCoverageOf(workspaceRoot: string, symbol?: string): Record<s
 							count: 1,
 							capture_epoch: x.source_epoch ?? null,
 							superseded: null,
+							contained: containmentVerdict(ancestorExits(x).oks),
+							contained_by: (() => {
+								const a = ancestorExits(x);
+								return containmentVerdict(a.oks) === true
+									? (a.chain[a.oks.indexOf(true)] ?? null)
+									: null;
+							})(),
 							lastSeen: sessionKey(x),
 						});
 					}

--- a/extension/src/runtime/traceStore.ts
+++ b/extension/src/runtime/traceStore.ts
@@ -106,6 +106,60 @@ export interface SymbolRecord {
 	observedUntagged: boolean;
 }
 
+/**
+ * Fold the observed exit outcomes of a failing frame's ANCESTORS into one
+ * containment verdict — did the exception escape, or did a caller absorb it?
+ *
+ * `ancestorExitedOk` is ordered innermost-caller-first, one entry per frame of
+ * the observed caller chain: `true` = that frame exited `ok`, `false` = it also
+ * exited with an error, `undefined` = its exit was not in the capture.
+ *
+ *  - `true`  — some ancestor exited `ok` while the callee raised, so a
+ *    `try/except` upstream handled it. The raise is control flow.
+ *  - `false` — every ancestor whose exit WAS observed also errored, so nothing
+ *    absorbed it: the exception escaped.
+ *  - `null`  — no ancestor exit was observed at all. Unknown, and consumers
+ *    must read unknown as escaped; treating it as handled would hide real
+ *    failures.
+ *
+ * Shared by the graph overlay (`indexGraph.absorbRawCaptures`) and the
+ * `coverage_of` MCP tool (`analysis.toolCoverageOf`) so both answer this
+ * question identically — the same reason their session ordering is shared.
+ */
+export function containmentVerdict(
+	ancestorExitedOk: Array<boolean | undefined>,
+): boolean | null {
+	let verdict: boolean | null = null;
+	for (const ok of ancestorExitedOk) {
+		if (ok === undefined) {
+			continue; // no evidence from this frame
+		}
+		if (ok) {
+			return true; // absorbed here — no need to look further out
+		}
+		verdict = false; // observed, and it errored too: still escaping
+	}
+	return verdict;
+}
+
+/**
+ * Merge containment across repeat occurrences of the SAME failure identity.
+ * Only "handled" when EVERY observed occurrence was absorbed: one escape makes
+ * the identity a real defect, and an unknown never upgrades a known escape.
+ */
+export function mergeContainment(
+	a: boolean | null,
+	b: boolean | null,
+): boolean | null {
+	if (a === false || b === false) {
+		return false;
+	}
+	if (a === null || b === null) {
+		return null;
+	}
+	return true;
+}
+
 /** One request's outcome, derived from its exit rows. */
 export interface RequestOutcome {
 	request_id: string;

--- a/extension/src/test/cockpit.test.ts
+++ b/extension/src/test/cockpit.test.ts
@@ -83,10 +83,11 @@ import {
 } from '../harness/stallBreaker';
 import { isServiceStarted, readBringupOutcome, readStartCommands } from '../bringup/bringup';
 import { collectRuntimeErrorClusters, selectHotspots } from '../harness/autoTrigger';
-import { isExpectedRejection } from '../harness/runtimeAnalysis';
+import { isExpectedRejection, isHandledInternally } from '../harness/runtimeAnalysis';
 import { composeTrajectoryReport, readEpisodeEvents } from '../harness/trajectoryReport';
 import {
 	collectCacheCandidates,
+	lifetimeFrames,
 	collectMemoryTrends,
 	collectRequestSpans,
 	collectSymbolTimings,
@@ -825,8 +826,14 @@ suite('Episode policy updater (credit attribution + promotion)', () => {
 		assert.strictEqual(computeUpdatedPolicy(current, sparse).preferred_arm, 0);
 
 		// Aborted / human-adjudicated (non-objective) episodes do NOT train arms.
+		// Arm 2 carries 5 objective successes, not 3, so it clears the now-enforced
+		// `min_promotion_n` gate: this case is about the OBJECTIVE FILTER, and
+		// `preferred_arm` is only its observable. (The gate itself — promotion needs
+		// min_promotion_n observations AND a promotion_delta margin — has its own
+		// test in rewardAndOpe.test.ts. Before the gate was wired up, 3 sufficed
+		// here, and so did 1, which is exactly the defect it closes.)
 		const withNonObjective: CompletedEpisode[] = [
-			...episodesFor([{ arm: 2, rewards: [1, 1, 1] }]),
+			...episodesFor([{ arm: 2, rewards: [1, 1, 1, 1, 1] }]),
 			{ armIndex: 5, propensity: 0.5, reward: -1, attempts: 1, verified: false, objective: false },
 			{ armIndex: 5, propensity: 0.5, reward: 1, attempts: 1, verified: true, objective: false },
 		];
@@ -1456,6 +1463,147 @@ suite('Session state (goal + trajectory across episodes)', () => {
 			fs.rmSync(ws, { recursive: true, force: true });
 		}
 	});
+
+});
+
+/**
+ * A CROSS-SURFACE INVARIANT, not one report's content: no reward is ever printed
+ * without saying what stood behind it.
+ *
+ * `reward` is renormalized over the rubric components that were AVAILABLE, and an
+ * abort short-circuits scoring to a flat −1 whatever the cause. So the bare number
+ * cannot distinguish a verified pass from an episode nothing could check, nor a
+ * cancelled run from a proven regression — each pair prints the same magnitude.
+ * This suite exists so the rule binds reward surfaces nobody has written yet,
+ * rather than being buried in a test named for one digest.
+ */
+suite('reward reporting: every printed reward carries its provenance', () => {
+	function tempWs(): string {
+		return fs.mkdtempSync(path.join(os.tmpdir(), 'vinv-reward-'));
+	}
+
+	test('no reward line is rendered bare', () => {
+		const ws = tempWs();
+		try {
+			recordEpisodeOutcome(ws, {
+				episode_id: 'ep-verified',
+				ts: 't1',
+				title: 'Verified with executable evidence',
+				arm_index: 0,
+				attempts: 1,
+				verified: true,
+				aborted: false,
+				reward: 0.9,
+				verification_weight: 0.9,
+				evidence: 'oracle + tests green',
+			});
+			recordEpisodeOutcome(ws, {
+				episode_id: 'ep-unverified',
+				ts: 't2',
+				title: 'Nothing executable ran',
+				arm_index: 1,
+				attempts: 1,
+				verified: false,
+				aborted: false,
+				reward: 1,
+				verification_weight: 0,
+				evidence: 'audit components only',
+			});
+			// Predates the field: UNKNOWN, which must not be asserted as a negative.
+			recordEpisodeOutcome(ws, {
+				episode_id: 'ep-legacy',
+				ts: 't3',
+				title: 'Recorded before the field existed',
+				arm_index: 2,
+				attempts: 1,
+				verified: true,
+				aborted: false,
+				reward: 0.7,
+				evidence: 'legacy record',
+			});
+			recordEpisodeOutcome(ws, {
+				episode_id: 'ep-aborted',
+				ts: 't4',
+				title: 'Cancelled',
+				arm_index: 3,
+				attempts: 1,
+				verified: false,
+				aborted: true,
+				reward: -1,
+				evidence: 'harness run failed: cancelled',
+			});
+			const report = composeTrajectoryReport(loadSession(ws), []);
+			const rewardLines = report.split('\n').filter((l) => l.includes('· reward '));
+			assert.strictEqual(rewardLines.length, 4, 'every episode prints a reward line');
+			for (const line of rewardLines) {
+				assert.match(
+					line,
+					/(verification weight|UNVERIFIED|not recorded|fixed abort penalty)/,
+					`a reward printed with no provenance qualifier: ${line}`,
+				);
+			}
+			// Unknown and zero are DIFFERENT, and neither is "verified".
+			assert.ok(
+				rewardLines.some((l) => l.includes('not recorded')),
+				'a pre-field record says its evidence is unknown, not that none ran',
+			);
+			assert.ok(
+				rewardLines.some((l) => l.includes('UNVERIFIED')),
+				'a zero-weight record says plainly that nothing executable ran',
+			);
+		} finally {
+			fs.rmSync(ws, { recursive: true, force: true });
+		}
+	});
+
+	test('aborted episodes are excluded from cumulative reward — and the exclusion is stated', () => {
+		const ws = tempWs();
+		try {
+			recordEpisodeOutcome(ws, {
+				episode_id: 'ep-ok',
+				ts: 't1',
+				title: 'A measured verdict',
+				arm_index: 0,
+				attempts: 1,
+				verified: true,
+				aborted: false,
+				reward: 0.5,
+				verification_weight: 0.9,
+				evidence: 'oracle passed',
+			});
+			// An abort scores a flat −1 whatever the cause and never trains the
+			// policy, so summing it into a figure a human reads as performance made
+			// a cancelled run weigh as much as shipped-and-reverted code.
+			recordEpisodeOutcome(ws, {
+				episode_id: 'ep-abort',
+				ts: 't2',
+				title: 'Cancelled before any verdict',
+				arm_index: 1,
+				attempts: 1,
+				verified: false,
+				aborted: true,
+				reward: -1,
+				evidence: 'harness run failed: cancelled',
+			});
+			const report = composeTrajectoryReport(loadSession(ws), []);
+			assert.ok(
+				report.includes('cumulative reward +0.50 across 1 measured verdict(s)'),
+				`the abort must not be summed into performance: ${report}`,
+			);
+			// Excluding silently would trade a wrong number for one that hides how
+			// much it left out — the same defect wearing the opposite costume.
+			assert.ok(
+				report.includes('1 aborted episode(s) excluded'),
+				'the exclusion has to be stated, not silent',
+			);
+			// A marked entry in the trend chain that is absent from the sum above
+			// must carry its own legend, or the two figures silently disagree.
+			assert.ok(report.includes('-1.00†'), 'aborts are marked in the trend chain');
+			assert.ok(report.includes('`†` = aborted'), 'the marker is explained');
+		} finally {
+			fs.rmSync(ws, { recursive: true, force: true });
+		}
+	});
 });
 
 suite('Bring-up outcome classification (services view states)', () => {
@@ -1580,7 +1728,7 @@ suite('Stall breaker (Nash bargaining)', () => {
 		// clustered as defects, they handed the agent an unfixable goal.
 		const fail = (error_type: string, error_message: string, count = 4) => ({
 			error_type, error_message, error_stack: null, request_id: 'r',
-			count, capture_epoch: null, superseded: null as null,
+			count, capture_epoch: null, superseded: null as null, contained: null, contained_by: null,
 			caller_chain: [], args_schema: null, args_summary: null, duration_ms: 1,
 		});
 		const nodes = [0, 1, 2].map((r) => makeNode(r));
@@ -1610,6 +1758,61 @@ suite('Stall breaker (Nash bargaining)', () => {
 		assert.strictEqual(isExpectedRejection('fastapi.exceptions.HTTPException', 'no status here'), false);
 		assert.strictEqual(isExpectedRejection('sqlalchemy.exc.IntegrityError', '409: fake'), false);
 		assert.strictEqual(isExpectedRejection('MyHTTPExceptionFactory', '404: x'), false);
+	});
+
+	test('exceptions a caller absorbed are NOT defects; escaping ones are', () => {
+		// The second live false-positive, same class as the 4xx one above. The
+		// embedder binds its port as a machine-wide single-instance lock, so a
+		// second `serve` raises OSError(EADDRINUSE) in make_server and
+		// _cmd_serve catches it and returns 0 (vinv_embedder/cli.py:91). The
+		// capture recorded make_server exit=error at depth 2, _cmd_serve exit=ok
+		// at depth 1, main exit=ok at depth 0 — handled control flow. It was
+		// clustered as a defect and dispatched as a fix episode anyway; the
+		// harness agent disputed the premise and the episode aborted at -1.00.
+		const fail = (
+			error_type: string,
+			error_message: string,
+			contained: boolean | null,
+			count = 1,
+		) => ({
+			error_type, error_message, error_stack: null, request_id: 'r',
+			count, capture_epoch: null, superseded: null as null, contained,
+			contained_by: contained === true ? 'vinv_embedder.cli._cmd_serve' : null,
+			caller_chain: ['vinv_embedder.cli._cmd_serve', 'vinv_embedder.cli.main'],
+			args_schema: null, args_summary: null, duration_ms: 1,
+		});
+		const nodes = [0, 1, 2, 3].map((r) => makeNode(r));
+		const overlay: Record<number, RuntimeOverlay> = {
+			// make_server: raised, but _cmd_serve absorbed it → not a defect.
+			0: { executed: true, calls: 1, total_ms: 1, errors: 1, error_types: ['OSError'],
+				failures: [fail('OSError', '[Errno 48] Address already in use', true)],
+				current_errors: 1, latest_epoch: null },
+			// A genuinely escaping error → still a defect.
+			1: { executed: true, calls: 3, total_ms: 5, errors: 2, error_types: ['ValueError'],
+				failures: [fail('ValueError', 'bad input', false, 2)],
+				current_errors: 2, latest_epoch: null },
+			// Containment unknown (no ancestor exit observed) → stays a defect.
+			2: { executed: true, calls: 2, total_ms: 3, errors: 1, error_types: ['KeyError'],
+				failures: [fail('KeyError', 'missing', null)],
+				current_errors: 1, latest_epoch: null },
+			// Same identity seen both absorbed AND escaping → one escape makes it
+			// a defect, so the merged verdict must be false, not true.
+			3: { executed: true, calls: 4, total_ms: 6, errors: 2, error_types: ['TimeoutError'],
+				failures: [fail('TimeoutError', 'timed out', false, 2)],
+				current_errors: 2, latest_epoch: null },
+		};
+		const { clusters } = collectRuntimeErrorClusters(nodes, overlay);
+		assert.deepStrictEqual(
+			clusters.map((c) => c.row).sort((a, b) => a - b),
+			[1, 2, 3],
+			'handled-internally symbol excluded; escaping and unknown kept',
+		);
+		// The predicate: only an observed `true` counts as handled. Unknown must
+		// never be read as handled — that would hide real failures.
+		assert.strictEqual(isHandledInternally(true), true);
+		assert.strictEqual(isHandledInternally(false), false);
+		assert.strictEqual(isHandledInternally(null), false);
+		assert.strictEqual(isHandledInternally(undefined), false);
 	});
 
 	test('the live stall-judge utilities escalate via the Nash rule', () => {
@@ -2229,6 +2432,51 @@ suite('Cache soundness gates (functional dependence + ceiling cap + security gua
 			const out = collectCacheCandidates(ws, [makeNode(0)]);
 			assert.strictEqual(out.length, 1);
 			assert.ok(out[0].reclaimable_ms <= 50, `capped at newest session (got ${out[0].reclaimable_ms})`);
+		} finally {
+			fs.rmSync(ws, { recursive: true, force: true });
+		}
+	});
+
+	test('an entry point is never a cache candidate — its duration is lifetime, not work', () => {
+		const ws = fs.mkdtempSync(path.join(os.tmpdir(), 'vinv-lifetime-'));
+		try {
+			// The live shape this closes. `main` is the process root: same argv →
+			// same exit 0 every launch, so functional dependence HOLDS, no crypto is
+			// on the path, and it returns 0 rather than None — all three existing
+			// soundness gates pass. The board therefore offered `main` and
+			// `_cmd_serve` at "~25101ms is cacheable (1 of 2 calls repeat)", i.e.
+			// memoize a server's CLI entry point, and ranked them #1/#2 of traced
+			// runtime at 31.2% each. For a process root, duration is WALL-CLOCK
+			// LIFETIME, not compute.
+			//
+			// fn0 = main at depth 0. fn1 = _cmd_serve, depth 1, spanning the whole
+			// root. fn2 = real work nested under fn1 at a fraction of the root — it
+			// MUST stay eligible, which is what keeps the gate narrow.
+			const lines: string[] = [];
+			for (const req of ['r0', 'r1']) {
+				lines.push(JSON.stringify({ event: 'enter', component: 'src.mod0.fn0', args_hash: 'aaaa', request_id: req, depth: 0 }));
+				lines.push(JSON.stringify({ event: 'enter', component: 'src.mod1.fn1', args_hash: 'bbbb', request_id: req, depth: 1 }));
+				lines.push(JSON.stringify({ event: 'enter', component: 'src.mod2.fn2', args_hash: 'cccc', request_id: req, depth: 2 }));
+				lines.push(JSON.stringify({ event: 'exit', component: 'src.mod2.fn2', error_type: 'None', request_id: req, depth: 2, duration_ms: 100, result_hash: 'h2' }));
+				lines.push(JSON.stringify({ event: 'exit', component: 'src.mod1.fn1', error_type: 'None', request_id: req, depth: 1, duration_ms: 1000, result_hash: 'h1' }));
+				lines.push(JSON.stringify({ event: 'exit', component: 'src.mod0.fn0', error_type: 'None', request_id: req, depth: 0, duration_ms: 1000, result_hash: 'h0' }));
+			}
+			writeTrace(ws, 's0', lines, Math.floor(Date.now() / 1000));
+			const nodes = [makeNode(0), makeNode(1), makeNode(2)];
+
+			const lifetime = lifetimeFrames(ws, nodes);
+			assert.ok(lifetime.has(0), 'depth-0 root is a lifetime frame');
+			assert.ok(lifetime.has(1), 'a pass-through spanning the whole root is a lifetime frame');
+			assert.ok(!lifetime.has(2), 'nested real work is NOT a lifetime frame');
+			assert.match(lifetime.get(0)!, /depth 0/);
+			assert.match(lifetime.get(1)!, /spans 100% of its request root/);
+
+			// Both entry points are duplicated (identical args across two runs) and
+			// would otherwise be the two biggest cache candidates by time.
+			const rows = collectCacheCandidates(ws, nodes).map((c) => c.row);
+			assert.ok(!rows.includes(0), 'the process root must not be offered for memoization');
+			assert.ok(!rows.includes(1), 'the pass-through must not be offered for memoization');
+			assert.deepStrictEqual(rows, [2], 'only genuine nested work stays eligible');
 		} finally {
 			fs.rmSync(ws, { recursive: true, force: true });
 		}

--- a/extension/src/test/configRequestPanel.test.ts
+++ b/extension/src/test/configRequestPanel.test.ts
@@ -141,6 +141,7 @@ suite('the submit arm', () => {
 			save: (answers) => writeAnswers(root, answers),
 			rerun: async () => { log.push('rerun'); },
 			showError: (m) => log.push(`error:${m}`),
+			notify: (m) => log.push(`notify:${m}`),
 		};
 	}
 
@@ -155,7 +156,13 @@ suite('the submit arm', () => {
 		);
 		assert.strictEqual(outcome.saved, 1);
 		assert.strictEqual(outcome.reran, true);
-		assert.deepStrictEqual(log, ['rerun']);
+		// The confirmation has to precede the re-run and name the file: saving
+		// disposes the panel, so this is the only evidence the user gets that a
+		// pasted credential landed somewhere.
+		assert.deepStrictEqual(log, [
+			'notify:Saved 1 value to .vinv/exercise/config_answers.json (owner-only) — re-running.',
+			'rerun',
+		]);
 		assert.deepStrictEqual(readAnswers(root), { A: 'x' });
 	});
 
@@ -178,6 +185,7 @@ suite('the submit arm', () => {
 			save: () => { throw new Error('disk full'); },
 			rerun: async () => { log.push('rerun'); },
 			showError: (m) => log.push(`error:${m}`),
+			notify: () => { throw new Error('must not claim a save that failed'); },
 		});
 		assert.strictEqual(outcome.saved, 0);
 		assert.strictEqual(outcome.reran, false, 're-ran on answers that were never saved');
@@ -189,6 +197,7 @@ suite('the submit arm', () => {
 			save: () => { throw new Error('should not be called'); },
 			rerun: async () => { throw new Error('should not be called'); },
 			showError: () => { throw new Error('should not be called'); },
+			notify: () => { throw new Error('should not be called'); },
 		});
 		assert.deepStrictEqual(outcome, { saved: 0, reran: false });
 	});

--- a/extension/src/test/contextGraph.test.ts
+++ b/extension/src/test/contextGraph.test.ts
@@ -726,7 +726,7 @@ suite('Harness handover pack (graph + evidence transfer)', () => {
 									duration_ms: 20865,
 									count: 1,
 									capture_epoch: 3,
-									superseded: null,
+									superseded: null, contained: null, contained_by: null,
 								},
 							],
 							current_errors: 1,

--- a/extension/src/test/criticAndDiscovery.test.ts
+++ b/extension/src/test/criticAndDiscovery.test.ts
@@ -112,7 +112,7 @@ suite('Deterministic answer critic', () => {
 					args_summary: null,
 					error_stack: null,
 					capture_epoch: 1,
-					superseded: 'not_reproduced',
+					superseded: 'not_reproduced', contained: null, contained_by: null,
 				},
 			],
 			arg_exemplars: [],

--- a/extension/src/test/exerciseWiring.test.ts
+++ b/extension/src/test/exerciseWiring.test.ts
@@ -40,6 +40,7 @@ function facts(over: Partial<FlowFacts> = {}): FlowFacts {
 		probes: [],
 		pendingEdges: 0,
 		autoPilot: { running: false, label: '' },
+		configRequests: 0,
 		...over,
 	};
 }

--- a/extension/src/test/findings.test.ts
+++ b/extension/src/test/findings.test.ts
@@ -118,14 +118,18 @@ suite('findings: assembly', () => {
 });
 
 suite('findings: message routing', () => {
-	test('openSource and refresh route through', async () => {
+	test('openSource, refresh and walk route through', async () => {
 		const log: string[] = [];
 		const a: FindingsActions = {
 			openSource: async (f, l) => void log.push(`open:${f}:${l}`),
 			refresh: async () => void log.push('refresh'),
+			walk: async () => void log.push('walk'),
 		};
 		await handleFindingsMessage({ type: 'openSource', file: 'x.py', line: 3 }, a);
 		await handleFindingsMessage({ type: 'refresh' }, a);
-		assert.deepStrictEqual(log, ['open:x.py:3', 'refresh']);
+		// The walkthrough is reached FROM the report now — Journey has no entry
+		// point of its own outside the command palette, so this is the path.
+		await handleFindingsMessage({ type: 'walk' }, a);
+		assert.deepStrictEqual(log, ['open:x.py:3', 'refresh', 'walk']);
 	});
 });

--- a/extension/src/test/fixtures/engine-artifacts/campaign_result.json
+++ b/extension/src/test/fixtures/engine-artifacts/campaign_result.json
@@ -8,7 +8,7 @@
     "fault oracle skipped 2 target(s): no annotated parameter to derive a contract from"
   ],
   "interpreter": {
-    "python": "<python>",
+    "python": "<venv>/bin/python",
     "origin": "vinv's own interpreter",
     "handed_off": false,
     "python_version": "3.13.14",
@@ -26,7 +26,7 @@
     ],
     "considered": [
       {
-        "python": "<python>",
+        "python": "<venv>/bin/python",
         "origin": "vinv's own interpreter",
         "detail": "fallback",
         "ok": true,
@@ -51,17 +51,17 @@
   "issues_merged": 1,
   "warm_started_arms": 4,
   "violations": 1,
-  "repeat_violations": 0,
+  "repeat_violations": 1,
   "credited_signatures": 1,
-  "new_ground": 3,
+  "new_ground": 2,
   "stopped": "budget-exhausted",
   "by_technique": {
     "contract-faults": {
-      "plays": 2,
+      "plays": 1,
       "violations": 0,
-      "coverage_sum": 2,
-      "cost_sum": 5.4969,
-      "posterior_mean": 0.375
+      "coverage_sum": 1,
+      "cost_sum": 1.0,
+      "posterior_mean": 0.4286
     },
     "deterministic": {
       "plays": 0,
@@ -71,20 +71,20 @@
       "posterior_mean": 0.4839
     },
     "schedule": {
-      "plays": 2,
+      "plays": 3,
       "violations": 1,
       "coverage_sum": 1,
-      "cost_sum": 8.0031,
-      "posterior_mean": 0.4
+      "cost_sum": 3.0,
+      "posterior_mean": 0.4815
     }
   },
   "by_oracle": {
     "concurrency": {
-      "plays": 2,
+      "plays": 3,
       "violations": 1,
       "coverage_sum": 1,
-      "cost_sum": 8.0031,
-      "posterior_mean": 0.4
+      "cost_sum": 3.0,
+      "posterior_mean": 0.4815
     },
     "crash": {
       "plays": 0,
@@ -94,11 +94,11 @@
       "posterior_mean": 0.4839
     },
     "fault": {
-      "plays": 2,
+      "plays": 1,
       "violations": 0,
-      "coverage_sum": 2,
-      "cost_sum": 5.4969,
-      "posterior_mean": 0.375
+      "coverage_sum": 1,
+      "cost_sum": 1.0,
+      "posterior_mean": 0.4286
     }
   },
   "preferred": {
@@ -106,5 +106,5 @@
     "technique": "deterministic",
     "oracle": "crash"
   },
-  "campaign_file": "<repo>\\.vinv\\exercise\\campaign.json"
+  "campaign_file": "<repo>/.vinv/exercise/campaign.json"
 }

--- a/extension/src/test/fixtures/engine-artifacts/functions.json
+++ b/extension/src/test/fixtures/engine-artifacts/functions.json
@@ -7,7 +7,7 @@
     "blocking": false
   },
   "interpreter": {
-    "python": "<python>",
+    "python": "<venv>/bin/python",
     "origin": "vinv's own interpreter",
     "handed_off": false,
     "python_version": "3.13.14",
@@ -25,7 +25,7 @@
     ],
     "considered": [
       {
-        "python": "<python>",
+        "python": "<venv>/bin/python",
         "origin": "vinv's own interpreter",
         "detail": "fallback",
         "ok": true,
@@ -47,7 +47,7 @@
     "pending": 0,
     "answered": 0,
     "overflow": 0,
-    "file": "<repo>\\.vinv\\exercise\\agent_config.json"
+    "file": "<repo>/.vinv/exercise/agent_config.json"
   },
   "blocked_imports_asked": [],
   "blocked_channel": {
@@ -56,7 +56,7 @@
     "pending": 0,
     "answered": 0,
     "overflow": 0,
-    "file": "<repo>\\.vinv\\exercise\\agent_blocked-import.json"
+    "file": "<repo>/.vinv/exercise/agent_blocked-import.json"
   },
   "diagnostics": [],
   "repo": "<repo>",
@@ -117,28 +117,38 @@
       "require_tier": null,
       "max_tier": null
     },
-    "tier": "process-shim",
+    "tier": "os-sandbox",
     "containment": {
-      "tier": "process-shim",
-      "mechanism": "python-shim",
-      "tool": null,
-      "blocks_writes_outside_root": false,
-      "blocks_network": false,
-      "effects_complete": false,
-      "detail": "generated sitecustomize patches the Python entry points; the durable guarantee is the disposable tree and the copied repo",
+      "tier": "os-sandbox",
+      "mechanism": "sandbox-exec",
+      "tool": "/usr/bin/sandbox-exec",
+      "blocks_writes_outside_root": true,
+      "blocks_network": true,
+      "effects_complete": true,
+      "detail": "probe passed",
       "checks": [
-        "shim-loaded-in-worker"
+        "profile-loads",
+        "write-inside-root-allowed",
+        "write-outside-root-denied",
+        "network-denied"
       ],
-      "fallback_reason": "no OS containment mechanism is known for platform 'win32'",
+      "fallback_reason": null,
       "guarantees": {
-        "writes_outside_root": "intercepted at the Python level (open/os.open/os.* family); a C extension calling open(2) is NOT stopped",
-        "network": "intercepted at the Python level (socket/ssl); a C extension calling connect(2) is NOT stopped",
-        "subprocess": "intercepted at the Python level (subprocess/os.exec*/os.spawn*)",
-        "effect_ledger": "INCOMPLETE wherever the static guard predicted C-level I/O \u2014 an empty effects map means 'we could not see', not 'nothing happened'"
+        "writes_outside_root": "IMPOSSIBLE \u2014 refused by the kernel, including from C extensions",
+        "network": "IMPOSSIBLE \u2014 refused by the kernel",
+        "subprocess": "intercepted by the Python shim; any child that escapes it inherits this OS sandbox",
+        "effect_ledger": "COMPLETE for the filesystem \u2014 a write either lands in the disposable tree (seen by the before/after walk) or is denied"
       },
-      "candidates": []
+      "candidates": [
+        {
+          "name": "sandbox-exec",
+          "tier": "os-sandbox",
+          "available": true,
+          "reason": "probe passed"
+        }
+      ]
     },
-    "effects_complete": false,
+    "effects_complete": true,
     "candidates": 0,
     "targets": 0,
     "modules": 0,
@@ -164,5 +174,5 @@
   },
   "issue_clusters": 0,
   "clusters": [],
-  "results_file": "<repo>\\.vinv\\exercise\\function_results.jsonl"
+  "results_file": "<repo>/.vinv/exercise/function_results.jsonl"
 }

--- a/extension/src/test/flowModel.test.ts
+++ b/extension/src/test/flowModel.test.ts
@@ -22,6 +22,7 @@ function facts(overrides: Partial<FlowFacts> = {}): FlowFacts {
 		probes: [],
 		pendingEdges: 0,
 		autoPilot: { running: false, label: '' },
+		configRequests: 0,
 		...overrides,
 	};
 }

--- a/extension/src/test/integrationPipeline.test.ts
+++ b/extension/src/test/integrationPipeline.test.ts
@@ -411,6 +411,7 @@ suite('end to end: what nothing could synthesise reaches a person', () => {
 				reran += 1;
 			},
 			showError: (message) => errors.push(message),
+			notify: () => undefined,
 		};
 		const outcome = await handlePanelMessage(
 			{ type: 'submit', values: { DEMO_REGION: 'eu-west-1', OPENAI_API_KEY: 'sk-typed' } },

--- a/extension/src/test/opportunityBoard.test.ts
+++ b/extension/src/test/opportunityBoard.test.ts
@@ -21,11 +21,18 @@ import {
 	opportunitySignature,
 	postOpportunities,
 	reconcileOpportunityBoard,
+	retireStructurallyInvalid,
 	renderOpportunityBoard,
 	rankedOpportunityCandidates,
 	syncOpportunityBoard,
 	type OpportunityInput,
 } from '../harness/opportunityBoard';
+import {
+	enqueueEpisodeRequest,
+	readRequestOutcomes,
+	recordRequestOutcome,
+	requestOutcomesPath,
+} from '../harness/requestQueue';
 import {
 	prepareOptimizationSweep,
 	prepareRowOptimization,
@@ -73,6 +80,81 @@ suite('opportunity board (lifecycle)', () => {
 		assert.strictEqual(a, b, 'measurements drift between traces — identity must not');
 		const c = opportunitySignature('fanout', 'a.py', 'f', '9 of 10 calls repeat; ~90ms cacheable');
 		assert.notStrictEqual(a, c, 'a different waste kind is a different opportunity');
+	});
+
+	test('a drained request records WHY it produced nothing', () => {
+		// The queue drains atomically, which is right for crash-safety and wrong
+		// for observability: before the outcome ledger, a request that dispatched
+		// nothing left no trace and its reason went only to a transient VS Code
+		// toast. Observed live: run_sweep hotspots reported "queued
+		// (episode-363c2c62-….json)", .vinv/requests/ was left empty, and
+		// .vinv/episodes.jsonl never gained a line — while noPlanMessage had
+		// computed a perfectly actionable reason and thrown it away.
+		const file = enqueueEpisodeRequest(root, { source: 'test', kind: 'hotspots' });
+		const id = path.basename(file).replace(/^episode-/, '').replace(/\.json$/, '');
+
+		// Nothing recorded yet: a queued request has no outcome until it is acted on.
+		assert.strictEqual(readRequestOutcomes(root).filter((r) => r.request_id === id).length, 0);
+
+		recordRequestOutcome(root, {
+			request_id: id,
+			kind: 'hotspots',
+			outcome: 'no_plan',
+			reason: 'all current opportunities are held on the board',
+		});
+		const rows = readRequestOutcomes(root).filter((r) => r.request_id === id);
+		assert.strictEqual(rows.length, 1);
+		assert.strictEqual(rows[0].outcome, 'no_plan');
+		assert.match(rows[0].reason, /held on the board/, 'the REASON survives, not just the fact');
+		assert.ok(rows[0].ts, 'timestamped so a caller can order it against its request');
+
+		// harness_busy is distinct from no_plan: the request was NOT consumed.
+		recordRequestOutcome(root, {
+			request_id: id, kind: 'hotspots', outcome: 'harness_busy',
+			reason: 'an episode was already running',
+		});
+		const all = readRequestOutcomes(root).filter((r) => r.request_id === id);
+		assert.deepStrictEqual(all.map((r) => r.outcome), ['no_plan', 'harness_busy'],
+			'append-only: outcomes accumulate in order, none overwrites another');
+
+		// A torn line must not hide the rest of the ledger.
+		fs.appendFileSync(requestOutcomesPath(root), '{not json\n');
+		assert.strictEqual(readRequestOutcomes(root).filter((r) => r.request_id === id).length, 2);
+	});
+
+	test('a posting a soundness gate now rejects stops being dispatchable at once', () => {
+		// The board is a PERSISTED ledger, so a gate that only filters new
+		// postings leaves the old one dispatchable. Live case: `main` and
+		// `_cmd_serve` sat at "~25101ms is cacheable" — memoize a server's CLI
+		// entry point — with misses 0 and status posted, still offered by
+		// run_sweep AFTER both the cache and per-call lifetime gates shipped.
+		// Expiry alone would have taken three capture sessions to clear them,
+		// because expiry means "the evidence moved", not "we were wrong to post".
+		postOpportunities(root, [
+			input({ row: 7, name: 'main', file: 'cli.py' }),
+			input({ row: 9, name: 'worker', file: 'work.py' }),
+		]);
+		assert.strictEqual(
+			loadOpportunityBoard(root).filter((e) => e.status === 'posted').length,
+			2,
+		);
+
+		const retired = retireStructurallyInvalid(root, new Set([7]), 'lifetime, not work');
+		assert.strictEqual(retired.length, 1, 'only the rejected row is retired');
+
+		const board = loadOpportunityBoard(root);
+		const main = board.find((e) => e.row === 7)!;
+		const worker = board.find((e) => e.row === 9)!;
+		assert.strictEqual(main.status, 'expired', 'no longer dispatchable');
+		assert.strictEqual(main.resolution, 'lifetime, not work', 'retired WITH a reason, not deleted');
+		assert.match(main.note ?? '', /soundness gate/);
+		assert.strictEqual(main.evidence, board.find((e) => e.row === 7)!.evidence, 'evidence preserved');
+		assert.strictEqual(worker.status, 'posted', 'an unaffected entry is untouched');
+
+		// Idempotent: a second pass has nothing left to retire.
+		assert.strictEqual(retireStructurallyInvalid(root, new Set([7]), 'x').length, 0);
+		// An empty invalid set is a no-op, not a sweep.
+		assert.strictEqual(retireStructurallyInvalid(root, new Set(), 'x').length, 0);
 	});
 
 	test('post → dedup: re-posting the same signature appends nothing', () => {

--- a/extension/src/test/optimizationAnalysis.test.ts
+++ b/extension/src/test/optimizationAnalysis.test.ts
@@ -99,6 +99,35 @@ suite('optimizationAnalysis: recoverable-time ranking', () => {
 		});
 	}
 
+	test('a lifetime frame is excluded from EVERY waste kind, not just cache', () => {
+		// Regression: gating collectCacheCandidates alone left per-call/fanout/
+		// staircase dispatchable, because those are derived here from `timings`.
+		// Live consequence on the embedder capture: _cmd_serve posted as
+		// "10738.8ms per call (self) — 148428.8× the typical symbol; unexpectedly
+		// slow for the work it does" — backwards for a serve loop that is meant to
+		// span the run. Row 1 has a measured cache candidate AND outlier timings,
+		// so it would qualify on more than one signal if the gate missed a kind.
+		const gated = computeOptimizationCandidates({
+			nodes: NODES,
+			edges: EDGES,
+			timings: baseTimings(),
+			cacheByRow: cacheFor(),
+			lifetimeRows: new Set([1]),
+		});
+		assert.ok(
+			!gated.some((c) => c.row === 1),
+			'a lifetime frame must not surface under any waste kind',
+		);
+		// The gate must be surgical: everything else still ranks as before.
+		assert.deepStrictEqual(
+			gated.map((c) => c.row),
+			candidates()
+				.map((c) => c.row)
+				.filter((r) => r !== 1),
+			'gating one row must not disturb the ranking of the others',
+		);
+	});
+
 	test('a hot-but-already-optimal symbol is excluded (hot ≠ optimizable)', () => {
 		assert.ok(
 			!candidates().some((c) => c.row === 3),

--- a/extension/src/test/rewardAndOpe.test.ts
+++ b/extension/src/test/rewardAndOpe.test.ts
@@ -1134,6 +1134,54 @@ suite('Episode walk: reward → ledger → policy update → OPE gate', () => {
 		assert.strictEqual(next.attempt_budget, 3);
 	});
 
+	test('preferred_arm respects min_promotion_n and promotion_delta', () => {
+		// These two knobs were declared, defaulted and range-validated in
+		// episodeTelemetry.ts but never READ by the updater, so promotion was a
+		// bare argmax over posterior means. With a Beta(1,1) prior ONE verified
+		// episode lifts an arm to 0.667 while every other arm sits at 0.5, so a
+		// single objective success promoted an arm. Observed live: a machine-global
+		// policy with episodes_seen 17, exactly one objective observation in the
+		// posteriors, and preferred_arm 4.
+		//
+		// preferred_arm is not merely reported — qna/answer.ts decodes bit 2 of it
+		// to choose Ask-Vinv's per-symbol snippet budget, so a thin promotion
+		// changes real behaviour. (Episode arm SELECTION is Thompson sampling with
+		// decaying epsilon and handles n=1 correctly on its own.)
+		const ep = (armIndex: number, verified: boolean) => ({
+			armIndex, propensity: 0.5, reward: verified ? 1 : 0,
+			attempts: 1, verified, objective: true,
+		});
+		const incumbent = POLICY_PRIORS.preferred_arm;
+
+		// n=1 is below min_promotion_n (5): the incumbent must hold.
+		assert.strictEqual(
+			computeUpdatedPolicy({ ...POLICY_PRIORS }, [ep(4, true)]).preferred_arm,
+			incumbent,
+			'one objective success must not promote an arm',
+		);
+
+		// Enough evidence AND a real margin: promote.
+		assert.strictEqual(
+			computeUpdatedPolicy(
+				{ ...POLICY_PRIORS },
+				[ep(4, true), ep(4, true), ep(4, true), ep(4, true), ep(4, true)],
+			).preferred_arm,
+			4,
+			'min_promotion_n met with margin must promote',
+		);
+
+		// Enough evidence but the challenger only matches the prior mean — no
+		// promotion_delta margin, so the incumbent holds.
+		assert.strictEqual(
+			computeUpdatedPolicy(
+				{ ...POLICY_PRIORS },
+				[ep(5, true), ep(5, false), ep(5, true), ep(5, false), ep(5, true), ep(5, false)],
+			).preferred_arm,
+			incumbent,
+			'a coin-flip arm must not displace the incumbent',
+		);
+	});
+
 	test('the OPE gate blocks a WORSE candidate policy outright', () => {
 		// Candidate action 10 is strictly worse than baseline 5 — supported,
 		// consistent, but its DR delta is negative, so the BCa LCB is < 0.

--- a/extension/src/views/configRequestPanel.ts
+++ b/extension/src/views/configRequestPanel.ts
@@ -167,6 +167,14 @@ export interface ConfigPanelActions {
 	/** Re-run the pipeline so the answers take effect. */
 	rerun: () => Promise<void>;
 	showError: (message: string) => void;
+	/**
+	 * Confirm what landed and where.
+	 *
+	 * Saving disposes the panel, so without this the entire visible response to
+	 * pasting a credential is the tab vanishing. Say what was written and that a
+	 * re-run started, or the user has no way to tell a save from a crash.
+	 */
+	notify: (message: string) => void;
 }
 
 /**
@@ -195,6 +203,12 @@ export async function handlePanelMessage(
 		);
 		return { saved: 0, reran: false };
 	}
+	// Names the file so a user who pasted a credential can go verify where it
+	// went — and its permissions — without taking our word for it.
+	actions.notify(
+		`Saved ${saved} value${saved === 1 ? '' : 's'} to .vinv/exercise/config_answers.json ` +
+			'(owner-only) — re-running.',
+	);
 	// Re-running is the whole point — an answer that sits on disk until someone
 	// remembers to press play is the same stall in a different place.
 	await actions.rerun();
@@ -255,6 +269,7 @@ export function getConfigPanelHtml(cspSource: string, model: ConfigPanelModel): 
 			</div>`;
 
 	return `<!DOCTYPE html><html><head>
+<meta charset="UTF-8">
 <meta http-equiv="Content-Security-Policy"
       content="default-src 'none'; style-src ${cspSource} 'unsafe-inline'; script-src 'nonce-${nonce}';">
 <style>
@@ -281,8 +296,8 @@ input:focus { outline: 2px solid var(--accent-fg); outline-offset: -2px; }
            border-left: 2px solid var(--line); padding-left: 8px; margin: 6px 0 0; }
 .actions { margin-top: 16px; }
 button.primary { font-family: ${VINV_FONT_MONO}; font-size: 12.5px; padding: 8px 16px;
-                 background: var(--accent); color: #ffffff; border: none; cursor: pointer; }
-button.primary:hover { background: var(--accent-hover); }
+                 background: var(--ok); color: #ffffff; border: none; cursor: pointer; }
+button.primary:hover { background: var(--ok-hover); }
 .empty { color: var(--muted); font-size: 13px; }
 </style></head><body>
 <h1>Vinv needs a few values</h1>

--- a/extension/src/views/findingsModel.ts
+++ b/extension/src/views/findingsModel.ts
@@ -55,6 +55,15 @@ export interface Findings {
 		stateCreated: number;
 		stateCleaned: number;
 	};
+	/**
+	 * The services bring-up verified, from .vinv/services.json.
+	 *
+	 * Carried here because this view is the one landing surface: services were
+	 * previously visible ONLY in the Journey tab, which had no entry point
+	 * outside the command palette, so "what did Vinv actually bring up" was
+	 * effectively unreachable.
+	 */
+	services: Array<{ name: string; kind: string; port: number | null; command: string }>;
 	issues: Array<{ kind: string; title: string; signature: string }>;
 	episodes: FindingsEpisode[];
 	opportunities: Array<{ kind: string; endpoint: string; detail: string; value: number }>;
@@ -130,6 +139,15 @@ export function buildFindings(workspaceRoot: string): Findings {
 	const episodesRaw = readJsonl(path.join(ex, 'optimize.jsonl'));
 	const regressRaw = readJsonl(path.join(ex, 'regress.jsonl'));
 	const ledger = readJsonl(path.join(ex, 'state_ledger.jsonl'));
+	const servicesDoc = readJson(path.join(workspaceRoot, '.vinv', 'services.json')) ?? {};
+	const services = (Array.isArray(servicesDoc.services) ? servicesDoc.services : []).map(
+		(s: any) => ({
+			name: String(s.name ?? ''),
+			kind: String(s.kind ?? ''),
+			port: typeof s.port === 'number' ? s.port : null,
+			command: String(s.command ?? ''),
+		}),
+	);
 
 	const episodes: FindingsEpisode[] = episodesRaw.slice(-MAX_EPISODES).map((e: any) => ({
 		at: Number(e.at ?? 0),
@@ -202,6 +220,7 @@ export function buildFindings(workspaceRoot: string): Findings {
 			stateCreated: Number(pollution.created ?? 0),
 			stateCleaned: Number(pollution.cleaned ?? 0),
 		},
+		services,
 		issues: (issuesDoc.clusters ?? []).map((c: any) => ({
 			kind: String(c.kind ?? ''),
 			title: String(c.title ?? ''),

--- a/extension/src/views/findingsView.ts
+++ b/extension/src/views/findingsView.ts
@@ -16,12 +16,13 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { VINV_BASE_CSS, VINV_FONT_SERIF } from './webviewTheme';
 import { buildFindings, writeFindingsSummary } from './findingsModel';
+import { openJourney } from './journeyView';
 import { openPathInEditor } from '../support/openDocument';
 
 export const FINDINGS_VIEW_TYPE = 'vinv.findings';
 
 export interface FindingsOutbound {
-	type: 'openSource' | 'refresh';
+	type: 'openSource' | 'refresh' | 'walk';
 	file?: string;
 	line?: number;
 }
@@ -29,6 +30,8 @@ export interface FindingsOutbound {
 export interface FindingsActions {
 	openSource: (file: string | undefined, line?: number) => Promise<void>;
 	refresh: () => Promise<void>;
+	/** Open the per-endpoint walkthrough (call tree, flamegraph, exact I/O). */
+	walk: () => Promise<void>;
 }
 
 export async function handleFindingsMessage(
@@ -39,6 +42,8 @@ export async function handleFindingsMessage(
 		await actions.openSource(msg.file, msg.line);
 	} else if (msg.type === 'refresh') {
 		await actions.refresh();
+	} else if (msg.type === 'walk') {
+		await actions.walk();
 	}
 }
 
@@ -116,6 +121,11 @@ function wireFindings(workspaceRoot: string, webview: vscode.Webview): vscode.Di
 			});
 		},
 		refresh: push,
+		// The deep walkthrough stays its own surface — a flamegraph and an
+		// input-authoring form do not belong inline in a scrolling report — but it
+		// is now reached FROM here rather than being a sibling tab with no entry
+		// point of its own.
+		walk: () => openJourney(workspaceRoot),
 	};
 
 	const sub = webview.onDidReceiveMessage((msg: FindingsOutbound | { type: 'webviewError' }) => {
@@ -171,7 +181,14 @@ function getHtml(): string {
 		td { padding: 4px 10px 4px 0; border-bottom: 1px solid var(--line); vertical-align: top; }
 		.badge { font-size: 9px; padding: 1px 6px; letter-spacing: 0.16em; text-transform: uppercase;
 			border: 1px solid currentColor; color: var(--muted-2); white-space: nowrap; }
-		.badge.accept { background: var(--ink); border-color: var(--ink); color: var(--bg); }
+		.walk-cta { color: var(--muted); font-size: 11px; margin-bottom: 10px;
+			display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+		.walk-cta button { font-family: inherit; font-size: 9px; font-weight: 500;
+			letter-spacing: 0.18em; text-transform: uppercase; padding: 5px 12px;
+			cursor: pointer; border-radius: 0;
+			background: transparent; border: 1px solid var(--line-strong); color: var(--ink); }
+		.walk-cta button:hover { border-color: var(--ink); }
+		.badge.accept { background: var(--ok); border-color: var(--ok); color: #ffffff; }
 		.badge.revert { color: var(--accent-fg); }
 		.badge.env { color: var(--muted); }
 		.epi { border: 1px solid var(--line-strong); padding: 10px 12px; margin-bottom: 10px; }
@@ -181,7 +198,7 @@ function getHtml(): string {
 		.epi .files { color: var(--muted-2); font-size: 10.5px; margin-top: 4px; }
 		.att { display: flex; align-items: center; gap: 10px; margin-top: 8px; }
 		.att .ap { flex: 1; min-width: 0; overflow-wrap: anywhere; font-size: 11px; }
-		.att .suite { flex: none; font-size: 10px; }
+		.att .suite { flex: none; font-size: 10px; color: var(--ok-fg); }
 		.att .suite.fail { color: var(--accent-fg); }
 		.att .cin { flex: none; font-size: 10px; color: var(--muted); white-space: nowrap; }
 		/* CI bar: signed axis, zero tick in the middle-ish; interval drawn as a
@@ -190,7 +207,7 @@ function getHtml(): string {
 			background: var(--bg-2); border: 1px solid var(--line-strong); }
 		.ci .zero { position: absolute; top: 0; bottom: 0; width: 1px; background: var(--line-strong); }
 		.ci .band { position: absolute; top: 2px; bottom: 2px; }
-		.ci .band.good { background: var(--ink); }
+		.ci .band.good { background: var(--ok); }
 		.ci .band.bad { background: var(--accent); }
 		.ci .pt { position: absolute; top: 0; bottom: 0; width: 2px; background: var(--accent-fg); }
 		.bar { position: relative; height: 8px; background: var(--bg-2);
@@ -264,6 +281,19 @@ function getHtml(): string {
 		tiles(f);
 		let html = '';
 
+		// Services lead, because "what did Vinv bring up" is the first question and
+		// the answer used to live only in the Journey tab, which had no entry point.
+		if (f.services && f.services.length) {
+			html += '<h2>Services</h2>';
+			html += '<table><tr><th>Service</th><th>Kind</th><th>Port</th><th>Starts with</th></tr>';
+			for (const s of f.services) {
+				html += '<tr><td>' + esc(s.name) + '</td><td>' + esc(s.kind) + '</td>' +
+					'<td>' + (s.port == null ? '—' : esc(String(s.port))) + '</td>' +
+					'<td><code>' + esc(s.command) + '</code></td></tr>';
+			}
+			html += '</table>';
+		}
+
 		html += '<h2>Issue clusters (' + f.issues.length + ')</h2>';
 		html += f.issues.length === 0 ? '<div class="empty">No failures found in anything that was exercised.</div>' : '';
 		for (const i of f.issues) {
@@ -334,6 +364,13 @@ function getHtml(): string {
 		}
 
 		html += '<h2>Latency profile per endpoint</h2>';
+		// A bare table header over zero rows reads as broken rather than empty, so
+		// the whole table is skipped and the section says why it is empty.
+		if (f.endpoints.length === 0) {
+			html += '<div class="empty">No endpoint has been exercised yet, so there is no latency to profile.</div>';
+		} else {
+		html += '<div class="walk-cta">Need the call tree, flamegraph and the exact inputs and outputs for one of these? ' +
+			'<button id="walk" type="button">Walk them one by one</button></div>';
 		const maxP95 = Math.max(1, ...f.endpoints.map((e) => e.p95Ms));
 		html += '<table><tr><th>Endpoint</th>' +
 			'<th title="Functions this endpoint can reach that a captured request actually executed (ran / reachable)">Coverage</th>' +
@@ -349,6 +386,7 @@ function getHtml(): string {
 				'<td>' + esc(Object.entries(e.statuses).map(([k, v]) => k + '×' + v).join(' ')) + '</td></tr>';
 		}
 		html += '</table>';
+		}
 
 		html += '<h2>Data the tests created (' + f.state.cleaned + '/' + f.state.created + ' cleaned up)</h2>';
 		if (f.state.rows.length === 0) {
@@ -372,6 +410,9 @@ function getHtml(): string {
 
 		html += '<div class="hint">Machine-readable copy of everything above: .vinv/reports/findings.json (this tab\\'s backing file).</div>';
 		document.getElementById('content').innerHTML = html;
+		// Wired after the mount because the section is rebuilt on every push.
+		const walk = document.getElementById('walk');
+		if (walk) { walk.addEventListener('click', () => vscode.postMessage({ type: 'walk' })); }
 	}
 
 	window.addEventListener('message', (event) => {

--- a/extension/src/views/flowModel.ts
+++ b/extension/src/views/flowModel.ts
@@ -100,6 +100,14 @@ export interface FlowFacts {
 	};
 	/** The onboarding compass's answer (computed by nextStep.ts). */
 	nextStep?: { label: string; detail: string; command: string; args?: unknown[] };
+	/**
+	 * Values the exerciser gave up on and is asking a human for
+	 * (.vinv/exercise/config_requests.json). Non-zero means a run is blocked on
+	 * a person, so the rail has to say so — the panel that collects them opens
+	 * only as a side effect of an exercise pass, and a closed tab was previously
+	 * unrecoverable without re-running the whole pipeline.
+	 */
+	configRequests: number;
 }
 
 // ---- outputs ---------------------------------------------------------------
@@ -161,6 +169,15 @@ export interface FlowModel {
 	/** The single next human action; absent while Auto-Pilot drives. */
 	nextAction?: FlowNextAction;
 	autoPilot: { running: boolean; label: string };
+	/**
+	 * Everything that is not a pipeline stage, in one always-present footer.
+	 *
+	 * The rail is the only surface a user never has to go looking for, so it —
+	 * not a nav bar repeated inside every panel — is where the other destinations
+	 * live. Before this, Journey and the configuration panel had no entry point
+	 * at all outside the command palette.
+	 */
+	destinations: FlowLink[];
 }
 
 // ---- computation -----------------------------------------------------------
@@ -301,7 +318,10 @@ function servicesStage(f: FlowFacts): FlowStage {
 		summary = `${failed.length} service${failed.length === 1 ? '' : 's'} could not be set up`;
 	} else if (real.length > 0 && set.length === real.length) {
 		status = 'done';
-		summary = `All ${real.length} service${real.length === 1 ? '' : 's'} know how to start`;
+		summary =
+			real.length === 1
+				? 'This service knows how to start'
+				: `All ${real.length} services know how to start`;
 	} else if (real.length === 0) {
 		status = f.services.length > 0 ? 'done' : 'waiting';
 		summary =
@@ -504,7 +524,14 @@ function verifyStage(f: FlowFacts): FlowStage {
 	} else if (f.probes.length > 0) {
 		const passed = f.probes.filter((p) => p.passed).length;
 		status = passed === f.probes.length && f.issues.length === 0 ? 'done' : 'error';
+		// Probes and runtime issues are different evidence: every probe can pass
+		// while a traced run still threw. Reporting only the probe tally then put
+		// a red "needs attention" directly above "2/2 checks passing" and never
+		// named the reason, so the summary carries both.
 		summary = `${passed}/${f.probes.length} checks passing`;
+		if (passed === f.probes.length && f.issues.length > 0) {
+			summary += ` · ${f.issues.length} problem${f.issues.length === 1 ? '' : 's'} in live runs`;
+		}
 		for (const p of f.probes) {
 			links.push({
 				label: p.label,
@@ -530,6 +557,47 @@ function verifyStage(f: FlowFacts): FlowStage {
 		summary,
 		links: capLinks(links, 8),
 	};
+}
+
+/**
+ * The footer's destinations, in the order a person needs them: the thing
+ * blocking a run first, then read-what-happened, then explore, then ask.
+ */
+function destinationsFor(f: FlowFacts): FlowLink[] {
+	const links: FlowLink[] = [];
+	if (f.configRequests > 0) {
+		links.push({
+			label: `Vinv needs ${f.configRequests} value${f.configRequests === 1 ? '' : 's'}`,
+			detail: 'a run is blocked until these are filled in',
+			command: 'vinv-vs.openConfigRequests',
+			state: 'error',
+		});
+	}
+	links.push(
+		{
+			// One landing surface: services, issues, episodes, regression replay and
+			// the endpoint profile, with the per-endpoint walkthrough reached from
+			// inside it. Listing Journey as a sibling here asked the user to choose
+			// between two tabs whose names do not tell them apart.
+			label: 'Report',
+			detail: 'services, findings, evidence — and the walk through what ran',
+			command: 'vinv-vs.openFindings',
+			state: 'ok',
+		},
+		{
+			label: 'Code map',
+			detail: 'every function, and what never ran',
+			command: 'vinv-vs.openGraphExplorer',
+			state: 'ok',
+		},
+		{
+			label: 'Ask Vinv',
+			detail: 'a question answered from the traces',
+			command: 'vinv-vs.askVinv',
+			state: 'ok',
+		},
+	);
+	return links;
 }
 
 /** Computes the whole rail from observable facts. Pure. */
@@ -577,7 +645,7 @@ export function computeFlowModel(f: FlowFacts): FlowModel {
 		};
 	}
 
-	return { stages, issues, nextAction, autoPilot: f.autoPilot };
+	return { stages, issues, nextAction, autoPilot: f.autoPilot, destinations: destinationsFor(f) };
 }
 
 /**

--- a/extension/src/views/flowPanel.ts
+++ b/extension/src/views/flowPanel.ts
@@ -225,11 +225,13 @@ function getFlowHtml(cspSource: string): string {
 			border-radius: 50%; box-sizing: border-box;
 			border: 1.5px solid var(--muted-2); background: var(--bg);
 		}
-		.stage.done .dot { border-color: var(--ink); background: var(--ink); }
+		.stage.done .dot { border-color: var(--ok-fg); background: var(--ok-fg); }
 		.stage.error .dot { border-color: var(--accent-fg); background: var(--accent-fg); }
 		.stage.running .dot {
+			--dot-ring: var(--accent-ring);
+			--dot-ring-soft: var(--accent-ring-soft);
 			border-color: var(--accent-fg); background: var(--accent-fg);
-			box-shadow: 0 0 0 4px rgba(215, 25, 33, 0.18);
+			box-shadow: 0 0 0 4px var(--dot-ring);
 			animation: v-pulse 2.4s ease-in-out infinite;
 		}
 		.stage h2 {
@@ -243,7 +245,7 @@ function getFlowHtml(cspSource: string): string {
 			color: var(--muted-2);
 		}
 		.stage.error h2 .st, .stage.running h2 .st { color: var(--accent-fg); }
-		.stage.done h2 .st { color: var(--muted); }
+		.stage.done h2 .st { color: var(--ok-fg); }
 		.summary { color: var(--muted); margin: 3px 0 0; line-height: 1.5; }
 		.stage.error .summary { color: var(--accent-fg); }
 		.activity { color: var(--accent-fg); margin: 3px 0 0; line-height: 1.5; }
@@ -271,11 +273,13 @@ function getFlowHtml(cspSource: string): string {
 			flex: none; width: 6px; height: 6px; border-radius: 50%;
 			align-self: center; background: var(--muted-2);
 		}
-		.lnk.s-ok .b { background: var(--ink); }
+		.lnk.s-ok .b { background: var(--ok-fg); }
 		.lnk.s-error .b { background: var(--accent-fg); }
 		.lnk.s-running .b {
+			--dot-ring: var(--accent-ring);
+			--dot-ring-soft: var(--accent-ring-soft);
 			background: var(--accent-fg);
-			box-shadow: 0 0 0 3px rgba(215, 25, 33, 0.18);
+			box-shadow: 0 0 0 3px var(--dot-ring);
 			animation: v-pulse 2.4s ease-in-out infinite;
 		}
 		.lnk .lab { color: var(--ink); }
@@ -309,6 +313,13 @@ function getFlowHtml(cspSource: string): string {
 		.issue .ev:hover { border-color: var(--ink); }
 		.issue .sent { align-self: center; font-size: 11px; letter-spacing: 0.04em; color: var(--muted); border: 1px dashed var(--line-strong); padding: 3px 8px; }
 
+		/* ---- destinations footer ---- */
+		.dests { margin-top: 16px; padding-top: 12px; border-top: 1px solid var(--line); }
+		.dests .k {
+			font-size: 9px; letter-spacing: 0.22em; text-transform: uppercase;
+			color: var(--muted-2); margin-bottom: 5px;
+		}
+
 		.empty { color: var(--muted); line-height: 1.6; padding: 4px 0; }
 		.brand {
 			display: flex; align-items: center; gap: 8px; margin: 0 0 12px;
@@ -331,6 +342,10 @@ function getFlowHtml(cspSource: string): string {
 	<div class="issues" id="issues">
 		<div class="hd" id="issues-hd">Problems found</div>
 		<div id="issues-list"></div>
+	</div>
+	<div class="dests" id="dests">
+		<div class="k">Open</div>
+		<div id="dests-list"></div>
 	</div>
 
 	<script nonce="${nonce}">
@@ -457,6 +472,12 @@ function getFlowHtml(cspSource: string): string {
 				item.appendChild(acts);
 				list.appendChild(item);
 			}
+
+			// Destinations. Reuses renderLink so a footer row behaves exactly like
+			// a stage row — same hover, same dot, same message back.
+			const dests = document.getElementById('dests-list');
+			dests.textContent = '';
+			for (const d of model.destinations || []) { dests.appendChild(renderLink(d)); }
 		}
 
 		document.getElementById('next-btn').addEventListener('click', () => {

--- a/extension/src/views/flowStateSource.ts
+++ b/extension/src/views/flowStateSource.ts
@@ -55,6 +55,7 @@ import {
 import { readAdjudicated, readPendingEdges } from '../graph/graphEnhancer';
 import { getHandbookPath, isHandbookGenerated } from '../handbook/handbook';
 import { computeNextStep } from './nextStep';
+import { readConfigRequests } from './configRequestPanel';
 import {
 	computeFlowModel,
 	flowStateJson,
@@ -252,6 +253,7 @@ export class FlowStateSource implements vscode.Disposable {
 			probes: [],
 			pendingEdges: 0,
 			autoPilot: { running: false, label: '' },
+			configRequests: 0,
 		};
 	}
 
@@ -299,6 +301,7 @@ export class FlowStateSource implements vscode.Disposable {
 		facts.reports = scanReports(root);
 		facts.autoPilot = getAutoPilotStatus();
 		facts.pipelinePhase = getPipelinePhase();
+		facts.configRequests = readConfigRequests(root).length;
 		try {
 			const storeDir = indexStoreDir(root);
 			const done = readAdjudicated(storeDir);

--- a/extension/src/views/graphExplorerHtml.ts
+++ b/extension/src/views/graphExplorerHtml.ts
@@ -351,6 +351,13 @@ export function getGraphHtml(): string {
 		bakeLayout(prev, filePos);
 		if (selected && !byId.has(selected)) { select(null); }
 		if (selected) { neighborIds = adjacency.get(selected) || new Set(); }
+		// Every status line counts dnodes, and this is the ONE place dnodes
+		// changes — legend toggle, expand, collapse. Refreshing per call site
+		// missed all three: showing the hidden-by-default tests/docs layers
+		// grows the set from 336 to 577, so Dead Code kept reporting "332 of 336"
+		// while the truth on screen was "573 of 577", and expanding a file left
+		// the file-node count sitting over a canvas of symbol nodes.
+		setStatus(modeStatus());
 	}
 
 	// ---- diff impact: changed symbols + inbound invoke closure, per file ----
@@ -1093,7 +1100,12 @@ export function getGraphHtml(): string {
 	function rtLabel(rt) {
 		if (!rt) { return ''; }
 		let t = '×' + rt.calls + ' · ' + Math.round(rt.ms ?? rt.total_ms ?? 0) + 'ms';
-		if (rt.errors > 0) { t += ' · ⚠' + rt.errors; }
+		// current_errors is the DEFECT count (contained raises and 4xx rejections
+		// already removed); errors is the raw lifetime tally. The warning triangle
+		// is a defect signal, so it has to read the former — keying it off the raw
+		// count put a ⚠ on every symbol that ever raised inside a try/except.
+		const defects = rt.current_errors ?? rt.errors;
+		if (defects > 0) { t += ' · ⚠' + defects; }
 		return t;
 	}
 
@@ -1181,13 +1193,30 @@ export function getGraphHtml(): string {
 			html += '<h2>' + esc(n.file) + '</h2>';
 			html += '<div class="sub">' + g.symbols + ' symbols · rank ' + g.rank.toFixed(3) +
 				(g.changed ? ' · <span style="color:var(--accent-fg)">changed this epoch</span>' : '') + '</div>';
+			// A raise a caller caught leaves current_errors at 0 with a lifetime
+			// error still on the books, which lands it in "resolved" — where it
+			// would be labelled "not reproduced in latest run" about an exception
+			// that reproduces on EVERY run and is deliberately handled. It is
+			// neither a defect nor a fix, so it gets its own line and its own
+			// (neutral) color rather than borrowing either verdict.
+			const containedOf = (r) => (r.failures || [])[0];
+			const isContained = (r) => (r.errors || 0) > 0 && containedOf(r)?.contained === true;
 			if (n.rt) {
 				// Live error badge reflects the latest run; lifetime history is
-				// noted separately so a fixed file is not flagged red.
+				// noted separately so a fixed file is not flagged red. A file whose
+				// only lifetime errors were CAUGHT gets neither badge: "none in
+				// latest run" would be false (it raised, and was handled) and the
+				// success color would credit a fix that never happened. The
+				// per-symbol "handled:" line below says what actually happened.
 				const liveErr = n.rt.current_errors ?? n.rt.errors;
+				const historyIsAllHandled = g.rows.every(
+					(row) => !((snapshot.runtime[row] || {}).errors > 0) || isContained(snapshot.runtime[row] || {}),
+				);
 				const errBadge = liveErr
 					? ' · <span style="color:var(--accent-fg)">⚠' + liveErr + ' errors (latest run)</span>'
-					: (n.rt.errors ? ' · <span style="color:' + cssVar('--muted') + '">' + n.rt.errors + ' errors in history, none in latest run</span>' : '');
+					: (n.rt.errors && !historyIsAllHandled
+							? ' · <span style="color:' + cssVar('--ok-fg') + '">' + n.rt.errors + ' errors in history, none in latest run</span>'
+							: '');
 				html += '<div class="sub">runtime: ' + n.rt.executed + ' symbols executed · ×' + n.rt.calls +
 					' · ' + Math.round(n.rt.ms) + 'ms' + errBadge + '</div>';
 			}
@@ -1198,10 +1227,12 @@ export function getGraphHtml(): string {
 				const r = snapshot.runtime[row] || {};
 				return (r.current_errors ?? r.errors) > 0;
 			});
-			const resolvedRows = g.rows.filter((row) => {
+			const settledRows = g.rows.filter((row) => {
 				const r = snapshot.runtime[row] || {};
 				return (r.current_errors ?? r.errors) === 0 && (r.errors || 0) > 0;
 			});
+			const handledRows = settledRows.filter((row) => isContained(snapshot.runtime[row] || {}));
+			const resolvedRows = settledRows.filter((row) => !isContained(snapshot.runtime[row] || {}));
 			if (errRows.length) {
 				html += '<div class="sub" style="color:var(--accent-fg)">failing: ' +
 					errRows.map((row) => {
@@ -1215,8 +1246,17 @@ export function getGraphHtml(): string {
 						return esc(s.name) + ' (' + esc(detail) + ')';
 					}).join(' · ') + '</div>';
 			}
+			if (handledRows.length) {
+				html += '<div class="sub">handled: ' +
+					handledRows.map((row) => {
+						const s = snapshot.nodes[row];
+						const f = containedOf(snapshot.runtime[row]);
+						const by = f.contained_by ? 'caught by ' + f.contained_by : 'caught by a caller';
+						return esc(s.name) + ' (' + esc(f.error_type) + ' — ' + esc(by) + ')';
+					}).join(' · ') + '</div>';
+			}
 			if (resolvedRows.length) {
-				html += '<div class="sub">resolved: ' +
+				html += '<div class="sub" style="color:' + cssVar('--ok-fg') + '">resolved: ' +
 					resolvedRows.map((row) => {
 						const s = snapshot.nodes[row];
 						const rt = snapshot.runtime[row];
@@ -1242,7 +1282,7 @@ export function getGraphHtml(): string {
 				const isNew = snapshot.store_epoch > 0 && s.epoch === snapshot.store_epoch;
 				html += '<div class="sym" data-act="open" data-file="' + esc(s.file) + '" data-line="' + s.start_line + '" title="jump to ' + esc(s.file) + ':' + s.start_line + '">' +
 					'<span class="nm">' + esc(s.name) + (isNew ? ' <span style="color:var(--accent-fg)">●</span>' : '') + '</span>' +
-					'<span class="rt' + (rt && rt.errors > 0 ? ' err' : '') + '">' + (rt ? rtLabel(rt) : '') + '</span></div>';
+					'<span class="rt' + (rt && (rt.current_errors ?? rt.errors) > 0 ? ' err' : '') + '">' + (rt ? rtLabel(rt) : '') + '</span></div>';
 			}
 			html += '</div></div>';
 			// Diff context: say WHAT changed here this epoch, not just that it did.
@@ -1269,6 +1309,14 @@ export function getGraphHtml(): string {
 			if (rt) {
 				html += '<div class="sub">runtime: ' + rtLabel(rt) +
 					(rt.error_types && rt.error_types.length ? ' [' + esc(rt.error_types.join(', ')) + ']' : '') + '</div>';
+				// Without this, a symbol that raises by design shows a bare error
+				// type and nothing to say a caller absorbed it — the reader is left
+				// to assume a defect the rest of the panel has already dismissed.
+				const cf = (rt.failures || [])[0];
+				if (cf && cf.contained === true) {
+					html += '<div class="sub">' + esc(cf.error_type) + ' is caught by ' +
+						esc(cf.contained_by || 'a caller') + ' — control flow, not a failure</div>';
+				}
 			} else {
 				html += '<div class="sub">runtime: never executed in captured traces</div>';
 			}
@@ -1397,6 +1445,10 @@ export function getGraphHtml(): string {
 			return;
 		}
 		tourIndex = Math.max(0, Math.min(tour.length - 1, tourIndex));
+		// The index clamps, so Prev at step 1 and Next at the last step were live
+		// buttons that did nothing — a click with no feedback reads as broken.
+		document.getElementById('t-prev').disabled = tourIndex === 0;
+		document.getElementById('t-next').disabled = tourIndex === tour.length - 1;
 		const stop = tour[tourIndex];
 		const s = snapshot.nodes[stop.row];
 		document.getElementById('t-name').textContent = s.name + ' — ' + s.file + ':' + s.start_line;

--- a/extension/src/views/journeyView.ts
+++ b/extension/src/views/journeyView.ts
@@ -231,7 +231,7 @@ function getHtml(): string {
 		td { padding: 4px 10px 4px 0; border-bottom: 1px solid var(--line);
 			vertical-align: top; font-family: inherit; }
 		td.io-json { max-width: 340px; overflow-wrap: anywhere; color: var(--muted); }
-		.st-2xx { color: var(--ink); } .st-4xx { color: var(--muted); } .st-5xx { color: var(--accent-fg); }
+		.st-2xx { color: var(--ok-fg); } .st-4xx { color: var(--muted); } .st-5xx { color: var(--accent-fg); }
 		ul.tree { list-style: none; margin: 0; padding: 0; }
 		ul.tree ul { list-style: none; margin: 0 0 0 8px; padding-left: 18px;
 			border-left: 1px dashed var(--line-strong); }

--- a/extension/src/views/optimizationSource.ts
+++ b/extension/src/views/optimizationSource.ts
@@ -36,6 +36,7 @@ import {
 	collectMemoryTrends,
 	collectRequestSpans,
 	collectSymbolTimings,
+	lifetimeFrames,
 	type SymbolSessionTiming,
 } from '../harness/runtimeAnalysis';
 import {
@@ -465,6 +466,9 @@ export class OptimizationSource implements vscode.Disposable {
 			spans,
 			calibration,
 			memoryLeaks,
+			// The panel and the board must never rank the same evidence
+			// differently, so the lifetime gate is applied identically here.
+			lifetimeRows: new Set(lifetimeFrames(root, nodes).keys()),
 		});
 	}
 

--- a/extension/src/views/webviewTheme.ts
+++ b/extension/src/views/webviewTheme.ts
@@ -31,6 +31,17 @@ export const VINV_BASE_CSS = `
 	 *   --accent-hover hover FILL — the same hue with lightness shifted per
 	 *               theme so white text stays ≥ 4.5:1 (darker in light,
 	 *               brighter in dark; #ff5a5f-style tints fail at 3.05:1)
+	 *
+	 * SUCCESS GREEN (--ok*) mirrors that contract exactly, so red can go back to
+	 * meaning failure and nothing else. Measured against the same references:
+	 *   --ok        fill  #15803d, white text 5.02:1 (red fill is 5.18:1)
+	 *   --ok-fg     text  #15803d on white 5.02:1 · #3fb950 on black 8.27:1
+	 *   --ok-hover  fill  #116a32 light 6.71:1 · #17853c dark 4.71:1
+	 * Hue 142 keeps it clear of the graph's layer palette — the data layer's sea
+	 * green sits at 162 and the scripts teal at 187 — so a success state never
+	 * reads as a layer. The dark hover brightens far less than red's does: green's
+	 * luminance climbs much faster per lightness step, and anything past #17853c
+	 * drops white text under 4.5:1.
 	 */
 	body {
 		--bg: #ffffff;
@@ -43,6 +54,13 @@ export const VINV_BASE_CSS = `
 		--accent-fg: #d71921;
 		--accent-hover: #b3151c;
 		--accent-soft: #ff5a5f;
+		--accent-ring: rgba(215, 25, 33, 0.18);
+		--accent-ring-soft: rgba(215, 25, 33, 0.05);
+		--ok: #15803d;
+		--ok-fg: #15803d;
+		--ok-hover: #116a32;
+		--ok-ring: rgba(21, 128, 61, 0.18);
+		--ok-ring-soft: rgba(21, 128, 61, 0.05);
 		--line: rgba(10, 10, 10, 0.14);
 		--line-strong: rgba(10, 10, 10, 0.32);
 		--grid: rgba(10, 10, 10, 0.05);
@@ -61,6 +79,13 @@ export const VINV_BASE_CSS = `
 		--accent-fg: #ff4048;
 		--accent-hover: #e2262f;
 		--accent-soft: #ff5a5f;
+		--accent-ring: rgba(255, 64, 72, 0.20);
+		--accent-ring-soft: rgba(255, 64, 72, 0.06);
+		--ok: #15803d;
+		--ok-fg: #3fb950;
+		--ok-hover: #17853c;
+		--ok-ring: rgba(63, 185, 80, 0.20);
+		--ok-ring-soft: rgba(63, 185, 80, 0.06);
 		--line: rgba(255, 255, 255, 0.14);
 		--line-strong: rgba(255, 255, 255, 0.32);
 		--grid: rgba(255, 255, 255, 0.05);
@@ -144,6 +169,10 @@ export const VINV_BASE_CSS = `
 	.v-btn:hover { border-color: var(--ink); letter-spacing: 0.26em; }
 	.v-btn.primary { background: var(--ink); border-color: var(--ink); color: var(--bg); }
 	.v-btn.primary:hover { background: var(--accent); border-color: var(--accent); color: #ffffff; }
+	/* Confirming action (save, accept, apply). Red fill is reserved for the
+	   destructive/failing one, so a form's submit button lives here. */
+	.v-btn.ok { background: var(--ok); border-color: var(--ok); color: #ffffff; }
+	.v-btn.ok:hover { background: var(--ok-hover); border-color: var(--ok-hover); color: #ffffff; }
 	.v-btn:disabled { opacity: 0.5; cursor: default; letter-spacing: 0.22em; }
 
 	/* tiny bordered badge */
@@ -156,21 +185,35 @@ export const VINV_BASE_CSS = `
 		color: var(--muted);
 		border-radius: 0;
 	}
+	.v-badge.ok { color: var(--ok-fg); }
+	.v-badge.bad { color: var(--accent-fg); }
 
-	/* pulsing live dot */
+	/* pulsing live dot. The ring colors come from variables so the .ok variant
+	   reuses one keyframe rather than duplicating the animation per hue. */
 	.v-dot {
+		--dot-ring: var(--accent-ring);
+		--dot-ring-soft: var(--accent-ring-soft);
 		display: inline-block;
 		width: 7px;
 		height: 7px;
 		border-radius: 50%;
 		background: var(--accent-fg);
-		box-shadow: 0 0 0 4px rgba(215, 25, 33, 0.18);
+		box-shadow: 0 0 0 4px var(--dot-ring);
 		animation: v-pulse 2.4s ease-in-out infinite;
 	}
-	@keyframes v-pulse {
-		0%, 100% { box-shadow: 0 0 0 4px rgba(215, 25, 33, 0.18); }
-		50% { box-shadow: 0 0 0 7px rgba(215, 25, 33, 0.05); }
+	.v-dot.ok {
+		--dot-ring: var(--ok-ring);
+		--dot-ring-soft: var(--ok-ring-soft);
+		background: var(--ok-fg);
 	}
+	@keyframes v-pulse {
+		0%, 100% { box-shadow: 0 0 0 4px var(--dot-ring); }
+		50% { box-shadow: 0 0 0 7px var(--dot-ring-soft); }
+	}
+
+	/* Success/failure text. Paired so a view never has to reach for a raw hex. */
+	.v-ok { color: var(--ok-fg); }
+	.v-bad { color: var(--accent-fg); }
 
 	::selection { background: var(--accent); color: #ffffff; }
 `;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,17 @@
 # identically to the members so root and per-package linting agree.
 [dependency-groups]
 dev = [
+    # The OTel contrib instrumentors tracelens wraps a service with. These were
+    # previously present in the venv ONLY because bring-up's prompt had an agent
+    # pip-install them (dist-info: INSTALLER=uv, REQUESTED=yes, and three of
+    # them absent from uv.lock entirely). `uv sync` is exact and prunes
+    # extraneous packages, so any unrelated sync silently deleted the whole
+    # contrib set and tracing quietly degraded to parent-process spans with no
+    # error — observed live. tracelens declared the set as its `otel-libs`
+    # extra but nothing ever installed it, so the declaration was dead.
+    # Depending on the extra here makes coverage a reconciled, locked fact
+    # instead of a side effect of whoever wrote to the venv last.
+    "tracelens[otel-libs]",
     "pytest>=8.0.0,<10.0.0",
     "pytest-cov>=5.0.0,<6.0.0",
     "hypothesis>=6.100.0,<7.0.0",
@@ -23,6 +34,19 @@ dev = [
     # skip without it, and a skipped honesty guarantee is no guarantee — this
     # keeps them RUNNING under the root `uv sync` that CI performs.
     "sqlalchemy>=2.0,<3.0",
+    # Same reason, for the exerciser's `hypothesis_valid` generator arm
+    # (exerciser[propertygen]): `hypothesis_valid_available()` gates a real
+    # generator arm, its tests branch on that probe, and with the package
+    # absent they passed while covering nothing. Installing it at the root
+    # makes the adopted arm actually run under the `uv sync` CI performs.
+    "hypothesis-jsonschema>=0.23.0,<0.24.0",
+    # core's DSPy agent runtime is an OPTIONAL extra (see core/pyproject.toml):
+    # nothing in this repo drives it, and keeping dspy/litellm out of the base
+    # install is what stops `pip install vinv-core` silently resolving BerriAI
+    # litellm in place of the in-tree shim. But three of core's test files DO
+    # exercise the dspy path, so the extra is installed here — a capability the
+    # tests cover must be present under the root `uv sync` CI performs.
+    "vinv-core[agents]",
 ]
 
 # Python version policy (see issue #14). Ceiling is <3.15 for every member.
@@ -30,6 +54,14 @@ dev = [
 # own floor: embedder >=3.10 (standalone embedding sidecar — widest reach),
 # contracts and tracelens >=3.11 (the data contract and the tracer, which run
 # against third-party targets), and every other engine >=3.12.
+[tool.uv.sources]
+# The root dev group depends on `tracelens[otel-libs]` (see above), so the
+# workspace member has to be named as a source rather than resolved from PyPI —
+# where the `tracelens` name belongs to an unrelated third-party project.
+tracelens = { workspace = true }
+# Same reason: the root dev group depends on `vinv-core[agents]`.
+vinv-core = { workspace = true }
+
 [tool.uv.workspace]
 members = [
     "contracts",

--- a/scripts/check-declared-deps.py
+++ b/scripts/check-declared-deps.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Fail when code imports a third-party package no manifest declares.
+
+WHY THIS EXISTS. Four separate instances of one defect shape were found in this
+repo, each independently and each after the code had been reviewed and shipped:
+
+  1. tracelens's `otel-libs` extra — declared, installed by NOTHING. The OTel
+     contrib instrumentors were only ever in the venv because bring-up had an
+     LLM agent pip-install them, so an unrelated `uv sync` pruned all nine and
+     tracing silently degraded to parent-process spans with no error.
+  2. exerciser's `hypothesis-jsonschema` — `generators.py` calls it "Adopted",
+     `plan.py` consumes the arm it gates, and it was declared in no manifest at
+     all. `hypothesis_valid_available()` returned False in every install that
+     has ever shipped, and the tests branched on that probe so they passed while
+     covering nothing.
+  3. `jsdom` — imported by scripts/e2e-graph-webview.mjs and
+     scripts/e2e-unlinked-node.mjs, declared nowhere, so both headless webview
+     e2e tests fail at import on any clean checkout.
+  4. `core`'s `litellm` — declared, but redirected to an in-tree shim by
+     `[tool.uv.sources]`, which is uv-only and absent from wheel metadata, so
+     `pip install vinv-core` silently resolved a DIFFERENT package.
+
+The shape is always: real code, a real consumer, an absent or
+installer-specific declaration. Nothing failed loudly, which is why all four
+survived. The check is mechanical, so it belongs in CI rather than in a
+reviewer's head.
+
+WHAT IT DOES. Collects every third-party top-level import across the Python
+engines and the repo's own scripts, resolves each against the union of every
+manifest's declared dependencies (all groups and extras) plus stdlib and
+first-party names, and reports the ones nothing declares.
+
+Soft imports count. A `try: import x / except ImportError:` capability probe is
+exactly case 2 — the probe makes absence silent, which is precisely why the
+declaration must exist and be checkable. An intentionally-optional package must
+be declared in an extra (that is what an extra is FOR); if it is genuinely not
+wanted, add it to KNOWN_ABSENT below with a reason.
+
+Exit 0 clean, 1 with findings. `--json` for machine output.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import sys
+import sysconfig
+import tomllib
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Python sources to scan: every engine's src/ plus the repo's own scripts.
+PY_ROOTS = (
+    "contracts",
+    "core",
+    "tracelens",
+    "identification",
+    "handbook",
+    "bringup",
+    "goal",
+    "embedder",
+    "exerciser",
+)
+
+SKIP_DIR_PARTS = {
+    ".venv",
+    "venv",
+    "node_modules",
+    "__pycache__",
+    ".git",
+    "build",
+    "dist",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    "site-packages",
+    # Vendored code ships its own manifest and is not this repo's declaration.
+    "vendor",
+    "vendored",
+    "third_party",
+    # Fixtures are deliberately synthetic mini-projects.
+    "fixtures",
+}
+
+# import name -> distribution name, where they differ. Only entries that
+# actually appear in this repo; a partial map is fine because an unmapped name
+# is compared against the manifests directly.
+IMPORT_TO_DIST = {
+    "yaml": "PyYAML",
+    "sklearn": "scikit-learn",
+    "dateutil": "python-dateutil",
+    "attr": "attrs",
+    "pkg_resources": "setuptools",
+    "dotenv": "python-dotenv",
+    "hypothesis_jsonschema": "hypothesis-jsonschema",
+    "dspy": "dspy-ai",
+    "PIL": "pillow",
+    "cv2": "opencv-python",
+    "OpenSSL": "pyOpenSSL",
+    "google": "protobuf",
+    "importlib_metadata": "importlib-metadata",
+    "sentence_transformers": "sentence-transformers",
+    "websocket": "websocket-client",
+    "huggingface_hub": "huggingface-hub",
+    "opentelemetry": "opentelemetry-api",
+    "jwt": "PyJWT",
+    "zoneinfo": "backports.zoneinfo",
+}
+
+# Packages deliberately NOT declared, each with the reason. Anything added here
+# is a decision on the record, which is the point.
+KNOWN_ABSENT: dict[str, str] = {
+    # tracelens is imported by the AST-injected trace hook inside a FOREIGN
+    # service's venv; it is this repo's own package, resolved by path there.
+    "tracelens": "first-party; injected into target venvs by path, never resolved from an index",
+}
+
+
+def norm(name: str) -> str:
+    """PEP 503 normalization, so `PyYAML`/`pyyaml`/`Py_YAML` compare equal."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def stdlib_names() -> set[str]:
+    names = set(sys.stdlib_module_names)
+    # Vendored-in-stdlib and platform bits that are not on stdlib_module_names
+    # for every version.
+    names |= {"__future__", "typing_extensions_stub"}
+    paths = {sysconfig.get_paths().get("stdlib", "")}
+    return {n for n in names if n} | {p for p in paths if False}
+
+
+def first_party_names() -> set[str]:
+    """Top-level packages this repo itself provides."""
+    out: set[str] = set()
+    for member in PY_ROOTS:
+        src = REPO / member / "src"
+        if not src.is_dir():
+            continue
+        for child in src.iterdir():
+            if child.is_dir() and (child / "__init__.py").exists():
+                out.add(child.name)
+            elif child.suffix == ".py":
+                out.add(child.stem)
+    return out
+
+
+def declared_distributions() -> set[str]:
+    """Every distribution named by ANY manifest — deps, groups, extras.
+
+    Deliberately a union rather than per-member: this check answers "does the
+    repo declare it at all", which is the question all four live cases failed.
+    Per-member correctness is a separate, stricter check.
+    """
+    out: set[str] = set()
+
+    def add_reqs(reqs) -> None:
+        if not isinstance(reqs, list):
+            return
+        for r in reqs:
+            if isinstance(r, str):
+                # "pkg[extra]>=1,<2 ; marker" -> "pkg"
+                out.add(norm(re.split(r"[<>=!~;\[ ]", r.strip(), maxsplit=1)[0]))
+
+    for manifest in [REPO / "pyproject.toml"] + [
+        REPO / m / "pyproject.toml" for m in PY_ROOTS
+    ]:
+        if not manifest.is_file():
+            continue
+        data = tomllib.loads(manifest.read_text(encoding="utf-8"))
+        proj = data.get("project", {}) or {}
+        add_reqs(proj.get("dependencies"))
+        for reqs in (proj.get("optional-dependencies") or {}).values():
+            add_reqs(reqs)
+        for reqs in (data.get("dependency-groups") or {}).values():
+            add_reqs(reqs)
+        add_reqs(((data.get("build-system") or {}).get("requires")))
+        tool_uv = (data.get("tool") or {}).get("uv") or {}
+        add_reqs(tool_uv.get("constraint-dependencies"))
+        add_reqs(tool_uv.get("override-dependencies"))
+    return out
+
+
+def py_files() -> list[Path]:
+    out: list[Path] = []
+    roots = [REPO / m / "src" for m in PY_ROOTS] + [REPO / "scripts"]
+    for root in roots:
+        if not root.is_dir():
+            continue
+        for f in root.rglob("*.py"):
+            if SKIP_DIR_PARTS & set(f.parts):
+                continue
+            out.append(f)
+    return out
+
+
+def imports_of(path: Path) -> set[str]:
+    """Top-level module names imported by `path` (absolute imports only)."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"))
+    except (OSError, SyntaxError):
+        return set()
+    out: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for a in node.names:
+                out.add(a.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom):
+            if node.level == 0 and node.module:  # skip relative imports
+                out.add(node.module.split(".")[0])
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--json", action="store_true", help="machine-readable output")
+    args = ap.parse_args()
+
+    declared = declared_distributions()
+    stdlib = stdlib_names()
+    first_party = first_party_names()
+    known_absent = {norm(k) for k in KNOWN_ABSENT}
+
+    findings: dict[str, set[str]] = {}
+    for f in py_files():
+        for imp in imports_of(f):
+            if imp in stdlib or imp in first_party or imp.startswith("_"):
+                continue
+            dist = norm(IMPORT_TO_DIST.get(imp, imp))
+            if dist in declared or dist in known_absent:
+                continue
+            findings.setdefault(f"{imp} (dist: {dist})", set()).add(
+                str(f.relative_to(REPO))
+            )
+
+    if args.json:
+        print(json.dumps({k: sorted(v) for k, v in sorted(findings.items())}, indent=2))
+    elif not findings:
+        print(
+            f"OK — every third-party import across {len(py_files())} Python files "
+            f"resolves to one of {len(declared)} declared distributions."
+        )
+    else:
+        print("UNDECLARED third-party imports (real code, absent declaration):\n")
+        for name, files in sorted(findings.items()):
+            print(f"  {name}")
+            for f in sorted(files)[:6]:
+                print(f"      {f}")
+            if len(files) > 6:
+                print(f"      … and {len(files) - 6} more")
+        print(
+            "\nFix by DECLARING it — in the member's dependencies if required, or in an "
+            "extra if genuinely optional (an extra is what makes an optional capability "
+            "installable AND checkable). If it is intentionally absent, add it to "
+            "KNOWN_ABSENT in this script with the reason, so the decision is on the record."
+        )
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tracelens/pyproject.toml
+++ b/tracelens/pyproject.toml
@@ -28,6 +28,18 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# The contrib instrumenters `load_contrib_instrumenters` activates. Every entry
+# is version-ranged with the others so the set stays on ONE core/contrib release
+# pair — mixing them makes the instrumenters crash at import with
+# `ImportError: _StabilityMode` / `HTTP_DURATION_HISTOGRAM_BUCKETS*` and the
+# JSONL exporter silently emits zero spans.
+#
+# This extra must stay in sync with `_CONTRIB_MAP` in launcher/otel_setup.py:
+# anything mapped there but missing here shows up as `instrumenter_missing` in
+# `probe_contrib_instrumenters()` and costs a whole capability silently — the
+# run still succeeds and trace.jsonl still fills, but every OUTBOUND call loses
+# its child span, so its latency is charged to the caller as unexplained
+# self-time and fan-out/N+1 detection sees N sequential calls as one slow call.
 otel-libs = [
     "opentelemetry-instrumentation-fastapi>=0.48b0,<0.50.0",
     "opentelemetry-instrumentation-requests>=0.48b0,<0.50.0",
@@ -36,6 +48,13 @@ otel-libs = [
     "opentelemetry-instrumentation-redis>=0.48b0,<0.50.0",
     "opentelemetry-instrumentation-psycopg2>=0.48b0,<0.50.0",
     "opentelemetry-instrumentation-asyncio>=0.48b0,<0.50.0",
+    # urllib3 and logging were reaching the venv ONLY via bring-up's agent-run
+    # `bootstrap -a install`, so they were absent from the lock and any `uv sync`
+    # pruned them. Both libraries are present in virtually every Python service
+    # (requests rides on urllib3; logging is stdlib), and `probe_contrib_instrumenters`
+    # reported both as `instrumenter_missing` once the un-declared copies were pruned.
+    "opentelemetry-instrumentation-urllib3>=0.48b0,<0.50.0",
+    "opentelemetry-instrumentation-logging>=0.48b0,<0.50.0",
 ]
 rca = [
     "dowhy>=0.11.0,<0.13.0",

--- a/uv.lock
+++ b/uv.lock
@@ -18,10 +18,13 @@ members = [
 [manifest.dependency-groups]
 dev = [
     { name = "hypothesis", specifier = ">=6.100.0,<7.0.0" },
+    { name = "hypothesis-jsonschema", specifier = ">=0.23.0,<0.24.0" },
     { name = "pytest", specifier = ">=8.0.0,<10.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0,<6.0.0" },
     { name = "ruff", specifier = ">=0.6.0,<0.9.0" },
     { name = "sqlalchemy", specifier = ">=2.0,<3.0" },
+    { name = "tracelens", extras = ["otel-libs"], editable = "tracelens" },
+    { name = "vinv-core", extras = ["agents"], editable = "core" },
 ]
 
 [[package]]
@@ -812,16 +815,22 @@ dev = [
     { name = "ruff" },
     { name = "sqlalchemy" },
 ]
+propertygen = [
+    { name = "hypothesis" },
+    { name = "hypothesis-jsonschema" },
+]
 
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.1.0,<9.0.0" },
+    { name = "hypothesis", marker = "extra == 'propertygen'", specifier = ">=6.100.0,<7.0.0" },
+    { name = "hypothesis-jsonschema", marker = "extra == 'propertygen'", specifier = ">=0.23.0,<0.24.0" },
     { name = "identification", editable = "identification" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0,<10.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.0,<0.9.0" },
     { name = "sqlalchemy", marker = "extra == 'dev'", specifier = ">=2.0,<3.0" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["propertygen", "dev"]
 
 [[package]]
 name = "faker"
@@ -1267,6 +1276,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b6/15/16239bfc9aad85aa0a0166f61b8aa4eddc69ee57b0c68188f191f4ef0b00/hypothesis-6.160.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d04e56812e135c3223cd06cd0016f61466ce7c56720167046d91123534240f5", size = 1261184, upload-time = "2026-07-22T14:10:43.241Z" },
     { url = "https://files.pythonhosted.org/packages/7d/b8/aa6f06d42d1505b2dab0f82d133d84853391437f34a15c4c39cbcda04f6a/hypothesis-6.160.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c18c5eb6260bda6e56689429723d5b62b62cedee88c95de03976799645c9b0ce", size = 1305573, upload-time = "2026-07-22T14:10:51.193Z" },
     { url = "https://files.pythonhosted.org/packages/44/13/645f8c95070a21fa1257f0d4cf68b938d7ec60e8371d79402ce7cb50d3c9/hypothesis-6.160.0-cp314-cp314t-win_amd64.whl", hash = "sha256:deabcb5645076988ac52237a7c3ee8fca2fbd4f859461537374911fbe0e99817", size = 655308, upload-time = "2026-07-22T14:10:38.969Z" },
+]
+
+[[package]]
+name = "hypothesis-jsonschema"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hypothesis" },
+    { name = "jsonschema" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4f/ad/2073dd29d8463a92c243d0c298370e50e0d4082bc67f156dc613634d0ec4/hypothesis-jsonschema-0.23.1.tar.gz", hash = "sha256:f4ac032024342a4149a10253984f5a5736b82b3fe2afb0888f3834a31153f215", size = 42896, upload-time = "2024-02-28T20:33:50.209Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/44/635a8d2add845c9a2d99a93a379df77f7e70829f0a1d7d5a6998b61f9d01/hypothesis_jsonschema-0.23.1-py3-none-any.whl", hash = "sha256:a4d74d9516dd2784fbbae82e009f62486c9104ac6f4e3397091d98a1d5ee94a2", size = 29200, upload-time = "2024-02-28T20:33:48.744Z" },
 ]
 
 [[package]]
@@ -2293,7 +2315,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.47.0"
+version = "1.109.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2305,9 +2327,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/61/9aeef14de759306e85175126d3d6d56ee4f5072a9512c6c171d58d02a62d/openai-2.47.0.tar.gz", hash = "sha256:4e205548acd4304f235b86202269912e55bc88270b15d2a051fa2b53b90343a6", size = 1089906, upload-time = "2026-07-22T17:47:29.723Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/a1/a303104dc55fc546a3f6914c842d3da471c64eec92043aef8f652eb6c524/openai-1.109.1.tar.gz", hash = "sha256:d173ed8dbca665892a6db099b4a2dfac624f94d20a93f46eb0b56aae940ed869", size = 564133, upload-time = "2025-09-24T13:00:53.075Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/69/26b032059273ad798d18fbcdbe369e871181841fd8bcb5caee32b7510039/openai-2.47.0-py3-none-any.whl", hash = "sha256:b3a1a7ad974092427ccb46d89f8852bdb67866680bcabeecc3ff5a3fdd71b15b", size = 1639987, upload-time = "2026-07-22T17:47:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/2a/7dd3d207ec669cacc1f186fd856a0f61dbc255d24f6fdc1a6715d6051b0f/openai-1.109.1-py3-none-any.whl", hash = "sha256:6bcaf57086cf59159b8e27447e4e7dd019db5d29a438072fbd49c290c7e65315", size = 948627, upload-time = "2025-09-24T13:00:50.754Z" },
 ]
 
 [[package]]
@@ -2465,6 +2487,19 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-instrumentation-logging"
+version = "0.49b2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/5f/142d5f7b73774bc0baa801d97011b6f9bde5bb202e88ed2b9394581898e3/opentelemetry_instrumentation_logging-0.49b2.tar.gz", hash = "sha256:625c825cb180d1a4da8008af2dc21de5f668af120f3821af16317cd3a2378d7e", size = 9718, upload-time = "2024-11-18T18:40:09.734Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/49/8f1d6ae082c657438bb9c162f27b1cf32c0e7057d36c200a4875706d5cd8/opentelemetry_instrumentation_logging-0.49b2-py3-none-any.whl", hash = "sha256:5ef73c37b34d8f564d37731cb399e7237636e2c8d7d97061d20526f6ece8afb1", size = 12133, upload-time = "2024-11-18T18:39:05.449Z" },
+]
+
+[[package]]
 name = "opentelemetry-instrumentation-psycopg2"
 version = "0.49b2"
 source = { registry = "https://pypi.org/simple" }
@@ -2522,6 +2557,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/62/df/351da8fff041d7277d497b1682763ce43fe61624ed458f21e4f3d449a82c/opentelemetry_instrumentation_sqlalchemy-0.49b2.tar.gz", hash = "sha256:e32f5d37e1fa6efd6b375c67f87d1e4789fe9745cccf692b679de9cccd9910e4", size = 13230, upload-time = "2024-11-18T18:40:22.465Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/72/80/11d8e6c35d4615d367771c91fefe85e9debcd0e2b2004012557743139099/opentelemetry_instrumentation_sqlalchemy-0.49b2-py3-none-any.whl", hash = "sha256:2769e3c8e4e0663c63823361ec7d6393e5c0a8289faec7f477a8e604b043d866", size = 13366, upload-time = "2024-11-18T18:39:21.008Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-urllib3"
+version = "0.49b2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/43/7b8e65657dfe3c0f38ddb46e940b21991feeebb7b1011c71c71dd71b3da9/opentelemetry_instrumentation_urllib3-0.49b2.tar.gz", hash = "sha256:28f47fe8044f321c6f5cadce4a6c3d4fdb9b86b610aac28ea8eb9820017cdfa3", size = 15418, upload-time = "2024-11-18T18:40:28.889Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/4a/b5da277d73eb1054fa6a7c258dc71f534a2ce941918e9c4d84cc95654984/opentelemetry_instrumentation_urllib3-0.49b2-py3-none-any.whl", hash = "sha256:8039a859fb5c4e2bcb5ddd11137033b3249f09ee6de5e882c0c7a93138b23a88", size = 12828, upload-time = "2024-11-18T18:39:34.144Z" },
 ]
 
 [[package]]
@@ -3774,6 +3825,53 @@ wheels = [
 ]
 
 [[package]]
+name = "tiktoken"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "regex" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/e5/5f3cb2159769d0f4324c0e9e87f9de3c4b1cd45848a96b2eb3566ad5ca77/tiktoken-0.13.0.tar.gz", hash = "sha256:c9435714c3a84c2319499de9a300c0e604449dd0799ff246458b3bb6a7f433c1", size = 38986, upload-time = "2026-05-15T04:51:27.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/8e/144bde4e01df66b34bb865557c7cd754ed08b036217ebd79c9db5e9048a9/tiktoken-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:32ac870a806cfb260a02d0cb70426aef02e038297f8ad50df5040bb5af360791", size = 1034888, upload-time = "2026-05-15T04:50:31.579Z" },
+    { url = "https://files.pythonhosted.org/packages/36/18/d4ac9d20956cdebca04841316660ed584c2fecdc2b81722a28bc7ad3b1e4/tiktoken-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4d9980f11429ed2d737c463bb1fb78cf330caa026adf002f714aced7849a687b", size = 982970, upload-time = "2026-05-15T04:50:32.961Z" },
+    { url = "https://files.pythonhosted.org/packages/74/ed/6bb8d05b9f731f749fee5c6f5ca63e981143c826a5985877330507bd13b7/tiktoken-0.13.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:3f277ebea5edd7b8bf03c6f9431e1d67d517530115572b2dc1d465326e8f88c7", size = 1115741, upload-time = "2026-05-15T04:50:34.475Z" },
+    { url = "https://files.pythonhosted.org/packages/34/de/2ca96b07a82d972b74fe4b46de055b79c904e45c7eab699354a0bfa697dc/tiktoken-0.13.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:a116178fa7e1b4065bff05214360373a65cac22f965be7b3f73d00a0dbfe7649", size = 1136523, upload-time = "2026-05-15T04:50:35.782Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/dc/9dafec002c2d4424378563cf4cf5c7fb93631d2a55013c8b87554ee4012c/tiktoken-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2c397ddda233208345b01bd30f2fca79ff730e55731d0108a603f9bc57f6af3b", size = 1181954, upload-time = "2026-05-15T04:50:36.99Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/d0/1f8578c45b2f24759b46f0b50d31878c63c73e6bf0f2227e10ec5c5408dc/tiktoken-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:95097e4f89b06403976e498abf61a0ee73a7497e73fb599cb211d8197a054d91", size = 1240069, upload-time = "2026-05-15T04:50:38.221Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/90/28d7f154888610aa9237e541986beb62b479df29d193a5a0617dbb1514d0/tiktoken-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:8f2d16e7a7c783ad81f36e457d046d1f1c8af70b22aec8a13238efe531977c41", size = 874748, upload-time = "2026-05-15T04:50:39.587Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/83/b096c859c2a47c11731bf2f5885f4028b809dfe2396582883eed9cae372f/tiktoken-0.13.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5df5d1507bd245f1ccad4a074698240021239e455eb0bb4ced4e3d7181872154", size = 1034228, upload-time = "2026-05-15T04:50:40.988Z" },
+    { url = "https://files.pythonhosted.org/packages/53/61/c68e123b6d753e3fc2751e9b18e732c9d8bf1e1926762e736eee935d931c/tiktoken-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8fe806a50664e83a6ffd56cbd1e4f5dcc6cd32a3e7538f70dc38b1a271384545", size = 982978, upload-time = "2026-05-15T04:50:42.195Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/8b/96cc178cc584e65d363134500f297790b06cd48cdeb1e8fcf7bbe60f4715/tiktoken-0.13.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:125bc05005e747f993a83dc67934249932d6e4209854452cd4c0b1d53fba3ba2", size = 1116355, upload-time = "2026-05-15T04:50:43.564Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f5/bab735d2c72ea55404b295d02d092644eb5f7cc6205e34d35eb9abfb9ab2/tiktoken-0.13.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5e6358911cab4adee6712da27d65573496a4f68cf8a2b5fca6a4ad10fc5748cf", size = 1135772, upload-time = "2026-05-15T04:50:44.782Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b9/6de04ebdf904edfaad87788011b3735087a0c9ea671b9027e1e4e965e8c8/tiktoken-0.13.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:975cbd78d085d75d26b59660e262736dcaed1e35f8f142cd6291025c01d25486", size = 1182415, upload-time = "2026-05-15T04:50:46.422Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/9c/470a05f3b1caf038f44880e334d47ab674e0c80d514c66b375d14d5afa10/tiktoken-0.13.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:75ab9bc99fa020a4c283424590ecd7f3afd70c1c281cb3fa3192a6c3af9f9615", size = 1239879, upload-time = "2026-05-15T04:50:48.052Z" },
+    { url = "https://files.pythonhosted.org/packages/42/a6/c1936d16055436cb32e6c6128d68629622e00f4768562f55653752d34768/tiktoken-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:6b1615f0ff71953d19729ceb18865429c185b0a23c5353f1bbca34a394bf60f7", size = 874829, upload-time = "2026-05-15T04:50:49.202Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/07/acb5992c3772b5a36284f742cfb7a5895aa4471d1848ac31464ad50d7fdf/tiktoken-0.13.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:6eb4a5bfbc6426938026b1a334e898ac53541360d62d8c689870160cc80abd67", size = 1033600, upload-time = "2026-05-15T04:50:50.4Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e9/742e9aec30f59b9f161f7ff7cd072e02ea836c9e1c0854a8076dfcd40d5c/tiktoken-0.13.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:43cee3e5400573b2046fbf092cc7a5bc30164f9e4c95ce20714da929df48737a", size = 982516, upload-time = "2026-05-15T04:50:52.03Z" },
+    { url = "https://files.pythonhosted.org/packages/72/74/ca1541b053e7648254d2e4b42a253e1bb4359f2c91a0a8d49228c794e1a0/tiktoken-0.13.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:7de52e3f566d19b3b11bd37eea552c6c305ad74081f736882bd44d148ed4c48d", size = 1115518, upload-time = "2026-05-15T04:50:53.543Z" },
+    { url = "https://files.pythonhosted.org/packages/46/e3/93825eaf5a4a504795b787e5d5dea07fbeb3dabf97aa7b450be8bde59c89/tiktoken-0.13.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:51384448aa508e4df84c0f7c1dc3211c7f7b8096325660ee5fc82f3e11b381ce", size = 1136867, upload-time = "2026-05-15T04:50:55.191Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/46/002b68de6827091d5ae90b048f326e8aad8d953520950e5ce1508879414f/tiktoken-0.13.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e28157350f7ebf35008dd8e9e0fdb621f976e4230c881099c85e8cf07eaa50e2", size = 1181826, upload-time = "2026-05-15T04:50:56.296Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c6/d393e3185a276505182f7abd93fe714f3c444a2be9180798fa052347504e/tiktoken-0.13.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:165cf1820ea4a354985c2490a5205d4cc74661c934aca79dd0368232fff94e0f", size = 1239489, upload-time = "2026-05-15T04:50:57.918Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/4d/bc07d1f1635d4897a202acc0ae11c2886eaa7325c359ba4741b47bf8e225/tiktoken-0.13.0-cp313-cp313t-win_amd64.whl", hash = "sha256:6c43a675ca14f6f2749ba7f12075d37456015a24b859f2517b9beb4ef30807ec", size = 873820, upload-time = "2026-05-15T04:50:59.528Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/93/0dd6adca026a616c3a92974566b43381eea4b475ce1f36c062b8271a9ac5/tiktoken-0.13.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaaaef47c2406277181d2086484c317bf7fc433e2d5d03ff94f56b0dcec87471", size = 1034977, upload-time = "2026-05-15T04:51:00.957Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/77/5ec6e6bc5b30bed6d93f7f2162d8f6b32437b3ba27cb527cfe004f6109c9/tiktoken-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ca8b310bd93b3772cb1b7922d915446864860f562bdfe4825c63a0aed3fb28cd", size = 983635, upload-time = "2026-05-15T04:51:02.629Z" },
+    { url = "https://files.pythonhosted.org/packages/94/b0/c8ae9aff00d625c50659b4513e707a0462c4bf5d4d6cc1b802103225c02e/tiktoken-0.13.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:32e0c12305105002c047b3bb1070b0dd9a73b0cb3b2856a8972b810e7a4f5881", size = 1116036, upload-time = "2026-05-15T04:51:04.082Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ac/6a5dddd1d0a6018ecb389bd0353e6b4a515eb4d2286611bd0ace1937b9e1/tiktoken-0.13.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:5ba5fd62507a932d1241346179e3b39bc7bf7408f03c272652d93b3bedf5db24", size = 1135544, upload-time = "2026-05-15T04:51:05.229Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/b8/585032b4384b2f7dcdaddcb52865c83a701a420d09e3c2b4a2be1c450c57/tiktoken-0.13.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d108bc2d470fc53c8ecd24f2c0fd2b5f98c33e87cdb6aa2e9b8c5dced703d273", size = 1182217, upload-time = "2026-05-15T04:51:06.517Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/b6/993ff1ded3958215fd341a847b8e5ffeb5de473f435296870d314fc91ac4/tiktoken-0.13.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cb99cb5127449f58d0a2d5f5ccfb390d8dbdfd919c221246caaee29d8725ed51", size = 1239404, upload-time = "2026-05-15T04:51:07.843Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3d/fef7e06e3b33e7538db0ced734cf9fe23b6832d2ac4990c119c377aec55e/tiktoken-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:115c4f26ffa11caac8b54eea35c2ad38c612c20a48d35dd15d70a02ac6f51f58", size = 918686, upload-time = "2026-05-15T04:51:08.925Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/82/a7fc44582bc32ab00de988a2299bf77c077f59068b233109e34b7d6ca7e6/tiktoken-0.13.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:472527e9132952f2fbf77cd290658bacf003d4d5a3fabc18e5fbd407cbae4d9b", size = 1034454, upload-time = "2026-05-15T04:51:10.035Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d0/24d8a890c14f432a05cea669c17bebeaa99f96a7c79523b590f564246411/tiktoken-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:4e2f67d27c9626cdd25fe33d9313c5cdb3d8d82da646b68d6eb8e7e9c20e6448", size = 982976, upload-time = "2026-05-15T04:51:11.23Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b7/2ab43f62788a9266187a9bfc1d3af99ad83e5eaa25fbef168a69cd5ad14f/tiktoken-0.13.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:2b920b35805cd64585a37c3dc7ce65fba4d2d36016be01e1d7942482ca29093a", size = 1115526, upload-time = "2026-05-15T04:51:12.608Z" },
+    { url = "https://files.pythonhosted.org/packages/64/39/1494321ed323ce7a14d88e3cd6cb9058625977df1c6961ddc492bd10a9f3/tiktoken-0.13.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:493af3aa28a4aaf2e3d2600a2ee717252c9bf5ab38fff94eb5a02db5ab77e5ad", size = 1136466, upload-time = "2026-05-15T04:51:13.926Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d9/dfd086aa2d918c563a140720e0ce296cada1634efd2783d5cf51e05f984e/tiktoken-0.13.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6644c9c2b5cf3916f5a3641d7d12fdb3f006a7b3d9ff6acdaec44e29ab1ff91e", size = 1181863, upload-time = "2026-05-15T04:51:15.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/68/a18b4f307086954fdae32714cb4f85562e34f9d34ab206e61f1816aa6018/tiktoken-0.13.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5cb65b60b9408563676d874a3a4ee573370066f0dc4e29d84e82e989c6517424", size = 1239218, upload-time = "2026-05-15T04:51:16.103Z" },
+    { url = "https://files.pythonhosted.org/packages/16/5b/f2aa703a4fc5d2dff73460a7d46cc2f3f44aa0f3dd8eeb20d2a0ecf68862/tiktoken-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:85b78cc3a2c3d48723ca751fa981f1fedccd54194ca0471b957364353a898b07", size = 918110, upload-time = "2026-05-15T04:51:17.237Z" },
+]
+
+[[package]]
 name = "tokenizers"
 version = "0.22.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3893,10 +3991,12 @@ otel-libs = [
     { name = "opentelemetry-instrumentation-asyncio" },
     { name = "opentelemetry-instrumentation-fastapi" },
     { name = "opentelemetry-instrumentation-httpx" },
+    { name = "opentelemetry-instrumentation-logging" },
     { name = "opentelemetry-instrumentation-psycopg2" },
     { name = "opentelemetry-instrumentation-redis" },
     { name = "opentelemetry-instrumentation-requests" },
     { name = "opentelemetry-instrumentation-sqlalchemy" },
+    { name = "opentelemetry-instrumentation-urllib3" },
 ]
 rca = [
     { name = "dowhy" },
@@ -3922,10 +4022,12 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-asyncio", marker = "extra == 'otel-libs'", specifier = ">=0.48b0,<0.50.0" },
     { name = "opentelemetry-instrumentation-fastapi", marker = "extra == 'otel-libs'", specifier = ">=0.48b0,<0.50.0" },
     { name = "opentelemetry-instrumentation-httpx", marker = "extra == 'otel-libs'", specifier = ">=0.48b0,<0.50.0" },
+    { name = "opentelemetry-instrumentation-logging", marker = "extra == 'otel-libs'", specifier = ">=0.48b0,<0.50.0" },
     { name = "opentelemetry-instrumentation-psycopg2", marker = "extra == 'otel-libs'", specifier = ">=0.48b0,<0.50.0" },
     { name = "opentelemetry-instrumentation-redis", marker = "extra == 'otel-libs'", specifier = ">=0.48b0,<0.50.0" },
     { name = "opentelemetry-instrumentation-requests", marker = "extra == 'otel-libs'", specifier = ">=0.48b0,<0.50.0" },
     { name = "opentelemetry-instrumentation-sqlalchemy", marker = "extra == 'otel-libs'", specifier = ">=0.48b0,<0.50.0" },
+    { name = "opentelemetry-instrumentation-urllib3", marker = "extra == 'otel-libs'", specifier = ">=0.48b0,<0.50.0" },
     { name = "opentelemetry-sdk", specifier = ">=1.27.0,<1.30.0" },
     { name = "pandas", specifier = ">=2.0.0,<2.3.0" },
     { name = "pyarrow", specifier = ">=23.0.1,<24.0.0" },
@@ -4183,11 +4285,7 @@ name = "vinv-core"
 version = "0.1.0"
 source = { editable = "core" }
 dependencies = [
-    { name = "dspy-ai" },
     { name = "httpx" },
-    { name = "jsonschema" },
-    { name = "litellm" },
-    { name = "openai" },
     { name = "pexpect" },
     { name = "pydantic" },
     { name = "pyyaml" },
@@ -4195,26 +4293,43 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+agents = [
+    { name = "certifi" },
+    { name = "dspy-ai" },
+    { name = "jsonschema" },
+    { name = "litellm" },
+    { name = "openai" },
+    { name = "tiktoken" },
+]
 dev = [
+    { name = "certifi" },
+    { name = "dspy-ai" },
+    { name = "jsonschema" },
+    { name = "litellm" },
+    { name = "openai" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "tiktoken" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "dspy-ai", specifier = ">=3.1.0" },
-    { name = "httpx", specifier = ">=0.24.0" },
-    { name = "jsonschema", specifier = ">=4.0.0" },
-    { name = "litellm", editable = "core/vendor/litellm_stub" },
-    { name = "openai", specifier = ">=1.59.0" },
-    { name = "pexpect", specifier = ">=4.9" },
-    { name = "pydantic", specifier = ">=2.10.5" },
+    { name = "certifi", marker = "extra == 'agents'", specifier = ">=2024.2.2" },
+    { name = "dspy-ai", marker = "extra == 'agents'", specifier = ">=3.1.0,<4.0.0" },
+    { name = "httpx", specifier = ">=0.27.0,<0.29.0" },
+    { name = "jsonschema", marker = "extra == 'agents'", specifier = ">=4.20.0,<5.0.0" },
+    { name = "litellm", marker = "extra == 'agents'", editable = "core/vendor/litellm_stub" },
+    { name = "openai", marker = "extra == 'agents'", specifier = ">=1.59.0,<3.0.0" },
+    { name = "pexpect", specifier = ">=4.9,<5.0" },
+    { name = "pydantic", specifier = ">=2.10.5,<3.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0,<10.0.0" },
-    { name = "pyyaml", specifier = ">=6.0.0" },
+    { name = "pyyaml", specifier = ">=6.0.1,<7.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.0,<0.9.0" },
-    { name = "websocket-client", specifier = ">=1.8.0" },
+    { name = "tiktoken", marker = "extra == 'agents'", specifier = ">=0.7.0,<1.0.0" },
+    { name = "vinv-core", extras = ["agents"], marker = "extra == 'dev'", editable = "core" },
+    { name = "websocket-client", specifier = ">=1.8.0,<2.0.0" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["agents", "dev"]
 
 [[package]]
 name = "vinv-embedder"


### PR DESCRIPTION
Two agents audited this repo using Vinv itself and kept finding the same defect wearing different costumes: **the product asserting an unverified inference as a finding.** Thirteen instances — eleven of them one class, *absence of evidence presented as evidence*. This PR fixes them and adds the gates that stop the class recurring.

The engine turned out to be consistently careful about **verdicts** and careless about **non-verdicts**. Every verdict-bearing gate held under scrutiny — `verifiedEligible` is veto-only, arm learning uses the binary `verified` bit, suspicious-pass paths are marked non-objective, the retrieval OPE correctly declines to promote a regression. What was wrong, repeatedly, was what got *rendered* or what got *dropped*.

## The four that would have cost a user something

**A caught exception dispatched as a bug.** `make_server` raises `OSError(EADDRINUSE)`; `_cmd_serve` catches it at `cli.py:91` as the single-instance lock. Vinv dispatched a fix episode. The agent correctly disputed the premise and the episode aborted at reward −1.00 — a real episode burned on a non-defect.

**"Memoize `main`."** The opportunity board listed the CLI entry point of a server as a cache candidate, "~25101ms is cacheable", and ranked `main` and `_cmd_serve` #1 and #2 in hotspots at 31.2% each. 62% of "traced runtime" was *the process was running*.

**"Dead Code" that meant "untraced".** `isDead(n) = !n.rt`. At 35 of 7577 symbols traced, that renders as a 99% dead-code finding. Selecting `_b` showed "never executed in captured traces" directly above "CALLED BY · 23".

**Ask Vinv's context budget set by one episode.** `min_promotion_n` and `promotion_delta` were declared, defaulted, range-validated, persisted — and read by nothing. With a Beta(1,1) prior one verified episode promotes an arm, and `qna/answer.ts` decodes bit 2 of `preferred_arm` to pick the snippet budget.

## What else is in here

- **Reward provenance.** `reward` is renormalized over available components, so a verified pass, an episode nothing could check, and one whose tests were discarded as non-discriminating all printed `1.00`. Now every printed reward carries what stood behind it; aborts are excluded from the cumulative figure *and the exclusion is stated*.
- **Request-outcome ledger.** A queued sweep that dispatched nothing sent its reason to a transient toast and nothing to disk — and the request was already drained, so a retry was a second silent consumption.
- **Six undeclared dependencies.** `tiktoken`/`certifi` made `count_tokens` fall back to `len // 4`, 43% off on a real sample while driving feasibility checks and chunk sizing. `otel-libs` was installed by nothing — an unrelated `uv sync` pruned all 9 instrumentors live, 14 packages → 4, silently.
- **UI.** Success green (red previously carried four meanings), the Dead Code count that never refreshed, a truncated line number, the API-key panel that had no command and no `<meta charset>`, and Journey — a full editor reachable only by typing its name in the palette — folded into Findings as the one landing surface.

## Two gaps found only because two agents validated separately

`index/eval` (30 tests) was gated by **no job at all**. It surfaced as a discrepancy between two independent test counts — 1804 vs 1834.

And **nothing ran the extension suite.** Grepping the workflows for `npm test`, `vscode-test` or `xvfb` returned zero. ~700 tests were gated only by whoever ran them locally — which is exactly why a broken test harness (`@vscode/test-electron` spawning a binary VS Code renamed) went unnoticed. *The gate's absence looked like passing.*

## How these were arrived at, including what we got wrong

Not everything flagged was real. **Three claims were retracted before they reached this PR** — "the reward model punishes a correct dispute" (it doesn't; aborts are recorded `objective: false` and never train the bandit), "`verifiedEligible` allows reward hacking" (it's veto-only), and "the retrieval OPE has never run" (103 evaluations, correctly declining to promote a regression). Two more were tool-generated false positives caught by reading the source: a coverage parser whose function-boundary regex overshot, and an engines scan that matched `>=12.22` looking for `22`. A proposed gate was also narrowed after measurement showed it would have excluded every web handler's real work.

Every retraction came from **re-running**, never from re-reading. That is the mechanism worth taking from this more than the bug count.

Three review heuristics fell out of it:

1. **Validation proves a value is well-formed, never that anyone consumes it.**
2. **A green test proves the assertion held, never that it was the right assertion.** One asserted `count_tokens(70M chars) >= 17_500_000` commented "token ≈ chars/4" — that comment *was* a missing dependency's fallback formula.
3. **Absence of output is indistinguishable from dead.**

## Verification

```
extension  700 passing, exit 0 · check · eslint · bundle 653.8kb
python     1834 passed, 5 skipped
dep sweep  188 files / 54 distributions — clean
uv lock --check clean
```

Fixes verified against **real captures of this repo**, not fixtures. Both producers (graph overlay and MCP `coverage_of`) agree on the full field set.

**On the new CI step.** `xvfb-run` gives VS Code a display but not a sandbox: `ubuntu-latest` is Ubuntu 24.04, which restricts unprivileged user namespaces via AppArmor, and Chromium's SUID sandbox needs exactly that — so the extension host would have died before a single test ran. Fixed with `--no-sandbox --disable-gpu`, scoped to `platform === 'linux'` so macOS and Windows keep the real sandbox.

The other ways a macOS-only suite breaks on Linux were checked too: all 545 relative imports resolve with exact case (Linux is case-sensitive, macOS is not), no hardcoded `/Users` or darwin branches, the `0600` mode assertions are POSIX, and the socket path that hits darwin's 103-char `sun_path` limit is ~60 chars on a runner. No apt step needed — the runner images ship Chrome, Firefox and Edge, so Chromium's libraries are already there.

That removes the known blocker but does not make the step *proven*: neither agent can execute GitHub Actions. **The first run on this PR is what validates it.** If it is red, it is the CI change failing — fix in place, revert nothing else.

## Reviewing

Three commits, each green on its own: lint/format debt → engine → rendering. The third reads `contained`/`contained_by`/`verificationWeight` from the second, so read them in order.

The commit boundary is **engine vs rendering**, not per-author. An author split was attempted and does not compile: `cockpit.test.ts` carries both agents' suites, and the `FailureExemplar` change makes fields required that one suite's fixtures need while the other needs a field from the opposite commit. Attribution is in the commit message bodies.

Generated with Qagent-vinv



