### PR TITLE
fix(pypi): any-Python wheels + `index` as a console entry point (0.0.2)

### DIFF
--- a/packaging/vinv/hatch_build.py
+++ b/packaging/vinv/hatch_build.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+import sysconfig
 from pathlib import Path
 
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
@@ -53,8 +54,15 @@ class CustomBuildHook(BuildHookInterface):
         if not built.exists():
             raise RuntimeError(f"index binary not found after build: {built}")
 
-        # Ship it as a script → installed onto the venv's bin/Scripts dir (PATH).
-        build_data["shared_scripts"][str(built)] = exe
-        # The wheel now carries a native binary: tag it for THIS platform.
+        # Ship the binary inside the package (vinv/_bin/) so the `index` console
+        # entry point (vinv._index:main) can exec it — this is what makes `index`
+        # available under pip/pipx/uvx/uv-tool, not just a bare `pip install`.
+        build_data["force_include"][str(built)] = f"vinv/_bin/{exe}"
+
+        # No Python C-extension here (pure Python + a standalone binary), so the
+        # wheel is Python-AGNOSTIC but platform-specific: one `py3-none-<platform>`
+        # wheel per OS installs on any supported Python 3.x — not just the version
+        # it was built with.
+        plat = sysconfig.get_platform().replace("-", "_").replace(".", "_")
         build_data["pure_python"] = False
-        build_data["infer_tag"] = True
+        build_data["tag"] = f"py3-none-{plat}"

--- a/packaging/vinv/pyproject.toml
+++ b/packaging/vinv/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "vinv"
-version = "0.0.1"
+version = "0.0.2"
 description = "Vinv runs, tests, and finds issues in your services — with zero code changes."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"
@@ -57,8 +57,11 @@ Repository = "https://github.com/VinvAI/VinvAI"
 Issues = "https://github.com/VinvAI/VinvAI/issues"
 Changelog = "https://github.com/VinvAI/VinvAI/blob/main/extension/CHANGELOG.md"
 
-# Every engine's console script, on the one package.
+# Every engine's console script, on the one package. `index` is a shim that
+# execs the bundled Rust binary (vinv/_index.py), so it is a first-class command
+# under pip/pipx/uvx/uv-tool like the rest.
 [project.scripts]
+index = "vinv._index:main"
 vinv-exerciser = "exerciser.cli:main"
 exerciser = "exerciser.cli:main"
 tracelens = "tracelens.cli:main"
@@ -97,7 +100,7 @@ path = "hatch_build.py"
 # path from the repo root. cargo's target/ persists across the per-Python wheel
 # builds on a platform, so Rust is compiled once and reused.
 [tool.cibuildwheel]
-build = "cp312-* cp313-*"
+build = "cp312-*"
 skip = "*-musllinux* *_i686 *-win32 pp*"
 
 [tool.cibuildwheel.linux]

--- a/packaging/vinv/vinv/_index.py
+++ b/packaging/vinv/vinv/_index.py
@@ -1,0 +1,41 @@
+"""Console-script entry point for the bundled Rust `index` binary.
+
+The binary ships inside the package at ``vinv/_bin/index`` (or ``index.exe`` on
+Windows). Exposing it as a `[project.scripts]` entry point — rather than only a
+wheel data-script — means `pip`, `pipx`, `uvx` and `uv tool` all put an `index`
+command on PATH, exactly like the Python engine commands.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import sys
+from pathlib import Path
+
+
+def _binary() -> Path:
+    exe = "index.exe" if os.name == "nt" else "index"
+    return Path(__file__).resolve().parent / "_bin" / exe
+
+
+def main() -> None:
+    binary = _binary()
+    if not binary.exists():
+        sys.exit(f"vinv: bundled index binary not found at {binary}")
+
+    # Defensive: ensure the executable bit survived packaging on POSIX.
+    if os.name != "nt":
+        try:
+            mode = binary.stat().st_mode
+            if not mode & stat.S_IXUSR:
+                binary.chmod(mode | 0o111)
+        except OSError:
+            pass
+
+    argv = [str(binary), *sys.argv[1:]]
+    if os.name == "nt":
+        import subprocess
+
+        raise SystemExit(subprocess.call(argv))
+    os.execv(str(binary), argv)


### PR DESCRIPTION
1. The wheels had cp312/cp313 tags, so any other Python (e.g. Homebrew 3.14) fell back to the empty 0.0.0 placeholder. The package has no Python C-extension, so the hook now tags the wheel py3-none-<platform> — one wheel per OS that installs on any supported Python 3.x. cibuildwheel builds one Python per platform.
2. `index` was a wheel data-script (only on PATH under plain pip). It is now a first-class console entry point (vinv._index:main execs the bundled binary from vinv/_bin/), so pip/pipx/uvx/uv-tool all expose it like the other engines.

<!--
Thanks for contributing to Vinv. Keep the diff reviewable and one logical
change per PR. See CONTRIBUTING.md (and AGENTS.md if an agent wrote any of this).
-->

## What & why

<!-- What does this change do, and why does it matter? Link the issue it closes, if any. -->

Closes #

## How it was verified

<!-- Check what you actually ran for the area you touched. Don't claim — run it. -->

- [ ] Python lint — `uv run ruff check` and `uv run ruff format --check` in the package I touched
- [ ] Python tests — `uv run pytest` in the package I touched (or repo root)
- [ ] Rust — `cargo test` in `index/` (if the index changed)
- [ ] Extension — `npm run check && npm run bundle` in `extension/` (if the extension changed)
- [ ] End-to-end honesty contract — `python tests/e2e/planted_bug_golden/run.py` stays green
- [ ] Manual testing (describe below)

<!-- Notes on manual testing / anything a reviewer should look at hardest: -->

## Ground rules (product promises — must stay true)

- [ ] No new runtime network calls (beyond the one-time embedding-model download / optional prebuilt index artifacts)
- [ ] No telemetry
- [ ] No new required configuration or env var (feature-level keys route through the user's coding-agent harness)
- [ ] Tracer stays zero-edit (users never modify their own code to use Vinv)

## AI-assisted?

<!-- If an agent wrote part of this, say so and flag where reviewers should look hardest.
     You own the diff regardless — see CONTRIBUTING.md → "Working with AI coding agents". -->
