### PR TITLE
fix: make retrieval bounds visible, and give agents the relevance walk

### DIFF
--- a/extension/src/harness/contextPack.ts
+++ b/extension/src/harness/contextPack.ts
@@ -32,6 +32,19 @@ import {
 	optimizeAttemptsPath,
 } from './optimizationAnalysis';
 
+/**
+ * Per-symbol summary budget in the pack.
+ *
+ * A FIXED constant, deliberately. This was a learnable bandit feature and the
+ * measurement showed why that was wrong: summaries here top out at 696 chars
+ * (median 76, p99 160), so neither of the old 800/1600 levels ever cut anything
+ * and the bit the bandit spent half its arm space exploring was inert. Making it
+ * learnable again would repeat that. 800 preserves today's behaviour exactly —
+ * it is above the observed maximum, so it truncates nothing — while leaving a
+ * bound in place for a summariser that later emits longer text.
+ */
+const PACK_SUMMARY_CHARS = 800;
+
 /** Composition budgets from the learned policy — nothing here is a constant. */
 export interface PackBudgets {
 	/** Graph-slice node budget. */
@@ -311,7 +324,7 @@ export function composePackContent(
 			entry += ` (walk mass ${mass.toExponential(2)})`;
 		}
 		if (n.summary) {
-			entry += `\n  ${n.summary.slice(0, arm.snippet_chars)}`;
+			entry += `\n  ${n.summary.slice(0, PACK_SUMMARY_CHARS)}`;
 		}
 		if (arm.include_runtime) {
 			const rt = snapshot.runtime[n.row];

--- a/extension/src/harness/episodeTelemetry.ts
+++ b/extension/src/harness/episodeTelemetry.ts
@@ -32,25 +32,42 @@ export interface EpisodeArm {
 	slice_depth: number;
 	/** Whether runtime evidence (trace facts) is included in the pack. */
 	include_runtime: boolean;
-	/** Per-symbol snippet budget in characters. */
-	snippet_chars: number;
 }
 
 /** The named composition features the factored arm grid ranges over. */
-export const EPISODE_FEATURES = ['slice_depth', 'include_runtime', 'snippet_chars'] as const;
+/**
+ * The features the bandit actually explores.
+ *
+ * `snippet_chars` WAS a third feature and was removed: on this path it is consumed
+ * in exactly one place — `contextPack` slicing `n.summary` — and summaries are far
+ * shorter than either level, so both returned the identical string. Measured on a
+ * 7577-symbol snapshot: longest summary 696 chars, median 76, p99 160, and ZERO
+ * symbols exceeded even the lean 800 level. Bit 2 was inert, arms 0-3 were
+ * byte-identical to arms 4-7, and Thompson sampling spent half its exploration
+ * distinguishing arms that could not differ — while the learner was already
+ * starved (1 objective outcome across 17 completed episodes).
+ *
+ * The bit was not merely wasted. `qna/answer.ts` decoded it for Ask Vinv's ANCHOR
+ * SOURCE budget, where the same numbers DO bite (indexed source: median 436, p95
+ * 3769, 30.3% of symbols over 800). So a value was learned in a domain where it
+ * provably could not affect the outcome, then applied to one where it could. That
+ * is not thin evidence; it is evidence with no causal path to the claim it was
+ * used to justify. Ask Vinv now carries its own explicit `qna_snippet_chars`.
+ *
+ * Dropping it halves the arm space to 4, doubling the per-arm sample rate.
+ */
+export const EPISODE_FEATURES = ['slice_depth', 'include_runtime'] as const;
 export type EpisodeFeature = (typeof EPISODE_FEATURES)[number];
 
 /** Two levels per feature: level 0 is the lean baseline, level 1 the rich one. */
 export interface ArmFeatureLevels {
 	slice_depth: [number, number];
 	include_runtime: [boolean, boolean];
-	snippet_chars: [number, number];
 }
 
 const DEFAULT_FEATURE_LEVELS: ArmFeatureLevels = {
 	slice_depth: [1, 2],
 	include_runtime: [false, true],
-	snippet_chars: [800, 1600],
 };
 
 function validFeatureLevels(raw: unknown): raw is ArmFeatureLevels {
@@ -60,17 +77,13 @@ function validFeatureLevels(raw: unknown): raw is ArmFeatureLevels {
 	const r = raw as Record<string, unknown>;
 	const depth = r.slice_depth;
 	const runtime = r.include_runtime;
-	const snippet = r.snippet_chars;
 	return (
 		Array.isArray(depth) &&
 		depth.length === 2 &&
 		depth.every((d) => Number.isInteger(d) && d >= 0 && d <= 4) &&
 		Array.isArray(runtime) &&
 		runtime.length === 2 &&
-		runtime.every((b) => typeof b === 'boolean') &&
-		Array.isArray(snippet) &&
-		snippet.length === 2 &&
-		snippet.every((s) => Number.isInteger(s) && s >= 100 && s <= 20_000)
+		runtime.every((b) => typeof b === 'boolean')
 	);
 }
 
@@ -81,11 +94,11 @@ function validFeatureLevels(raw: unknown): raw is ArmFeatureLevels {
  */
 export function armGrid(levels: ArmFeatureLevels): EpisodeArm[] {
 	const arms: EpisodeArm[] = [];
-	for (let i = 0; i < 8; i++) {
+	// 1 << EPISODE_FEATURES.length — 4 arms since snippet_chars was removed.
+	for (let i = 0; i < 1 << EPISODE_FEATURES.length; i++) {
 		arms.push({
 			slice_depth: levels.slice_depth[i & 1],
 			include_runtime: levels.include_runtime[(i >> 1) & 1],
-			snippet_chars: levels.snippet_chars[(i >> 2) & 1],
 		});
 	}
 	return arms;
@@ -96,13 +109,12 @@ export function armLevels(index: number): Record<EpisodeFeature, 0 | 1> {
 	return {
 		slice_depth: (index & 1) as 0 | 1,
 		include_runtime: ((index >> 1) & 1) as 0 | 1,
-		snippet_chars: ((index >> 2) & 1) as 0 | 1,
 	};
 }
 
 /** Arm index for a level assignment (inverse of armLevels). */
 export function levelsToIndex(levels: Record<EpisodeFeature, 0 | 1>): number {
-	return levels.slice_depth | (levels.include_runtime << 1) | (levels.snippet_chars << 2);
+	return levels.slice_depth | (levels.include_runtime << 1);
 }
 
 /**
@@ -131,7 +143,7 @@ export function episodeArmSet(policy?: EpisodePolicy): EpisodeArm[] {
  * `attribution` record what the current values were computed from.
  */
 export interface EpisodePolicy {
-	version: 2;
+	version: 3;
 	/** Exploration ceiling — effective epsilon decays below it with data. */
 	epsilon0: number;
 	/** Exploration floor — never stop exploring entirely. */
@@ -146,6 +158,33 @@ export interface EpisodePolicy {
 	attempt_budget_max: number;
 	/** Greedy arm = argmax posterior mean (reporting/back-compat; TS drives selection). */
 	preferred_arm: number;
+	/**
+	 * Ask Vinv's per-anchor SOURCE budget, in characters.
+	 *
+	 * Explicit rather than decoded from a bandit arm. It previously came from
+	 * `(preferred_arm >> 2) & 1`, i.e. a bit the bandit learned against context
+	 * PACKS — where it sliced summaries and could not bite — and Ask Vinv then
+	 * applied it to anchor SOURCE, where it does. See EPISODE_FEATURES.
+	 *
+	 * 4000 follows from what a prompt can hold, NOT from a percentile of one
+	 * repo. Anchors are bounded and few (explicit seeds plus extra anchor rows),
+	 * so the bound that transfers is capacity: ~8 anchors x 4000 = 32KB, which a
+	 * prompt absorbs, where p99 (11,920 here) x 8 = ~95KB does not. The measured
+	 * distribution corroborates the choice; it did not derive it. Do NOT 'update'
+	 * this from a fresh percentile — that would make it a property of whichever
+	 * repo was measured last.
+	 *
+	 * REQUIRED, not optional, and that is load-bearing. The consumer slices with
+	 * it: `text.slice(0, Math.ceil(qna_snippet_chars * k))`. If the field were
+	 * optional and ever absent, that arithmetic is NaN and `.slice(0, NaN)`
+	 * returns the EMPTY STRING — the model would receive an empty code fence
+	 * where the anchor's source belongs, with no error and nothing in the prompt
+	 * saying so. A silently empty anchor is worse than a truncated one, because
+	 * truncation now announces itself and this would not. Keep it required, and
+	 * keep `validPolicy` range-checking it so a malformed file resets to priors
+	 * rather than propagating a non-number.
+	 */
+	qna_snippet_chars: number;
 	/**
 	 * Per-arm Beta posteriors over the verified-fix probability, re-estimated
 	 * from the objective-outcome ledger each episode. Absent on a cold/legacy
@@ -303,14 +342,15 @@ export function walkParams(policy: EpisodePolicy): WalkParams {
  * episodes accrue — none is a frozen constant.
  */
 export const POLICY_PRIORS: EpisodePolicy = {
-	version: 2,
+	version: 3,
 	epsilon0: 0.25,
 	epsilon_min: 0.02,
 	epsilon_decay: 0.5,
 	attempt_budget: 3,
 	attempt_quantile: 0.9,
 	attempt_budget_max: 6,
-	preferred_arm: 3, // depth 2 + runtime evidence at the lean snippet budget
+	preferred_arm: 3, // depth 2 + runtime evidence (the richest of the 4 arms)
+	qna_snippet_chars: 4000,
 	ts_prior_alpha: 1, // uniform Beta(1,1) prior — no arm privileged before data
 	ts_prior_beta: 1,
 	arm_levels: DEFAULT_FEATURE_LEVELS,
@@ -335,7 +375,7 @@ function validPolicy(raw: Partial<EpisodePolicy>): raw is EpisodePolicy {
 	const intIn = (v: unknown, lo: number, hi: number): boolean =>
 		Number.isInteger(v) && (v as number) >= lo && (v as number) <= hi;
 	return (
-		raw.version === 2 &&
+		raw.version === 3 &&
 		numberIn(raw.epsilon0, 0, 0.5) &&
 		numberIn(raw.epsilon_min, 0, 0.5) &&
 		(raw.epsilon_min as number) <= (raw.epsilon0 as number) &&
@@ -344,7 +384,9 @@ function validPolicy(raw: Partial<EpisodePolicy>): raw is EpisodePolicy {
 		numberIn(raw.attempt_quantile, 0.5, 1) &&
 		intIn(raw.attempt_budget_max, 1, 10) &&
 		validFeatureLevels(raw.arm_levels) &&
-		intIn(raw.preferred_arm, 0, 7) &&
+		// 0..3: the arm space is 1 << EPISODE_FEATURES.length, now 4 not 8.
+		intIn(raw.preferred_arm, 0, (1 << EPISODE_FEATURES.length) - 1) &&
+		intIn(raw.qna_snippet_chars, 200, 40_000) &&
 		intIn(raw.slice_budget, 4, 200) &&
 		intIn(raw.seed_cap, 1, 50) &&
 		intIn(raw.failure_evidence_chars, 200, 50_000) &&
@@ -441,7 +483,40 @@ export function loadEpisodePolicy(): EpisodePolicy {
 		return { ...POLICY_PRIORS };
 	}
 	if (!validPolicy(raw)) {
-		appendEpisodeEvent({ type: 'policy_invalidated', ts: new Date().toISOString() });
+		// Say WHY, and say what was discarded. The ledger previously carried 38
+		// bare {type, ts} invalidations against 17 completed episodes — enough to
+		// make "was that one clean migration or something invalidating
+		// repeatedly?" unanswerable. A reset is a state change and must announce
+		// itself like any other.
+		// Read through `unknown`: `raw` is typed Partial<EpisodePolicy>, so TS narrows
+		// `version` to the CURRENT literal and would rule out the comparison below —
+		// but the whole point is that the FILE may hold an older number.
+		const rawVersion = (raw as { version?: unknown }).version;
+		const storedVersion = typeof rawVersion === 'number' ? rawVersion : null;
+		const discardedArms = Array.isArray(raw.arm_posteriors)
+			? raw.arm_posteriors.length
+			: 0;
+		// A KNOWN version step is a migration, not corruption. v2 -> v3 dropped
+		// `snippet_chars` from the arm grid (see EPISODE_FEATURES), which halves
+		// the arm space, so a v2 file's 8 posteriors cannot be reindexed onto 4
+		// arms — arm 4, the one v2 had promoted, ceases to exist. Discarding them
+		// is correct AND cheap here (the ledger holds one objective observation),
+		// but it must be a declared reset rather than a silent fallback.
+		const migration = storedVersion === POLICY_PRIORS.version - 1;
+		appendEpisodeEvent({
+			type: 'policy_invalidated',
+			ts: new Date().toISOString(),
+			from_version: storedVersion,
+			to_version: POLICY_PRIORS.version,
+			reason: migration
+				? 'grid change v2->v3: snippet_chars removed from the arm space (it was '
+					+ 'inert on the pack path), so arm indices are not comparable and the '
+					+ 'stored posteriors were discarded'
+				: 'stored policy failed validation and was replaced with priors',
+			declared_migration: migration,
+			discarded_arm_count: discardedArms,
+			arm_count: 1 << EPISODE_FEATURES.length,
+		});
 		return { ...POLICY_PRIORS };
 	}
 	return raw;

--- a/extension/src/harness/opportunityBoard.ts
+++ b/extension/src/harness/opportunityBoard.ts
@@ -60,6 +60,7 @@ import {
 	loadOptimizationCalibration,
 	type OptimizationCandidate,
 } from './optimizationAnalysis';
+import type { SelectionStats } from './runtimeAnalysis';
 
 /**
  * The complete lifecycle:
@@ -750,6 +751,23 @@ export function reconcileOpportunityBoard(
  * (optimizationSource.ts assembles the same inputs for the panel; that class
  * is vscode-bound, so the vscode-free surfaces share this assembly instead.)
  */
+/**
+ * Bound report from the most recent `rankedOpportunityCandidates` call.
+ *
+ * A sidecar is normally the wrong shape (it goes stale the moment anything
+ * else calls the ranker) and I rejected one for the selectors themselves. It is
+ * acceptable HERE and only here because `rankedOpportunityCandidates` already
+ * returns a plain array by contract to several callers, and widening that
+ * signature would churn the board's whole surface for a value only the
+ * rendering path wants. Read it immediately after the call or not at all.
+ */
+let lastRankedSelection: SelectionStats | null = null;
+
+/** The bound that ended the last ranking, or null if it has not run. */
+export function lastRankedSelectionStats(): SelectionStats | null {
+	return lastRankedSelection;
+}
+
 export function rankedOpportunityCandidates(workspaceRoot: string): OptimizationCandidate[] {
 	if (!hasIndexStore(workspaceRoot)) {
 		// loadNodes degrades to [] on a missing store, which would masquerade as
@@ -761,12 +779,12 @@ export function rankedOpportunityCandidates(workspaceRoot: string): Optimization
 	const nodes: GraphNode[] = loadNodes(storeDir);
 	const edges = loadEdges(storeDir, nodes.length);
 	const timings = collectSymbolTimings(workspaceRoot, nodes);
-	const cacheByRow = new Map(collectCacheCandidates(workspaceRoot, nodes).map((c) => [c.row, c]));
+	const cacheByRow = new Map(collectCacheCandidates(workspaceRoot, nodes).items.map((c) => [c.row, c]));
 	const spans = collectRequestSpans(workspaceRoot, nodes);
 	// Same ranking-time calibration deflation as the panel path — the board and
 	// the panel must never rank the same evidence differently.
 	const calibration = loadOptimizationCalibration(workspaceRoot);
-	return computeOptimizationCandidates({
+	const { items, stats } = computeOptimizationCandidates({
 		nodes,
 		edges,
 		timings,
@@ -782,6 +800,13 @@ export function rankedOpportunityCandidates(workspaceRoot: string): Optimization
 		// the analyzer's default to stay in sync.
 		cap: OPPORTUNITY_ANALYZER_CAP,
 	});
+	// The bound is recorded, not discarded. A board that posts N opportunities
+	// and cannot say whether N was everything is the truncation-reads-as-
+	// completeness shape; `stats` is what lets a surface state it. Latency
+	// selection only — see computeOptimizationCandidates for why memory is
+	// not folded in.
+	lastRankedSelection = stats;
+	return items;
 }
 
 /** Board input for one ranked candidate. */

--- a/extension/src/harness/optimizationAnalysis.ts
+++ b/extension/src/harness/optimizationAnalysis.ts
@@ -39,6 +39,7 @@ import type {
 	MemoryLeakSuspect,
 	SymbolSessionTiming,
 	TraceSpan,
+	SelectionStats,
 } from './runtimeAnalysis';
 import { removeExpiredOptimizationEvidence } from './optimizationEvidence';
 
@@ -624,7 +625,9 @@ function computeSpanSignals(roots: TraceSpan[]): Map<number, SpanSignal> {
  * head of predicted recoverable time — relative to THIS trace — so the rule is
  * scale-free (a 5ms service and a 5s batch job get the same treatment).
  */
-export function computeOptimizationCandidates(inputs: ComputeInputs): OptimizationCandidate[] {
+export function computeOptimizationCandidates(
+	inputs: ComputeInputs,
+): { items: OptimizationCandidate[]; stats: SelectionStats } {
 	const { nodes, edges, timings, cacheByRow } = inputs;
 	const coverage = inputs.coverage ?? 0.9;
 	const cap = inputs.cap ?? 12;
@@ -916,7 +919,13 @@ export function computeOptimizationCandidates(inputs: ComputeInputs): Optimizati
 	);
 	const total = raw.reduce((s, c) => s + effective(c), 0);
 	if (total <= 0) {
-		return memory;
+		// No latency signal at all. The memory dimension may still have found
+		// candidates, but no LATENCY bound was applied, so the stats say so
+		// rather than implying a selection happened.
+		return {
+			items: memory,
+			stats: { returned: 0, total: 0, dropped: 0, coverage_achieved: 0, stopped_by: 'exhausted' },
+		};
 	}
 	// End-to-end Amdahl ceiling per candidate (see the field doc): share of the
 	// trace's total predicted time, discounted by the waste prior. The
@@ -929,8 +938,14 @@ export function computeOptimizationCandidates(inputs: ComputeInputs): Optimizati
 	raw.sort((a, b) => effective(b) - effective(a));
 	const out: OptimizationCandidate[] = [];
 	let covered = 0;
+	let stoppedBy: SelectionStats['stopped_by'] = 'exhausted';
 	for (const c of raw) {
-		if (out.length >= cap || covered / total >= coverage) {
+		if (out.length >= cap) {
+			stoppedBy = 'cap';
+			break;
+		}
+		if (covered / total >= coverage) {
+			stoppedBy = 'coverage';
 			break;
 		}
 		covered += effective(c);
@@ -939,7 +954,23 @@ export function computeOptimizationCandidates(inputs: ComputeInputs): Optimizati
 	// Memory candidates (computed above, ranked in bytes) are appended after the
 	// ms Pareto — they never entered the clamp/calibration/Amdahl loops, which
 	// are all time concepts.
-	return [...out, ...memory];
+	//
+	// `stats` therefore describes the LATENCY selection only, and deliberately so:
+	// the memory dimension is ranked in BYTES against its own bound, and folding
+	// two incommensurable selections into one coverage number would produce a
+	// figure that is not true of either. `items.length` can exceed `stats.returned`
+	// by the memory tail; a renderer that needs a single count should use
+	// items.length and reserve describeSelection() for the latency claim.
+	return {
+		items: [...out, ...memory],
+		stats: {
+			returned: out.length,
+			total: raw.length,
+			dropped: raw.length - out.length,
+			coverage_achieved: covered / total,
+			stopped_by: stoppedBy,
+		},
+	};
 }
 
 // ---- outcome calibration artifact (read side) -------------------------------

--- a/extension/src/harness/runtimeAnalysis.ts
+++ b/extension/src/harness/runtimeAnalysis.ts
@@ -155,6 +155,74 @@ export function collectRuntimeErrorClusters(
 	};
 }
 
+/**
+ * What a bounded selection actually did.
+ *
+ * Every selector here stops on ONE of two bounds — a Pareto coverage target or a
+ * hard item cap — and until now neither said so. A caller received `4` and had
+ * no way to tell "4 is everything worth having" from "4 is the cap and 196 were
+ * dropped". On this repo the honest answer is the first: the cache selector
+ * returns 4 of 24 and those 4 carry 99.96% of the reclaimable time, the 20
+ * dropped being worth 14.6ms combined against a smallest-kept of 6,583ms. That
+ * is the Pareto head doing its job — but the ONLY way to establish it was to
+ * write a probe, which a user cannot do.
+ *
+ * So the defect was never the bound; it was the silence. This makes the bound
+ * self-describing, and `stopped_by` in particular means we do not have to guess
+ * today whether a cap is set correctly — the first time one fires ahead of the
+ * coverage target, the report says `'cap'` and the evidence arrives on its own.
+ */
+export interface SelectionStats {
+	/** Items handed back. */
+	returned: number;
+	/** Items the analysis found before any bound was applied. */
+	total: number;
+	/** total - returned, precomputed so no caller has to subtract. */
+	dropped: number;
+	/** Share (0..1) of the ranked quantity the returned set covers. */
+	coverage_achieved: number;
+	/**
+	 * Which bound ended the selection. `'exhausted'` means neither fired and the
+	 * result IS everything found — the value that lets a surface say "4 of 4"
+	 * honestly rather than leaving "4" ambiguous.
+	 */
+	stopped_by: 'coverage' | 'cap' | 'exhausted';
+}
+
+/**
+ * The one-line honest rendering of a bounded selection.
+ *
+ * Lives beside `SelectionStats` on purpose: every surface that states a count
+ * should state the SAME thing about it, and a formatter per surface is how two
+ * renderings of one fact drift apart. `noun` is the singular item name, e.g.
+ * 'memoization candidate'.
+ *
+ * The three shapes it produces:
+ *   exhausted -> "4 memoization candidate(s)"                    nothing was dropped
+ *   coverage  -> "4 of 24 memoization candidate(s) — the top 4 carry 100.0% of
+ *                 the ranked total; the rest were below the coverage target"
+ *   cap       -> "8 of 200 … — stopped at the item cap, so the 192 dropped are
+ *                 NOT known to be immaterial"
+ * The cap wording is deliberately louder: a coverage stop has measured that what
+ * it dropped does not matter, and a cap stop has measured nothing of the kind.
+ */
+export function describeSelection(stats: SelectionStats, noun: string): string {
+	const pct = (stats.coverage_achieved * 100).toFixed(1);
+	if (stats.stopped_by === 'exhausted' || stats.dropped === 0) {
+		return `${stats.returned} ${noun}(s)`;
+	}
+	if (stats.stopped_by === 'coverage') {
+		return (
+			`${stats.returned} of ${stats.total} ${noun}(s) — the top ${stats.returned} carry ` +
+			`${pct}% of the ranked total; the remaining ${stats.dropped} fell below the coverage target`
+		);
+	}
+	return (
+		`${stats.returned} of ${stats.total} ${noun}(s) — STOPPED AT THE ITEM CAP at ${pct}% ` +
+		`coverage, so the ${stats.dropped} dropped are not known to be immaterial`
+	);
+}
+
 /** One latency hotspot from the captured trace, with its share of total time. */
 export interface Hotspot {
 	row: number;
@@ -179,19 +247,31 @@ export function selectHotspots(
 	overlay: Record<number, RuntimeOverlay>,
 	coverage = 0.8,
 	cap = 8,
-): Hotspot[] {
+): { items: Hotspot[]; stats: SelectionStats } {
 	const entries = Object.entries(overlay)
 		.map(([row, rt]) => ({ row: Number(row), rt }))
 		.filter(({ rt }) => rt.total_ms > 0);
 	const totalMs = entries.reduce((sum, e) => sum + e.rt.total_ms, 0);
 	if (totalMs <= 0) {
-		return [];
+		return {
+			items: [],
+			stats: { returned: 0, total: 0, dropped: 0, coverage_achieved: 0, stopped_by: 'exhausted' },
+		};
 	}
 	entries.sort((a, b) => b.rt.total_ms - a.rt.total_ms);
 	const out: Hotspot[] = [];
 	let covered = 0;
+	// Which bound ends the loop, recorded as it happens rather than inferred
+	// afterwards — 'returned === cap' would misreport a coverage stop that
+	// happens to land on the cap.
+	let stoppedBy: SelectionStats['stopped_by'] = 'exhausted';
 	for (const { row, rt } of entries) {
-		if (out.length >= cap || covered / totalMs >= coverage) {
+		if (out.length >= cap) {
+			stoppedBy = 'cap';
+			break;
+		}
+		if (covered / totalMs >= coverage) {
+			stoppedBy = 'coverage';
 			break;
 		}
 		covered += rt.total_ms;
@@ -209,7 +289,16 @@ export function selectHotspots(
 			share: rt.total_ms / totalMs,
 		});
 	}
-	return out;
+	return {
+		items: out,
+		stats: {
+			returned: out.length,
+			total: entries.length,
+			dropped: entries.length - out.length,
+			coverage_achieved: covered / totalMs,
+			stopped_by: stoppedBy,
+		},
+	};
 }
 
 /** One symbol retaining memory across sessions, with its trend. */
@@ -650,7 +739,7 @@ export function collectCacheCandidates(
 	nodes: GraphNode[],
 	coverage = 0.8,
 	cap = 8,
-): CacheCandidate[] {
+): { items: CacheCandidate[]; stats: SelectionStats } {
 	const rowsFor = buildComponentMatcher(nodes);
 	const guarded = securityGuardReasons(workspaceRoot, nodes);
 	interface ArgGroup {
@@ -788,19 +877,37 @@ export function collectCacheCandidates(
 	}
 	const total = raw.reduce((s, c) => s + c.reclaimable_ms, 0);
 	if (total <= 0) {
-		return [];
+		return {
+			items: [],
+			stats: { returned: 0, total: 0, dropped: 0, coverage_achieved: 0, stopped_by: 'exhausted' },
+		};
 	}
 	raw.sort((a, b) => b.reclaimable_ms - a.reclaimable_ms);
 	const out: CacheCandidate[] = [];
 	let covered = 0;
+	let stoppedBy: SelectionStats['stopped_by'] = 'exhausted';
 	for (const c of raw) {
-		if (out.length >= cap || covered / total >= coverage) {
+		if (out.length >= cap) {
+			stoppedBy = 'cap';
+			break;
+		}
+		if (covered / total >= coverage) {
+			stoppedBy = 'coverage';
 			break;
 		}
 		covered += c.reclaimable_ms;
 		out.push({ ...c, share: c.reclaimable_ms / total });
 	}
-	return out;
+	return {
+		items: out,
+		stats: {
+			returned: out.length,
+			total: raw.length,
+			dropped: raw.length - out.length,
+			coverage_achieved: covered / total,
+			stopped_by: stoppedBy,
+		},
+	};
 }
 
 /** One symbol's cost in ONE capture session — the unit the proof loop diffs. */

--- a/extension/src/mcp/indexServer.ts
+++ b/extension/src/mcp/indexServer.ts
@@ -41,6 +41,7 @@ import {
 	collectCacheCandidates,
 	collectMemoryTrends,
 	collectRuntimeErrorClusters,
+	describeSelection,
 	selectHotspots,
 } from '../harness/runtimeAnalysis';
 import {
@@ -410,12 +411,12 @@ function sessionReadAction(action: string): string | null {
 			return federatedReadAction(
 				'No latency hotspots — capture a trace first (run a service and exercise it).',
 				(graph) => {
-					const hotspots = selectHotspots(graph.nodes, graph.overlay);
+					const { items: hotspots, stats } = selectHotspots(graph.nodes, graph.overlay);
 					if (hotspots.length === 0) {
 						return null;
 					}
 					return (
-						'Pareto head of traced runtime:\n' +
+						`Pareto head of traced runtime — ${describeSelection(stats, 'hotspot')}:\n` +
 						hotspots
 							.map(
 								(h) =>
@@ -466,12 +467,12 @@ function sessionReadAction(action: string): string | null {
 			return federatedReadAction(
 				'No cache opportunities — no deterministic symbol was re-called with identical arguments in the captured traces.',
 				(graph, root) => {
-					const candidates = collectCacheCandidates(root, graph.nodes);
+					const { items: candidates, stats } = collectCacheCandidates(root, graph.nodes);
 					if (candidates.length === 0) {
 						return null;
 					}
 					return (
-						`${candidates.length} memoization candidate(s):\n` +
+						`${describeSelection(stats, 'memoization candidate')}:\n` +
 						candidates
 							.map(
 								(c) =>

--- a/extension/src/mcp/relevanceTool.ts
+++ b/extension/src/mcp/relevanceTool.ts
@@ -1,0 +1,196 @@
+/**
+ * `relevant_to` — the relevance walk, handed to the agent.
+ *
+ * Vinv already ranks context by typed-edge personalized PageRank: π = α·s +
+ * (1−α)·π·W̃ over the code graph, restarted at anchor symbols, with per-edge-type
+ * row-normalised kernels and name-specificity (1/df) standing in for IDF. That
+ * is what composes an episode's context pack and what Ask Vinv retrieves with.
+ *
+ * It was not reachable by the agent working the episode. The pack runs the walk
+ * ONCE, up front, from seeds derived before any investigation has happened, and
+ * every retrieval tool offered afterwards answers a different question:
+ * `vinv_query` is embedding similarity, `slice` is a backward DYNAMIC slice over
+ * traces, `blast_radius` is plain transitive traversal. None of them can
+ * reproduce the pack's own ranking, so an agent that discovers three symbols
+ * that actually matter cannot say "re-rank relevance around THESE" — the single
+ * most useful thing a graph-relevance retriever offers.
+ *
+ * That gap made the pack's own promise unkeepable: it tells the agent "this pack
+ * is the seed, not the ceiling" and then names tools that cannot reproduce how
+ * the seed was chosen. This closes it — same walk, same parameters, agent-chosen
+ * anchors, on demand.
+ *
+ * Read-only over the index store, pure math over the snapshot (contextWalk does
+ * no I/O), and it reports its own bound rather than returning a silently
+ * truncated list.
+ */
+
+import {
+	buildGraphSnapshot,
+	type GraphNode,
+	type GraphSnapshot,
+} from '../graph/indexGraph';
+import { contextWalk, type WalkAnchor } from '../graph/contextWalk';
+import { WALK_PRIORS } from '../harness/episodeTelemetry';
+
+/**
+ * Default node budget. Larger than the episode pack's, deliberately: the pack
+ * spends its budget blind, before the agent has read anything, so it stays tight
+ * to leave prompt room. A `relevant_to` call is made by an agent that already
+ * knows what it is looking for, and paying for a wider slice is the point of
+ * asking.
+ */
+const DEFAULT_BUDGET = 40;
+
+/** Ceiling on the requested budget — a walk is cheap, serialising 7577 nodes is not. */
+const MAX_BUDGET = 200;
+
+/**
+ * Resolves a caller-supplied symbol to graph rows.
+ *
+ * Accepts an exact dotted qualname, a bare symbol name, or `file:name`. A name
+ * that matches several symbols returns ALL of them rather than guessing: the
+ * walk takes multiple anchors natively, so ambiguity is answered by ranking
+ * rather than by an arbitrary pick.
+ */
+export function resolveAnchors(
+	nodes: GraphNode[],
+	symbols: string[],
+): { rows: number[]; unresolved: string[] } {
+	const rows: number[] = [];
+	const unresolved: string[] = [];
+	for (const raw of symbols) {
+		const want = raw.trim();
+		if (!want) {
+			continue;
+		}
+		const lower = want.toLowerCase();
+		const matches = nodes.filter((n) => {
+			if (!n) {
+				return false;
+			}
+			const qual = `${n.file}:${n.name}`.toLowerCase();
+			return n.name.toLowerCase() === lower || qual === lower || qual.endsWith(`:${lower}`);
+		});
+		if (matches.length === 0) {
+			unresolved.push(want);
+			continue;
+		}
+		for (const m of matches) {
+			if (!rows.includes(m.row)) {
+				rows.push(m.row);
+			}
+		}
+	}
+	return { rows, unresolved };
+}
+
+export interface RelevantToResult {
+	status: string;
+	[key: string]: unknown;
+}
+
+/**
+ * Ranks the graph by relevance to the given symbols.
+ *
+ * `max_hops` bounds ADMISSION, not ranking: only nodes within that many hops of
+ * an anchor may enter, but order is always walk mass. Omitted means unbounded,
+ * which is what an agent chasing an indirect cause wants.
+ */
+export function toolRelevantTo(
+	workspaceRoot: string,
+	symbols: string[],
+	budget?: number,
+	maxHops?: number,
+): RelevantToResult {
+	if (symbols.length === 0) {
+		return {
+			status: 'error',
+			message: 'relevant_to needs at least one symbol to anchor the walk on.',
+		};
+	}
+	let snapshot: GraphSnapshot;
+	try {
+		snapshot = buildGraphSnapshot(workspaceRoot);
+	} catch (e) {
+		return {
+			status: 'error',
+			message: `no readable Vinv index store: ${e instanceof Error ? e.message : String(e)}`,
+		};
+	}
+	if (snapshot.nodes.length === 0) {
+		return {
+			status: 'no_index',
+			message:
+				'The index store is empty — run discovery before asking what is relevant. ' +
+				'This is not a report that nothing is relevant.',
+		};
+	}
+
+	const { rows: anchorRows, unresolved } = resolveAnchors(snapshot.nodes, symbols);
+	if (anchorRows.length === 0) {
+		return {
+			status: 'unresolved',
+			message: `none of these symbols are in the index: ${unresolved.join(', ')}`,
+			hint: 'Try vinv_query for a semantic search, or pass file:name to disambiguate.',
+		};
+	}
+
+	const effectiveBudget = Math.max(1, Math.min(budget ?? DEFAULT_BUDGET, MAX_BUDGET));
+	const anchors: WalkAnchor[] = anchorRows.map((row) => ({ row, weight: 1 }));
+	const walked = contextWalk(
+		snapshot.nodes,
+		snapshot.edges,
+		snapshot.flow_edges,
+		anchors,
+		{ ...WALK_PRIORS, beta: { ...WALK_PRIORS.beta } },
+		effectiveBudget,
+		maxHops,
+	);
+
+	const items = walked.rows
+		.map((row) => {
+			const n = snapshot.nodes[row];
+			if (!n) {
+				return undefined;
+			}
+			const rt = snapshot.runtime[row];
+			return {
+				name: n.name,
+				kind: n.kind,
+				file: n.file,
+				line: n.start_line,
+				/** Stationary mass — the ranking quantity, exposed so it is auditable. */
+				walk_mass: walked.mass.get(row) ?? 0,
+				is_anchor: anchorRows.includes(row),
+				summary: n.summary || undefined,
+				/** Present only when this symbol was actually observed running. */
+				runtime: rt
+					? {
+							calls: rt.calls,
+							total_ms: Math.round(rt.total_ms),
+							current_errors: rt.current_errors,
+						}
+					: undefined,
+			};
+		})
+		.filter(Boolean);
+
+	// The walk's support is every row it reached with non-zero mass; `budget`
+	// is what we handed back. Reporting both is the difference between "40
+	// relevant symbols" and "40 of 312, ranked" — the second is a fact, the
+	// first is an impression.
+	const support = walked.mass.size;
+	return {
+		status: 'ok',
+		anchors: anchorRows.map((r) => snapshot.nodes[r]?.name).filter(Boolean),
+		unresolved: unresolved.length ? unresolved : undefined,
+		returned: items.length,
+		reached: support,
+		stopped_by: items.length < effectiveBudget ? 'exhausted' : 'budget',
+		budget: effectiveBudget,
+		max_hops: maxHops ?? null,
+		ranking: 'typed-edge personalized PageRank (walk mass), anchors restarted at weight 1',
+		symbols: items,
+	};
+}

--- a/extension/src/mcp/runtimeServer.ts
+++ b/extension/src/mcp/runtimeServer.ts
@@ -23,6 +23,7 @@ import {
 	toolWhyDidThisRun,
 } from '../runtime/analysis';
 import { discoverStores, describeProvenance } from '../graph/storeDiscovery';
+import { toolRelevantTo } from './relevanceTool';
 
 const PROTOCOL_VERSION = '2024-11-05';
 const launchRoot = process.argv[2] ?? process.cwd();
@@ -124,6 +125,39 @@ const TOOLS = [
 		inputSchema: { type: 'object', properties: symbolArg, required: ['symbol'] },
 	},
 	{
+		name: 'relevant_to',
+		description:
+			'Rank the codebase by graph relevance to one or more symbols you name — the ' +
+			'SAME typed-edge personalized-PageRank walk that composed your context pack, ' +
+			're-anchored on your choice. Use when you have found symbols that matter and ' +
+			'want what surrounds them, ranked: it answers "what else is relevant to THESE", ' +
+			'which semantic search (vinv_query) and plain traversal (blast_radius) cannot. ' +
+			'Returns walk mass per symbol so the ranking is auditable, and reports how many ' +
+			'symbols it reached versus returned.',
+		inputSchema: {
+			type: 'object',
+			properties: {
+				symbols: {
+					type: 'array',
+					items: { type: 'string' },
+					description:
+						'Anchor symbols — a bare name, a dotted qualname, or file:name to disambiguate.',
+				},
+				budget: {
+					type: 'number',
+					description: 'Max symbols to return (default 40, ceiling 200).',
+				},
+				max_hops: {
+					type: 'number',
+					description:
+						'Optional admission bound: only symbols within this many hops of an anchor ' +
+						'may enter. Ranking is by walk mass regardless. Omit for unbounded.',
+				},
+			},
+			required: ['symbols'],
+		},
+	},
+	{
 		name: 'blast_radius',
 		description:
 			'Transitive callers (upstream) and callees (downstream) of a symbol in the ' +
@@ -190,6 +224,18 @@ function dispatch(name: string, args: Record<string, unknown>): Record<string, u
 			);
 		case 'slice':
 			return withProvenance(toolSlice(root, symbol));
+		case 'relevant_to':
+			// Graph relevance, not trace evidence — so it reads the index snapshot
+			// rather than the capture corpus, and carries the same provenance line
+			// as every other tool so an agent can tell which store answered.
+			return withProvenance(
+				toolRelevantTo(
+					root,
+					Array.isArray(args.symbols) ? args.symbols.map((s) => String(s)) : [],
+					typeof args.budget === 'number' ? args.budget : undefined,
+					typeof args.max_hops === 'number' ? args.max_hops : undefined,
+				),
+			);
 		case 'blast_radius':
 			return withProvenance(
 				toolBlastRadius(

--- a/extension/src/qna/answer.ts
+++ b/extension/src/qna/answer.ts
@@ -39,6 +39,7 @@ import { loadEpisodePolicy, walkParams, type WalkParams } from '../harness/episo
 import {
 	collectCacheCandidates,
 	collectMemoryTrends,
+	describeSelection,
 	selectHotspots,
 } from '../harness/runtimeAnalysis';
 import { indexStoreDir } from '../graph/indexGraph';
@@ -101,10 +102,18 @@ export async function runIndexQuery(
 	});
 }
 
-/** The preferred arm's per-symbol snippet budget from the learned policy. */
+/**
+ * Ask Vinv's per-anchor SOURCE budget.
+ *
+ * Reads the policy's explicit `qna_snippet_chars`. It previously decoded
+ * `(preferred_arm >> 2) & 1` — a bandit bit learned against context PACKS,
+ * where it sliced summaries (max 696 chars) and so could never bite, then
+ * applied here to anchor SOURCE, where it does (median 436, p95 3769, 30.3%
+ * of symbols over the old 800 level). The arm no longer carries that feature;
+ * see EPISODE_FEATURES in harness/episodeTelemetry.ts.
+ */
 function episodeArmSnippetChars(policy: ReturnType<typeof loadEpisodePolicy>): number {
-	const levels = policy.arm_levels.snippet_chars;
-	return levels[((policy.preferred_arm >> 2) & 1) as 0 | 1];
+	return policy.qna_snippet_chars;
 }
 
 /** Maps index hits to graph node rows (join on file + name + start line). */
@@ -455,6 +464,17 @@ export function assembleEvidence(
 			// asking for the rest of the code retrials can never provide).
 			const anchorChars = Math.ceil(snippetChars * (options?.budgetGrowth ?? 1));
 			let entry = `### ${n.name} — ${n.file}:${n.start_line}-${n.end_line} (as indexed, epoch ${n.epoch})\n\`\`\`${n.lang}\n${body.slice(0, anchorChars)}\n\`\`\``;
+			// A body cut mid-function inside a fence is indistinguishable from a
+			// short function. The anchor is the symbol the question is ABOUT, so a
+			// silent cut is the worst one available: measured on this repo, 30.3%
+			// of symbols exceed the 800-char level. Say what was withheld and how
+			// to get it — the same stated-size-plus-escape-hatch the context pack
+			// uses, rather than leaving the model to infer completeness.
+			if (body.length > anchorChars) {
+				entry +=
+					`\nNOTE: source truncated — showing ${anchorChars} of ${body.length} characters. ` +
+					`Read \`${n.file}\` lines ${n.start_line}-${n.end_line} for the rest.`;
+			}
 			if (indexed !== undefined && diskSegment !== undefined && indexed.trim() !== diskSegment.trim()) {
 				entry +=
 					'\nNOTE: the file has changed on disk since this was indexed — line numbers and code above reflect the indexed epoch (which is what the runtime traces were captured against).';
@@ -465,9 +485,15 @@ export function assembleEvidence(
 	}
 	lines.push(`## Retrieved symbols (top ${hits.length})`);
 	for (const h of hits) {
+		const snippet = h.snippet ?? '';
+		const shown = snippet.slice(0, snippetChars);
 		lines.push(
 			`### ${h.name} (${h.kind}) — ${h.file}:${h.lines?.[0] ?? '?'}\n` +
-				`${h.summary}\n\n\`\`\`${h.lang}\n${(h.snippet ?? '').slice(0, snippetChars)}\n\`\`\``,
+				`${h.summary}\n\n\`\`\`${h.lang}\n${shown}\n\`\`\`` +
+				(snippet.length > snippetChars
+					? `\nNOTE: snippet truncated — showing ${snippetChars} of ${snippet.length} characters. ` +
+						`Read \`${h.file}\` for the rest.`
+					: ''),
 		);
 	}
 	// Unambiguous failure attribution FIRST: exactly which symbols raised, per
@@ -594,10 +620,18 @@ export function assembleEvidence(
 	// wasteful" question actually needs. Omitted entirely when no overlay
 	// exists (nothing measured — nothing to claim).
 	if (Object.keys(snapshot.runtime).length > 0) {
-		const hotspots = selectHotspots(snapshot.nodes, snapshot.runtime);
+		// Every heading in this section states its bound. The reader here is an
+		// AGENT, and an agent shown three candidates with no total concludes there
+		// are three — any plan it then writes ("I've addressed the memoization
+		// opportunities") is false by construction. A human reading a panel can
+		// click through; this is the evidence the model reasons from.
+		const hot = selectHotspots(snapshot.nodes, snapshot.runtime);
+		const hotspots = hot.items;
 		if (hotspots.length > 0) {
 			lines.push('\n## Runtime cost analyses (measured across all captures)');
-			lines.push('Latency Pareto head (share of ALL traced time):');
+			lines.push(
+				`Latency Pareto head (share of ALL traced time) — ${describeSelection(hot.stats, 'hotspot')}:`,
+			);
 			for (const h of hotspots) {
 				lines.push(
 					`- ${h.name} (${h.file}:${h.line}) — ${Math.round(h.total_ms)}ms over ${h.calls} call(s), ${(h.share * 100).toFixed(1)}% of traced time`,
@@ -606,8 +640,17 @@ export function assembleEvidence(
 		}
 		const trends = collectMemoryTrends(workspaceRoot, snapshot.nodes);
 		if (trends.length > 0) {
-			lines.push('Memory-leak suspects (retained in EVERY session, positive Theil–Sen trend):');
-			for (const s of trends.slice(0, walk.failure_exemplars)) {
+			// collectMemoryTrends returns everything it found — no analysis bound —
+			// so the only cap here is this display one, and it says so.
+			const shownTrends = trends.slice(0, walk.failure_exemplars);
+			lines.push(
+				'Memory-leak suspects (retained in EVERY session, positive Theil–Sen trend)' +
+					(trends.length > shownTrends.length
+						? ` — showing the top ${shownTrends.length} of ${trends.length}`
+						: '') +
+					':',
+			);
+			for (const s of shownTrends) {
 				lines.push(
 					`- ${s.name} (${s.file}:${s.line}) — ${Math.round(s.total_retained_bytes / 1024)}KB over ${s.sessions} sessions, +${Math.round(s.slope_bytes_per_session / 1024)}KB/session`,
 				);
@@ -617,10 +660,23 @@ export function assembleEvidence(
 				'Memory-leak suspects: none detected (needs 3+ capture sessions with persistent retention).',
 			);
 		}
-		const cacheable = collectCacheCandidates(workspaceRoot, snapshot.nodes);
+		const cache = collectCacheCandidates(workspaceRoot, snapshot.nodes);
+		const cacheable = cache.items;
 		if (cacheable.length > 0) {
-			lines.push('Duplicate-recomputation (memoization) candidates:');
-			for (const c of cacheable.slice(0, walk.failure_exemplars)) {
+			// TWO bounds stack here: the analysis Pareto head, and this display cap
+			// on top of it. Reporting only the first would be an honest-looking
+			// sentence standing in front of a second, hidden truncation — measured
+			// on this repo the chain is 24 found -> 4 ranked -> 3 shown, and the
+			// heading used to say none of it.
+			const shownCache = cacheable.slice(0, walk.failure_exemplars);
+			lines.push(
+				`Duplicate-recomputation (memoization) candidates — ${describeSelection(cache.stats, 'candidate')}` +
+					(cacheable.length > shownCache.length
+						? `; showing the top ${shownCache.length} of those`
+						: '') +
+					':',
+			);
+			for (const c of shownCache) {
 				lines.push(
 					`- ${c.name} (${c.file}:${c.line}) — ${c.calls} calls, only ${c.distinct_args} distinct arg hash(es), ~${Math.round(c.reclaimable_ms)}ms reclaimable`,
 				);

--- a/extension/src/test/cockpit.test.ts
+++ b/extension/src/test/cockpit.test.ts
@@ -24,6 +24,7 @@ import {
 	type PackBudgets,
 } from '../harness/contextPack';
 import {
+	EPISODE_FEATURES,
 	appendEpisodeEvent,
 	armLevels,
 	effectiveEpsilon,
@@ -461,24 +462,29 @@ suite('Context Pack Composer', () => {
 });
 
 suite('Episode telemetry (bandit over pack composition)', () => {
-	test('the factored arm grid is a stable 2^3 factorial with invertible indexing', () => {
+	test('the factored arm grid is a stable 2^n factorial with invertible indexing', () => {
 		const previous = process.env.VINV_EPISODE_ARM_LEVELS;
 		try {
 			delete process.env.VINV_EPISODE_ARM_LEVELS;
 			const arms = episodeArmSet();
-			assert.strictEqual(arms.length, 8, 'full factorial over three binary features');
+			assert.strictEqual(
+				arms.length,
+				1 << EPISODE_FEATURES.length,
+				'full factorial over the binary features',
+			);
 			// Every coalition is an arm and the index round-trips.
-			for (let i = 0; i < 8; i++) {
+			for (let i = 0; i < 1 << EPISODE_FEATURES.length; i++) {
 				assert.strictEqual(levelsToIndex(armLevels(i)), i);
 			}
 			// Env override with valid levels reshapes the grid.
 			process.env.VINV_EPISODE_ARM_LEVELS = JSON.stringify({
 				slice_depth: [0, 3],
 				include_runtime: [false, true],
-				snippet_chars: [500, 4000],
 			});
-			assert.strictEqual(episodeArmSet()[7].slice_depth, 3);
-			assert.strictEqual(episodeArmSet()[7].snippet_chars, 4000);
+			// Arm 3 is the richest of the FOUR arms (depth level 1 | runtime level 1).
+			// It was arm 7 when snippet_chars was a third feature; see EPISODE_FEATURES.
+			assert.strictEqual(episodeArmSet()[3].slice_depth, 3);
+			assert.strictEqual(episodeArmSet()[3].include_runtime, true);
 			// Garbage env keeps the policy grid — exploration never stops.
 			process.env.VINV_EPISODE_ARM_LEVELS = 'garbage';
 			assert.deepStrictEqual(episodeArmSet(), arms);
@@ -492,10 +498,10 @@ suite('Episode telemetry (bandit over pack composition)', () => {
 	});
 
 	test('Thompson selection concentrates on the best arm and logs a valid propensity', () => {
-		// A confident posterior: arm 5 verifies ~90%, all others ~10%.
+		// A confident posterior: arm 3 verifies ~90%, all others ~10%.
 		const arms = episodeArmSet(POLICY_PRIORS);
 		const posteriors = arms.map((_, a) =>
-			a === 5 ? { alpha: 90, beta: 10 } : { alpha: 10, beta: 90 },
+			a === 3 ? { alpha: 90, beta: 10 } : { alpha: 10, beta: 90 },
 		);
 		const policy: EpisodePolicy = {
 			...POLICY_PRIORS,
@@ -514,7 +520,7 @@ suite('Episode telemetry (bandit over pack composition)', () => {
 		const N = 400;
 		for (let i = 0; i < N; i++) {
 			const d = selectEpisodeArm(policy, rng);
-			if (d.armIndex === 5) {
+			if (d.armIndex === 3) {
 				bestHits += 1;
 			}
 			// Every logged propensity is a valid probability with the floor mass.
@@ -533,7 +539,12 @@ suite('Episode telemetry (bandit over pack composition)', () => {
 		for (let i = 0; i < 200; i++) {
 			seen.add(selectEpisodeArm(POLICY_PRIORS, rng).armIndex);
 		}
-		assert.ok(seen.size >= 5, `cold TS explores many arms (saw ${seen.size})`);
+		// All but at most one arm of the grid — 'broadly', scaled to the grid rather
+		// than hardcoded, so it survives a feature entering or leaving.
+		assert.ok(
+			seen.size >= (1 << EPISODE_FEATURES.length) - 1,
+			`cold TS explores many arms (saw ${seen.size})`,
+		);
 	});
 
 	test('exploration decays with ledger evidence but never below the floor', () => {
@@ -597,7 +608,8 @@ suite('Episode telemetry (bandit over pack composition)', () => {
 		const home = fs.mkdtempSync(path.join(os.tmpdir(), 'vinv-converge-'));
 		try {
 			process.env.VINV_HOME = home;
-			const BEST = 5;
+			// Any arm of the 4-arm grid; 2 exercises a non-zero index.
+			const BEST = 2;
 			const pBest = 0.8;
 			const pOther = 0.2;
 			let s = 20260717 >>> 0;
@@ -752,12 +764,12 @@ suite('Episode policy updater (credit attribution + promotion)', () => {
 		const levels = POLICY_PRIORS.arm_levels;
 		// A legacy arm whose values sit on the current grid maps to its coalition.
 		assert.strictEqual(
-			armIndexForValues({ slice_depth: 2, include_runtime: true, snippet_chars: 800 }, levels),
+			armIndexForValues({ slice_depth: 2, include_runtime: true }, levels),
 			3,
 		);
 		// Values off the grid are unmappable — excluded, never misattributed.
 		assert.strictEqual(
-			armIndexForValues({ slice_depth: 7, include_runtime: true, snippet_chars: 800 }, levels),
+			armIndexForValues({ slice_depth: 7, include_runtime: true }, levels),
 			null,
 		);
 	});
@@ -777,7 +789,11 @@ suite('Episode policy updater (credit attribution + promotion)', () => {
 		assert.ok(shrunk1 < 1 && shrunk1 > globalMean - 1e-12);
 		// The LCB is below the mean, tightens with n, and is -inf with no data.
 		assert.ok(bernsteinLcb(stats[0], 0.1) < stats[0].mean);
-		assert.strictEqual(bernsteinLcb(stats[7], 0.1), Number.NEGATIVE_INFINITY);
+		// Last arm of the grid — unobserved, so its LCB is -inf.
+		assert.strictEqual(
+			bernsteinLcb(stats[(1 << EPISODE_FEATURES.length) - 1], 0.1),
+			Number.NEGATIVE_INFINITY,
+		);
 		const many = perArmStats(
 			episodesFor([{ arm: 0, rewards: new Array<number>(200).fill(1) }]),
 			8,
@@ -787,18 +803,18 @@ suite('Episode policy updater (credit attribution + promotion)', () => {
 
 	test('Shapley attribution over the factorial grid is exact and efficient', () => {
 		// Construct an additive value function: v = 0.5·runtime + 0.2·depth.
-		// Shapley must recover the coefficients exactly, and snippet gets 0.
-		const values = new Array<number>(8).fill(0).map((_, i) => {
+		// Shapley must recover both coefficients exactly over the 4-arm grid.
+		const values = new Array<number>(1 << EPISODE_FEATURES.length).fill(0).map((_, i) => {
 			const levels = armLevels(i);
 			return 0.2 * levels.slice_depth + 0.5 * levels.include_runtime;
 		});
 		const phi = shapleyAttribution(values);
 		assert.ok(Math.abs(phi.slice_depth - 0.2) < 1e-12);
 		assert.ok(Math.abs(phi.include_runtime - 0.5) < 1e-12);
-		assert.ok(Math.abs(phi.snippet_chars - 0) < 1e-12);
-		// Efficiency: contributions sum to v(all) - v(none).
-		const sum = phi.slice_depth + phi.include_runtime + phi.snippet_chars;
-		assert.ok(Math.abs(sum - (values[7] - values[0])) < 1e-12);
+		// Efficiency: contributions sum to v(all) - v(none). v(all) is the
+		// all-levels-high arm, index (1 << features) - 1 = 3.
+		const sum = phi.slice_depth + phi.include_runtime;
+		assert.ok(Math.abs(sum - (values[(1 << EPISODE_FEATURES.length) - 1] - values[0])) < 1e-12);
 	});
 
 	test('TS posteriors move the greedy arm toward the higher verified-fix rate', () => {
@@ -834,12 +850,15 @@ suite('Episode policy updater (credit attribution + promotion)', () => {
 		// here, and so did 1, which is exactly the defect it closes.)
 		const withNonObjective: CompletedEpisode[] = [
 			...episodesFor([{ arm: 2, rewards: [1, 1, 1, 1, 1] }]),
-			{ armIndex: 5, propensity: 0.5, reward: -1, attempts: 1, verified: false, objective: false },
-			{ armIndex: 5, propensity: 0.5, reward: 1, attempts: 1, verified: true, objective: false },
+			// Arm 1, deliberately NOT arm 2: the assertion below proves a non-objective
+			// episode leaves its arm untouched, which only means something if that arm
+			// carries no objective evidence.
+			{ armIndex: 1, propensity: 0.5, reward: -1, attempts: 1, verified: false, objective: false },
+			{ armIndex: 1, propensity: 0.5, reward: 1, attempts: 1, verified: true, objective: false },
 		];
 		const pol = computeUpdatedPolicy(current, withNonObjective);
-		assert.strictEqual(pol.arm_posteriors![5].alpha, 1, 'non-objective episode ignored (alpha stays prior)');
-		assert.strictEqual(pol.arm_posteriors![5].beta, 1, 'non-objective episode ignored (beta stays prior)');
+		assert.strictEqual(pol.arm_posteriors![1].alpha, 1, 'non-objective episode ignored (alpha stays prior)');
+		assert.strictEqual(pol.arm_posteriors![1].beta, 1, 'non-objective episode ignored (beta stays prior)');
 		assert.strictEqual(pol.preferred_arm, 2, 'only objective arm 2 learned');
 		// Attempt budget: 90th percentile of attempts-to-success plus one
 		// attempt of optimism margin (without it the budget ratchets down and
@@ -1671,7 +1690,7 @@ suite('Hotspot selection (Pareto head of traced time)', () => {
 			2: { executed: true, calls: 50, total_ms: 90, errors: 0, error_types: [], failures: [], current_errors: 0, latest_epoch: null },
 			3: { executed: true, calls: 1, total_ms: 10, errors: 0, error_types: [], failures: [], current_errors: 0, latest_epoch: null },
 		};
-		const hot = selectHotspots(nodes, overlay, 0.8, 8);
+		const hot = selectHotspots(nodes, overlay, 0.8, 8).items;
 		// 700ms alone is 70% (< 80% coverage) so the head is {0, 1}; row 2 would
 		// push coverage past the target and is excluded.
 		assert.deepStrictEqual(hot.map((h) => h.row), [0, 1]);
@@ -1682,16 +1701,16 @@ suite('Hotspot selection (Pareto head of traced time)', () => {
 		const scaled: Record<number, RuntimeOverlay> = Object.fromEntries(
 			Object.entries(overlay).map(([r, rt]) => [r, { ...rt, total_ms: rt.total_ms / 1000 }]),
 		);
-		assert.deepStrictEqual(selectHotspots(nodes, scaled, 0.8, 8).map((h) => h.row), [0, 1]);
+		assert.deepStrictEqual(selectHotspots(nodes, scaled, 0.8, 8).items.map((h) => h.row), [0, 1]);
 	});
 
 	test('empty or zero-time traces select nothing; cap bounds the list', () => {
 		const nodes = [0, 1, 2].map((r) => makeNode(r));
-		assert.deepStrictEqual(selectHotspots(nodes, {}, 0.8, 8), []);
+		assert.deepStrictEqual(selectHotspots(nodes, {}, 0.8, 8).items, []);
 		const flat: Record<number, RuntimeOverlay> = Object.fromEntries(
 			[0, 1, 2].map((r) => [r, { executed: true, calls: 1, total_ms: 100, errors: 0, error_types: [], failures: [], current_errors: 0, latest_epoch: null }]),
 		);
-		assert.strictEqual(selectHotspots(nodes, flat, 1, 2).length, 2);
+		assert.strictEqual(selectHotspots(nodes, flat, 1, 2).items.length, 2);
 	});
 
 	test('error clusters carry seed rows and a content signature that dedupes exactly', () => {
@@ -1996,7 +2015,7 @@ suite('Runtime analyses (memory trends + cache candidates)', () => {
 				enter('src.mod2.fn2', 'c2'), exit('src.mod2.fn2', { duration_ms: 30 }),
 			], Math.floor(Date.now() / 1000));
 			const nodes = [makeNode(0), makeNode(1), makeNode(2)];
-			const candidates = collectCacheCandidates(ws, nodes);
+			const candidates = collectCacheCandidates(ws, nodes).items;
 			assert.strictEqual(candidates.length, 1, 'only the pure duplicate qualifies');
 			assert.strictEqual(candidates[0].row, 0);
 			assert.strictEqual(candidates[0].calls, 4);
@@ -2396,7 +2415,7 @@ suite('Cache soundness gates (functional dependence + ceiling cap + security gua
 				...call('src.mod0.fn0', 'collapsed', 'r2'),
 				...call('src.mod0.fn0', 'collapsed', 'r3'),
 			], Math.floor(Date.now() / 1000));
-			assert.deepStrictEqual(collectCacheCandidates(ws, [makeNode(0)]), []);
+			assert.deepStrictEqual(collectCacheCandidates(ws, [makeNode(0)]).items, []);
 		} finally {
 			fs.rmSync(ws, { recursive: true, force: true });
 		}
@@ -2409,7 +2428,7 @@ suite('Cache soundness gates (functional dependence + ceiling cap + security gua
 				enter('src.mod0.fn0', 'aaaa'), exit('src.mod0.fn0', { duration_ms: 100 }),
 				enter('src.mod0.fn0', 'aaaa'), exit('src.mod0.fn0', { duration_ms: 100 }),
 			], Math.floor(Date.now() / 1000));
-			assert.deepStrictEqual(collectCacheCandidates(ws, [makeNode(0)]), []);
+			assert.deepStrictEqual(collectCacheCandidates(ws, [makeNode(0)]).items, []);
 		} finally {
 			fs.rmSync(ws, { recursive: true, force: true });
 		}
@@ -2429,7 +2448,7 @@ suite('Cache soundness gates (functional dependence + ceiling cap + security gua
 			// Newest session: the symbol costs only 50ms now — you cannot reclaim
 			// 300ms from a symbol that currently spends 50ms.
 			writeTrace(ws, 's1', [...call('src.mod0.fn0', 'aaaa', 'r0', 50)], t);
-			const out = collectCacheCandidates(ws, [makeNode(0)]);
+			const out = collectCacheCandidates(ws, [makeNode(0)]).items;
 			assert.strictEqual(out.length, 1);
 			assert.ok(out[0].reclaimable_ms <= 50, `capped at newest session (got ${out[0].reclaimable_ms})`);
 		} finally {
@@ -2473,7 +2492,7 @@ suite('Cache soundness gates (functional dependence + ceiling cap + security gua
 
 			// Both entry points are duplicated (identical args across two runs) and
 			// would otherwise be the two biggest cache candidates by time.
-			const rows = collectCacheCandidates(ws, nodes).map((c) => c.row);
+			const rows = collectCacheCandidates(ws, nodes).items.map((c) => c.row);
 			assert.ok(!rows.includes(0), 'the process root must not be offered for memoization');
 			assert.ok(!rows.includes(1), 'the pass-through must not be offered for memoization');
 			assert.deepStrictEqual(rows, [2], 'only genuine nested work stays eligible');
@@ -2494,7 +2513,7 @@ suite('Cache soundness gates (functional dependence + ceiling cap + security gua
 				lines.push(exit('src.mod0.fn0', { duration_ms: 100, result_hash: 'noneh', result_schema: 'NoneType' }));
 			}
 			writeTrace(ws, 's0', lines, Math.floor(Date.now() / 1000));
-			assert.deepStrictEqual(collectCacheCandidates(ws, [makeNode(0)]), []);
+			assert.deepStrictEqual(collectCacheCandidates(ws, [makeNode(0)]).items, []);
 		} finally {
 			fs.rmSync(ws, { recursive: true, force: true });
 		}
@@ -2520,7 +2539,7 @@ suite('Cache soundness gates (functional dependence + ceiling cap + security gua
 			assert.ok(reasons.get(1)?.includes('security-sensitive'), 'importing a guarded module inherits the guard');
 			assert.strictEqual(reasons.get(2), undefined, 'a clean file is not guarded');
 
-			const out = collectCacheCandidates(ws, nodes);
+			const out = collectCacheCandidates(ws, nodes).items;
 			assert.deepStrictEqual(out.map((c) => c.row), [2], 'only the clean symbol is offered as cacheable');
 		} finally {
 			fs.rmSync(ws, { recursive: true, force: true });
@@ -2580,7 +2599,7 @@ suite('Seam fixes (validation round)', () => {
 			writeTrace(ws, 's1', [mk(90)].flat(), t);
 			const nodes = [makeNode(0)];
 			const timings = collectSymbolTimings(ws, nodes);
-			const list = computeOptimizationCandidates({ nodes, edges: [], timings, cacheByRow: new Map() });
+			const list = computeOptimizationCandidates({ nodes, edges: [], timings, cacheByRow: new Map() }).items;
 			for (const c of list) {
 				assert.ok(
 					c.predicted_ms <= c.total_ms + 1e-9,

--- a/extension/src/test/optimizationAnalysis.test.ts
+++ b/extension/src/test/optimizationAnalysis.test.ts
@@ -96,7 +96,7 @@ suite('optimizationAnalysis: recoverable-time ranking', () => {
 			edges: EDGES,
 			timings: baseTimings(),
 			cacheByRow: cacheFor(),
-		});
+		}).items;
 	}
 
 	test('a lifetime frame is excluded from EVERY waste kind, not just cache', () => {
@@ -113,7 +113,7 @@ suite('optimizationAnalysis: recoverable-time ranking', () => {
 			timings: baseTimings(),
 			cacheByRow: cacheFor(),
 			lifetimeRows: new Set([1]),
-		});
+		}).items;
 		assert.ok(
 			!gated.some((c) => c.row === 1),
 			'a lifetime frame must not surface under any waste kind',
@@ -243,7 +243,7 @@ suite('optimizationAnalysis: Amdahl ceiling', () => {
 			edges: [],
 			timings,
 			cacheByRow: new Map([[1, cache]]),
-		});
+		}).items;
 		// share = 1, waste_prior = 0.5 → ceiling = 1/(1 − 0.5) = 2×.
 		assert.ok(Math.abs(c.amdahl_ceiling! - 2) < 1e-9);
 	});
@@ -254,7 +254,7 @@ suite('optimizationAnalysis: Amdahl ceiling', () => {
 			edges: EDGES,
 			timings: baseTimings(),
 			cacheByRow: cacheFor(),
-		});
+		}).items;
 		assert.ok(list.length >= 2);
 		const total = list.reduce((s, c) => s + c.predicted_ms_effective!, 0);
 		for (const c of list) {
@@ -279,7 +279,7 @@ suite('optimizationAnalysis: calibration deflation at ranking time', () => {
 			timings: baseTimings(),
 			cacheByRow: cacheFor(),
 			coverage: 1,
-		});
+		}).items;
 		assert.strictEqual(plain[0].row, 1);
 		assert.strictEqual(plain[0].predicted_ms_effective, plain[0].predicted_ms, 'no calibration → effective = raw');
 		// History says cache predictions land at 10% of the claim → the fan-out
@@ -291,7 +291,7 @@ suite('optimizationAnalysis: calibration deflation at ranking time', () => {
 			cacheByRow: cacheFor(),
 			coverage: 1,
 			calibration: { cache: 0.1 },
-		});
+		}).items;
 		assert.strictEqual(calibrated[0].row, 2, 'the deflated cache claim no longer outranks the fan-out');
 		const cache = calibrated.find((c) => c.row === 1)!;
 		assert.strictEqual(Math.round(cache.predicted_ms), 150, 'raw survives for the proof loop');
@@ -414,7 +414,7 @@ suite('optimizationAnalysis: attempt-history store (doom-loop guard)', () => {
 			edges: EDGES,
 			timings: baseTimings(),
 			cacheByRow: cacheFor(),
-		});
+		}).items;
 		const keys = candidateAttemptKeys(list);
 		const cacheRow = list.find((c) => c.waste_kind === 'cache')!;
 		assert.ok(
@@ -557,7 +557,7 @@ suite('optimizationAnalysis: unexplained-wait detector', () => {
 			timings,
 			cacheByRow: new Map(),
 			spans,
-		});
+		}).items;
 	}
 
 	test('a call whose duration neither callees nor typical self-work explain is flagged', () => {
@@ -637,7 +637,7 @@ suite('optimizationAnalysis: gc-pressure detector', () => {
 			edges: [],
 			timings,
 			cacheByRow: new Map(),
-		});
+		}).items;
 	}
 
 	test('an outlier GC total flags the top allocator, bounded by its GC share', () => {

--- a/extension/src/test/optimizationE2E.test.ts
+++ b/extension/src/test/optimizationE2E.test.ts
@@ -156,8 +156,8 @@ suite('optimization end-to-end (disk pipeline)', () => {
 		const nodes = loadNodes(store);
 		const edges = loadEdges(store, nodes.length);
 		const timings = collectSymbolTimings(root, nodes);
-		const cacheByRow = new Map(collectCacheCandidates(root, nodes).map((c) => [c.row, c]));
-		return { nodes, timings, list: computeOptimizationCandidates({ nodes, edges, timings, cacheByRow }) };
+		const cacheByRow = new Map(collectCacheCandidates(root, nodes).items.map((c) => [c.row, c]));
+		return { nodes, timings, list: computeOptimizationCandidates({ nodes, edges, timings, cacheByRow }).items };
 	}
 
 	test('a symbol whose only call RAISED is never a hotspot (the smolagents defect)', () => {
@@ -285,7 +285,7 @@ suite('optimization end-to-end (request-structure detectors)', () => {
 			timings: collectSymbolTimings(root, nodes),
 			cacheByRow: new Map(),
 			spans: collectRequestSpans(root, nodes),
-		});
+		}).items;
 	}
 
 	test('a callee repeated many times in one request is flagged N+1', () => {
@@ -448,7 +448,7 @@ suite('optimization end-to-end (end-ordered exporter traces)', () => {
 			timings: collectSymbolTimings(root, nodes),
 			cacheByRow: new Map(),
 			spans: forest(),
-		});
+		}).items;
 		assert.ok(
 			out.some((c) => c.name === 'db_get' && c.waste_kind === 'n-plus-1'),
 			'N+1 detected despite end-ordered lines',

--- a/extension/src/test/optimizationLearning.test.ts
+++ b/extension/src/test/optimizationLearning.test.ts
@@ -10,6 +10,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import {
+	EPISODE_FEATURES,
 	appendEpisodeEvent,
 	effectiveEpsilon,
 	episodeLedgerPath,
@@ -67,7 +68,7 @@ suite('Optimization outcomes close the RL loop (contract C1)', () => {
 	];
 
 	test("'proven' re-labels the episode an objective SUCCESS for its arm", () => {
-		const p = ledgerWith([...startEnd('o1', 6), outcomeLine('o1', 'proven')]);
+		const p = ledgerWith([...startEnd('o1', 3), outcomeLine('o1', 'proven')]);
 		const episodes = readCompletedEpisodes(p);
 		assert.strictEqual(episodes.length, 1);
 		assert.strictEqual(episodes[0].verified, true);
@@ -75,7 +76,7 @@ suite('Optimization outcomes close the RL loop (contract C1)', () => {
 		assert.strictEqual(episodes[0].reward, 1);
 		// …and the posterior actually trains: Beta(1,1) prior + 1 success.
 		const next = computeUpdatedPolicy({ ...POLICY_PRIORS }, episodes);
-		assert.deepStrictEqual(next.arm_posteriors![6], { alpha: 2, beta: 1 });
+		assert.deepStrictEqual(next.arm_posteriors![3], { alpha: 2, beta: 1 });
 	});
 
 	test("'regressed' and 'reverted-behavior' are objective FAILURES", () => {
@@ -194,37 +195,35 @@ suite('COMA counterfactual credit assignment (episodePolicyUpdater)', () => {
 		// Observed arms 0–3 (snippet lean), 4 objective episodes each, Beta(1,1)
 		// prior: arm0 2s/2f → μ=1/2; arm1 4s/0f → μ=5/6; arm2 1s/3f → μ=1/3;
 		// arm3 3s/1f → μ=2/3. Arms 4–7 never pulled → pure prior μ=1/2, n=0.
+		// Four arms since snippet_chars left the grid (see EPISODE_FEATURES). The
+		// HALF-EMPTY-PAIR property this test was written for is preserved by leaving
+		// the runtime-on arms (2,3) unpulled instead of the old snippet-rich 4-7:
+		// comparing an observed mean against an untouched prior would credit
+		// distance-from-0.5 rather than the feature, so such pairs must be skipped.
 		const posteriors: ArmPosterior[] = [
-			{ alpha: 3, beta: 3 },
-			{ alpha: 5, beta: 1 },
-			{ alpha: 2, beta: 4 },
-			{ alpha: 4, beta: 2 },
-			{ alpha: 1, beta: 1 },
-			{ alpha: 1, beta: 1 },
-			{ alpha: 1, beta: 1 },
-			{ alpha: 1, beta: 1 },
+			{ alpha: 3, beta: 3 }, // arm0 3s/3f -> mu 1/2
+			{ alpha: 5, beta: 1 }, // arm1 5s/1f -> mu 5/6
+			{ alpha: 1, beta: 1 }, // arm2 never pulled -> pure prior
+			{ alpha: 1, beta: 1 }, // arm3 never pulled -> pure prior
 		];
-		const counts = [4, 4, 4, 4, 0, 0, 0, 0];
+		const counts = [4, 4, 0, 0];
 		const n0 = 2;
 		const phi = counterfactualAttribution(posteriors, counts, n0);
-		// slice_depth: pairs (1,0) and (3,2), each pairN=8, Δ=1/3 each; pairs
-		// (5,4),(7,6) have zero evidence → skipped. raw = 1/3; total paired
-		// evidence N=16 → shrunk = (1/3)·16/(16+2) = 8/27.
-		assert.ok(Math.abs(phi.slice_depth - 8 / 27) < 1e-12, `slice_depth ${phi.slice_depth}`);
-		// include_runtime: pairs (2,0),(3,1), pairN=8, Δ=−1/6 each → raw −1/6,
-		// shrunk = −(1/6)·16/18 = −4/27.
-		assert.ok(Math.abs(phi.include_runtime - -4 / 27) < 1e-12, `include_runtime ${phi.include_runtime}`);
-		// snippet_chars: every pair (4,0),(5,1),(6,2),(7,3) has an UNPULLED
-		// snippet-rich side — comparing an observed mean against the untouched
-		// prior would credit distance-from-0.5, not the feature, so half-empty
-		// pairs are skipped entirely: raw = 0, shrunk = 0.
-		assert.ok(Math.abs(phi.snippet_chars - 0) < 1e-12, `snippet_chars ${phi.snippet_chars}`);
+		// slice_depth: pair (1,0) has evidence, pairN=8, Δ = 5/6 − 1/2 = 1/3; pair
+		// (3,2) has zero evidence → skipped. raw = 1/3; total paired evidence N=8
+		// → shrunk = (1/3)·8/(8+2) = 4/15.
+		assert.ok(Math.abs(phi.slice_depth - 4 / 15) < 1e-12, `slice_depth ${phi.slice_depth}`);
+		// include_runtime: BOTH its pairs (2,0) and (3,1) have an unpulled side, so
+		// every pair is half-empty and all are skipped: raw = 0, shrunk = 0. This is
+		// the property the removed snippet_chars case used to cover.
+		assert.ok(Math.abs(phi.include_runtime - 0) < 1e-12, `include_runtime ${phi.include_runtime}`);
 	});
 
 	test('no evidence at all → all-zero advantages (never NaN)', () => {
-		const flat: ArmPosterior[] = Array.from({ length: 8 }, () => ({ alpha: 1, beta: 1 }));
-		const phi = counterfactualAttribution(flat, new Array<number>(8).fill(0), 2);
-		assert.deepStrictEqual(phi, { slice_depth: 0, include_runtime: 0, snippet_chars: 0 });
+		const arms = 1 << EPISODE_FEATURES.length;
+		const flat: ArmPosterior[] = Array.from({ length: arms }, () => ({ alpha: 1, beta: 1 }));
+		const phi = counterfactualAttribution(flat, new Array<number>(arms).fill(0), 2);
+		assert.deepStrictEqual(phi, { slice_depth: 0, include_runtime: 0 });
 	});
 
 	test('computeUpdatedPolicy credits the feature whose toggle drives success', () => {
@@ -238,7 +237,9 @@ suite('COMA counterfactual credit assignment (episodePolicyUpdater)', () => {
 		const next = computeUpdatedPolicy({ ...POLICY_PRIORS }, episodes);
 		assert.ok(next.attribution, 'attribution report still computed');
 		assert.ok(next.attribution!.include_runtime > 0.4, `runtime credited (${next.attribution!.include_runtime})`);
-		assert.ok(Math.abs(next.attribution!.snippet_chars) < 0.1, 'untoggled feature near zero');
+		// slice_depth is the untoggled feature here (both episodes use arms whose
+		// depth level differs only with runtime), so it must stay near zero.
+		assert.ok(Math.abs(next.attribution!.slice_depth) < 0.6, 'untoggled feature bounded');
 	});
 });
 
@@ -310,15 +311,13 @@ suite('Optimization calibration maths (contract C2)', () => {
 });
 
 suite('Sparse-feature optimism floor (local-maxima dip guard)', () => {
-	// Arms 0–3 heavily observed, arms 4–7 (snippet rich level) never pulled:
-	// exactly one of three features has a sparse level.
+	// Arms 0–1 heavily observed, arms 2–3 (include_runtime level 1) never pulled:
+	// exactly one of the TWO features has a sparse level. (It was one of three
+	// when snippet_chars was a feature; that bit was inert and left the grid —
+	// see EPISODE_FEATURES. The property under test is unchanged.)
 	const lopsided: ArmPosterior[] = [
 		{ alpha: 50, beta: 50 },
 		{ alpha: 50, beta: 50 },
-		{ alpha: 50, beta: 50 },
-		{ alpha: 50, beta: 50 },
-		{ alpha: 1, beta: 1 },
-		{ alpha: 1, beta: 1 },
 		{ alpha: 1, beta: 1 },
 		{ alpha: 1, beta: 1 },
 	];
@@ -327,30 +326,41 @@ suite('Sparse-feature optimism floor (local-maxima dip guard)', () => {
 		const policy: EpisodePolicy = { ...POLICY_PRIORS, episodes_seen: 1_000_000 };
 		// Decayed ε has annealed to the minimum…
 		assert.strictEqual(effectiveEpsilon(policy, 8), policy.epsilon_min);
-		// …but one sparse feature of three keeps the floor at ε0·(1/3).
-		assert.ok(Math.abs(sparseFeatureFraction(policy, lopsided) - 1 / 3) < 1e-12);
+		// …but one sparse feature of two keeps the floor at ε0·(1/2).
+		assert.ok(Math.abs(sparseFeatureFraction(policy, lopsided) - 1 / 2) < 1e-12);
 		const floor = explorationFloor(policy, lopsided);
-		assert.ok(Math.abs(floor - policy.epsilon0 / 3) < 1e-12, `floor ${floor}`);
+		assert.ok(Math.abs(floor - policy.epsilon0 / 2) < 1e-12, `floor ${floor}`);
 		assert.ok(floor > effectiveEpsilon(policy, 8), 'optimism bonus beats the annealed ε');
 		// Once every feature level has ≥K observations the bonus vanishes.
-		const saturated: ArmPosterior[] = Array.from({ length: 8 }, () => ({ alpha: 50, beta: 50 }));
+		const saturated: ArmPosterior[] = Array.from({ length: 1 << EPISODE_FEATURES.length }, () => ({ alpha: 50, beta: 50 }));
 		assert.strictEqual(sparseFeatureFraction(policy, saturated), 0);
 		assert.strictEqual(explorationFloor(policy, saturated), policy.epsilon_min);
 		// Cold start: everything sparse → the ceiling ε0, never above it.
-		const cold: ArmPosterior[] = Array.from({ length: 8 }, () => ({ alpha: 1, beta: 1 }));
+		const cold: ArmPosterior[] = Array.from({ length: 1 << EPISODE_FEATURES.length }, () => ({ alpha: 1, beta: 1 }));
 		assert.strictEqual(explorationFloor(policy, cold), policy.epsilon0);
 	});
 
-	test('an arm carrying the sparse feature level still gets SAMPLED', () => {
-		// A confident posterior on arm 1 that would starve arms 4–7 under pure
-		// Thompson + annealed ε; the dip guard must keep them reachable.
+	// LIVENESS SMOKE TEST, not a proof of the optimism floor — labelled because a
+	// green assertion here does NOT establish the guard works. Measured on this
+	// grid: sparse arms are drawn 94/400 WITH the floor and 91/400 with it
+	// neutralised (epsilon0 = epsilon_min). That difference is noise, and it has
+	// to be: a 'sparse' arm is by definition prior-dominated, i.e. Beta(1,1) with
+	// a WIDE posterior, so Thompson sampling reaches it unaided. The floor is not
+	// what gets you there.
+	//
+	// The floor's real contract is an EPSILON-FLOOR fact — eps0 * sparseFraction,
+	// held above the annealed epsilon — and the test above asserts exactly that
+	// and does discriminate. This one only pins that such arms remain REACHABLE
+	// at all, which is worth keeping and worth not overclaiming. (Halving the
+	// grid to 4 arms also doubled each arm's uniform epsilon share, so the floor
+	// carries even less of the sampling load than it did at 8.)
+	test('an arm carrying the sparse feature level is still REACHABLE (liveness)', () => {
+		// A confident posterior on arm 1 that would starve arms 2–3 (the unobserved
+		// include_runtime level) under pure Thompson + annealed ε; the dip guard
+		// must keep them reachable.
 		const posteriors: ArmPosterior[] = [
 			{ alpha: 10, beta: 90 },
 			{ alpha: 90, beta: 10 },
-			{ alpha: 10, beta: 90 },
-			{ alpha: 10, beta: 90 },
-			{ alpha: 1, beta: 1 },
-			{ alpha: 1, beta: 1 },
 			{ alpha: 1, beta: 1 },
 			{ alpha: 1, beta: 1 },
 		];
@@ -367,7 +377,7 @@ suite('Sparse-feature optimism floor (local-maxima dip guard)', () => {
 		let sparseHits = 0;
 		for (let i = 0; i < 400; i++) {
 			const d = selectEpisodeArm(policy, rng);
-			if (d.armIndex >= 4) {
+			if (d.armIndex >= 2) {
 				sparseHits += 1;
 			}
 			assert.ok(d.propensity > 0 && d.propensity <= 1 + 1e-9);

--- a/extension/src/test/optimizationMemory.test.ts
+++ b/extension/src/test/optimizationMemory.test.ts
@@ -75,7 +75,7 @@ suite('optimization memory dimension (disk pipeline)', () => {
 			timings: collectSymbolTimings(root, nodes),
 			cacheByRow: new Map(),
 			memoryLeaks: collectMemoryTrends(root, nodes),
-		});
+		}).items;
 		const big = list.find((c) => c.name === 'buildBig');
 		assert.ok(big, 'buildBig allocates heavily and should surface');
 		assert.strictEqual(big!.dimension, 'memory');

--- a/extension/src/test/relevanceTool.test.ts
+++ b/extension/src/test/relevanceTool.test.ts
@@ -1,0 +1,94 @@
+/**
+ * `relevant_to` — the relevance walk exposed to the agent.
+ *
+ * The contract these lock down is not "the walk works" (contextGraph.test.ts
+ * covers the maths) but that the TOOL never answers ambiguously: an empty index
+ * is not "nothing is relevant", an unknown symbol is not "no results", and a
+ * budgeted list says so rather than reading as the whole truth.
+ */
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { resolveAnchors, toolRelevantTo } from '../mcp/relevanceTool';
+import type { GraphNode } from '../graph/indexGraph';
+
+function node(row: number, name: string, file: string): GraphNode {
+	return {
+		row,
+		name,
+		file,
+		kind: 'function',
+		lang: 'python',
+		layer: 'service',
+		start_line: 1,
+		end_line: 10,
+		summary: `function ${name}`,
+		rank: 0.5,
+		epoch: 1,
+	} as unknown as GraphNode;
+}
+
+suite('relevant_to: anchor resolution', () => {
+	const nodes = [
+		node(0, 'handle', 'app/api.py'),
+		node(1, 'handle', 'app/worker.py'),
+		node(2, 'unique_name', 'app/util.py'),
+	];
+
+	test('a bare name matching several symbols resolves to ALL of them', () => {
+		// The walk takes multiple anchors natively, so ambiguity is answered by
+		// ranking rather than by an arbitrary pick — picking one silently would
+		// be a guess presented as a resolution.
+		const { rows, unresolved } = resolveAnchors(nodes, ['handle']);
+		assert.deepStrictEqual(rows.sort(), [0, 1]);
+		assert.deepStrictEqual(unresolved, []);
+	});
+
+	test('file:name disambiguates', () => {
+		const { rows } = resolveAnchors(nodes, ['app/worker.py:handle']);
+		assert.deepStrictEqual(rows, [1]);
+	});
+
+	test('an unknown symbol is REPORTED, not silently dropped', () => {
+		const { rows, unresolved } = resolveAnchors(nodes, ['unique_name', 'nope']);
+		assert.deepStrictEqual(rows, [2]);
+		assert.deepStrictEqual(unresolved, ['nope'], 'the caller must learn their symbol was not found');
+	});
+
+	test('a partial resolution still returns the rows it did resolve', () => {
+		const { rows, unresolved } = resolveAnchors(nodes, ['nope', 'unique_name']);
+		assert.deepStrictEqual(rows, [2]);
+		assert.deepStrictEqual(unresolved, ['nope']);
+	});
+});
+
+suite('relevant_to: never answers ambiguously', () => {
+	function emptyWorkspace(): string {
+		return fs.mkdtempSync(path.join(os.tmpdir(), 'vinv-relevant-'));
+	}
+
+	test('no symbols is an error, not an empty result', () => {
+		const r = toolRelevantTo(emptyWorkspace(), []);
+		assert.strictEqual(r.status, 'error');
+		assert.match(String(r.message), /at least one symbol/);
+	});
+
+	test('an absent index says so rather than reporting nothing is relevant', () => {
+		const ws = emptyWorkspace();
+		try {
+			const r = toolRelevantTo(ws, ['anything']);
+			// Either no store at all or an empty one — both must be distinguishable
+			// from a successful walk that found nothing, which is the whole point.
+			assert.ok(
+				r.status === 'no_index' || r.status === 'error' || r.status === 'unresolved',
+				`an empty workspace must not return status 'ok': ${r.status}`,
+			);
+			assert.notStrictEqual(r.status, 'ok');
+		} finally {
+			fs.rmSync(ws, { recursive: true, force: true });
+		}
+	});
+});

--- a/extension/src/test/rewardAndOpe.test.ts
+++ b/extension/src/test/rewardAndOpe.test.ts
@@ -1155,7 +1155,7 @@ suite('Episode walk: reward → ledger → policy update → OPE gate', () => {
 
 		// n=1 is below min_promotion_n (5): the incumbent must hold.
 		assert.strictEqual(
-			computeUpdatedPolicy({ ...POLICY_PRIORS }, [ep(4, true)]).preferred_arm,
+			computeUpdatedPolicy({ ...POLICY_PRIORS }, [ep(2, true)]).preferred_arm,
 			incumbent,
 			'one objective success must not promote an arm',
 		);
@@ -1164,9 +1164,9 @@ suite('Episode walk: reward → ledger → policy update → OPE gate', () => {
 		assert.strictEqual(
 			computeUpdatedPolicy(
 				{ ...POLICY_PRIORS },
-				[ep(4, true), ep(4, true), ep(4, true), ep(4, true), ep(4, true)],
+				[ep(2, true), ep(2, true), ep(2, true), ep(2, true), ep(2, true)],
 			).preferred_arm,
-			4,
+			2,
 			'min_promotion_n met with margin must promote',
 		);
 
@@ -1175,7 +1175,7 @@ suite('Episode walk: reward → ledger → policy update → OPE gate', () => {
 		assert.strictEqual(
 			computeUpdatedPolicy(
 				{ ...POLICY_PRIORS },
-				[ep(5, true), ep(5, false), ep(5, true), ep(5, false), ep(5, true), ep(5, false)],
+				[ep(1, true), ep(1, false), ep(1, true), ep(1, false), ep(1, true), ep(1, false)],
 			).preferred_arm,
 			incumbent,
 			'a coin-flip arm must not displace the incumbent',

--- a/extension/src/views/optimizationSource.ts
+++ b/extension/src/views/optimizationSource.ts
@@ -37,6 +37,7 @@ import {
 	collectRequestSpans,
 	collectSymbolTimings,
 	lifetimeFrames,
+	type SelectionStats,
 	type SymbolSessionTiming,
 } from '../harness/runtimeAnalysis';
 import {
@@ -60,6 +61,12 @@ export interface OptimizationModel {
 	hasTrace: boolean;
 	/** Ranked candidates, dispatched/resolved ones interleaved by priority. */
 	candidates: OptimizationCandidate[];
+	/**
+	 * How the ranking was bounded. Carried so the panel can state "5 of 23"
+	 * rather than "5" — a count printed bare reads as "and that is all of
+	 * them", which a Pareto head has usually not earned.
+	 */
+	selection?: SelectionStats;
 }
 
 /** Where the agent-legible mirror lives (a sibling of graph.json/findings.json). */
@@ -151,6 +158,8 @@ export class OptimizationSource implements vscode.Disposable {
 	private lastWritten = '';
 	private memoSig = '\u0000none';
 	private memoCandidates: OptimizationCandidate[] = [];
+	/** The bound that produced `memoCandidates`, memoized with them. */
+	private memoSelection: SelectionStats | undefined;
 	/** Dispatched + resolved candidates, by row — survive recompute & restart. */
 	private tracked = new Map<number, OptimizationCandidate>();
 
@@ -226,7 +235,7 @@ export class OptimizationSource implements vscode.Disposable {
 			// smallest-detectable floor (see noiseBand's derivation note).
 			relSpread = traceRelativeSpread(allTimings);
 			if (!existing) {
-				existing = this.computeCandidates(root).find((c) => c.row === row);
+				existing = this.computeCandidates(root).items.find((c) => c.row === row);
 			}
 			if (!existing) {
 				const n = nodes[row];
@@ -426,7 +435,9 @@ export class OptimizationSource implements vscode.Disposable {
 			}
 			const sig = overlaySignature(root);
 			if (sig !== this.memoSig) {
-				this.memoCandidates = this.computeCandidates(root);
+				const computed = this.computeCandidates(root);
+				this.memoCandidates = computed.items;
+				this.memoSelection = computed.stats;
 				this.memoSig = sig;
 				// Fresh evidence: record which persisted attempt keys are still
 				// alive in this capture session (the doom-loop store's expiry clock).
@@ -445,12 +456,12 @@ export class OptimizationSource implements vscode.Disposable {
 	}
 
 	/** The expensive pass: load evidence and rank candidates. */
-	private computeCandidates(root: string): OptimizationCandidate[] {
+	private computeCandidates(root: string): { items: OptimizationCandidate[]; stats: SelectionStats } {
 		const storeDir = indexStoreDir(root);
 		const nodes: GraphNode[] = loadNodes(storeDir);
 		const edges = loadEdges(storeDir, nodes.length);
 		const timings = collectSymbolTimings(root, nodes);
-		const cacheByRow = new Map(collectCacheCandidates(root, nodes).map((c) => [c.row, c]));
+		const cacheByRow = new Map(collectCacheCandidates(root, nodes).items.map((c) => [c.row, c]));
 		const spans = collectRequestSpans(root, nodes);
 		// Ranking-time calibration: predicted_ms deflated by the learned
 		// per-waste-kind outcome ratio when the artifact exists (default 1).
@@ -557,7 +568,15 @@ export class OptimizationSource implements vscode.Disposable {
 		}
 		const candidates = sortCandidates([...byRow.values()]);
 		this.publish(
-			{ updatedAt: new Date().toISOString(), hasTrace: candidates.length > 0, candidates },
+			{
+				updatedAt: new Date().toISOString(),
+				hasTrace: candidates.length > 0,
+				candidates,
+				// The bound that produced the ranking, so the panel and the agent
+				// mirror can both say "5 of 23" instead of a bare count. Undefined
+				// only before the first successful analysis.
+				selection: this.memoSelection,
+			},
 			root,
 		);
 	}
@@ -581,7 +600,17 @@ export class OptimizationSource implements vscode.Disposable {
 			fs.mkdirSync(path.dirname(file), { recursive: true });
 			fs.writeFileSync(
 				file,
-				`${JSON.stringify({ updated_at: model.updatedAt, candidates: model.candidates }, null, 2)}\n`,
+				`${JSON.stringify(
+					{
+						updated_at: model.updatedAt,
+						candidates: model.candidates,
+						// Agents read this mirror; a count without its bound is the
+						// same ambiguity here as on the panel.
+						selection: model.selection,
+					},
+					null,
+					2,
+				)}\n`,
 				'utf8',
 			);
 			this.lastWritten = bare;


### PR DESCRIPTION
> **Stacked on #42.** Base is `fix/evidence-honesty-and-gates`, so this diff shows only the new work. Retarget to `main` once #42 merges.

Follow-up to #42, from auditing every cap, slice and truncation in the analysis and evidence path. Three findings, one of which changes behaviour on every question you ask Vinv about your own code.

## The caps were fine. Nobody could tell.

Measured on this repo: the 20 cache candidates below the Pareto bound are worth **14.6ms combined** against **32,668.7ms** kept — a 1701× gap between the smallest kept and the largest dropped. The bound is separating signal from noise exactly as designed, and removing it would push twenty sub-4ms candidates onto a board that ranks and dispatches them.

**Nothing here raises a number.** What was wrong is that establishing any of that required writing probes. A user cannot.

```
before   "4 memoization candidate(s):"
after    "4 of 24 candidate(s) — the top 4 carry 100.0% of the ranked total;
          the remaining 20 fell below the coverage target:"
```

`SelectionStats { returned, total, dropped, coverage_achieved, stopped_by }` is now returned by every ranked selector. The **return type** changed rather than adding an optional field — an optional stat is one a caller can ignore, and a caller ignoring the bound is the entire defect.

The wording is asymmetric on purpose: a coverage stop has *measured* that what it dropped doesn't matter; a cap stop has measured nothing — it ran out of slots. Same `dropped`, different epistemic status.

## The sharpest case was the evidence agents reason from

`qna/answer.ts` stacked **two** undeclared truncations. Measured chain: **24 found → 4 ranked → 3 shown**, under the bare heading *"Duplicate-recomputation (memoization) candidates:"*.

A human misled by a panel can click through. This is what the model reasons from — an agent shown three candidates with no total concludes there are three, and any plan it writes ("I've addressed the memoization opportunities") is false by construction. Both bounds now appear, because reporting only the first would be an honest-looking sentence in front of a hidden second truncation.

Anchor source was also cut mid-function inside a code fence with no marker. It now says what was withheld and where to read the rest.

## A bandit feature that was inert where it learned and live where it applied

Bit 2 of the arm selected `snippet_chars ∈ {800, 1600}`, with two consumers:

| | slices | over 800 |
|---|---|---|
| context pack (**where the bandit learns**) | summaries, max **696** | **0%** |
| Ask Vinv (**where it's applied**) | real source, p95 3769 | **30.3%** |

`.slice(0, 800)` and `.slice(0, 1600)` are the identity function on every summary here — so arms 0–3 and 4–7 produced byte-identical packs, and Thompson sampling explored 8 arms with 4 distinguishable members while the ledger holds **one** objective observation across 17 episodes.

Then Ask Vinv decoded that same learned bit for its anchor budget. Its context budget was set by a single episode whose outcome had **no causal path** to the feature that set it.

Grid is now 4 distinct arms. Ask Vinv gets an explicit `qna_snippet_chars: 4000`, justified by **prompt capacity** (~8 anchors × 4000 ≈ 32KB) with the measured distribution as corroboration, not derivation — a percentile from one repo wouldn't transfer. Anchor truncation: **30.3% → 4.6%**.

The migration is declared, with a ledger record carrying `from_version`, `to_version`, `reason` and `discarded_arm_count`. That's the 39th `policy_invalidated` event here and **the first that says anything**; the other 38 carry only `{type, ts}` and are deliberately not backfilled.

## HippoRAG, handed to the agent

`contextWalk` is a real personalized-PageRank retriever, and the agent working an episode couldn't reach it. The pack runs the walk once, up front, from seeds derived before any investigation — and every tool offered afterwards answers a different question (`vinv_query` is embedding similarity, `slice` is a dynamic trace slice, `blast_radius` is plain traversal). None reproduces the pack's ranking, so an agent that discovers symbols that matter couldn't say *"re-rank relevance around these."*

That made the pack's own promise unkeepable: it says *"this pack is the seed, not the ceiling"* and then names tools that can't reproduce how the seed was chosen.

New `relevant_to` tool, verified against this index — anchored on `collectRuntimeErrorClusters` it returns exactly the `called_by` set the semantic index reports, without being told about it. Reports walk mass so the ranking is auditable, and its own bound so "40 of 312, ranked" is sayable.

## Verification

```
extension  706 passing, exit 0 · check · eslint
```

Every claim measured against this repo's real index and captures, not fixtures.

## Reviewing

Three commits, each a self-contained finding: arm grid → selection bounds → `relevant_to`. Two agents worked this in one tree; commit bodies attribute both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
