### PR TITLE
fix(harness): codex exec rejects removed --full-auto flag

### DIFF
--- a/extension/src/harness/harnessRunner.ts
+++ b/extension/src/harness/harnessRunner.ts
@@ -161,10 +161,22 @@ export const HARNESSES: ReadonlyArray<HarnessDef> = [
 		id: 'codex',
 		label: 'Codex CLI',
 		kind: 'cli',
+		bin: 'codex',
 		// `exec` is headless; `-` reads the prompt from stdin. --skip-git-repo-check
 		// because target workspaces are not necessarily git repos.
-		bin: 'codex',
-		args: 'exec --full-auto --skip-git-repo-check -',
+		//
+		// --dangerously-bypass-approvals-and-sandbox is the full-bypass mode, the peer
+		// of Claude's bypassPermissions / Cursor's --force / Gemini's --yolo above: an
+		// episode fixes code and runs bring-up commands with zero human approval.
+		//
+		// We do NOT use `--full-auto`: newer Codex CLIs (0.128+) rejected it on `exec`
+		// outright — "unexpected argument '--full-auto'". Its documented replacement,
+		// `--sandbox workspace-write`, is ALSO wrong here: Codex's sandbox is OS-enforced
+		// (Linux seccomp / macOS Seatbelt) and does not exist on Windows, so there
+		// workspace-write silently collapses to read-only and EVERY command — even an
+		// in-workspace write — is "rejected: blocked by policy" (verified, Codex 0.150.1
+		// on Windows). Full bypass is the only mode that operates on all three platforms.
+		args: 'exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check -',
 		installHint: 'Install with `npm install -g @openai/codex` and run `codex` once to sign in.',
 		installCommand: 'npm install -g @openai/codex',
 		postInstall: 'Then run `codex` once in a terminal to sign in.',


### PR DESCRIPTION
Newer Codex CLIs (0.128+) removed --full-auto from codex exec, so episodes dispatched to the Codex harness failed immediately with error: unexpected argument '--full-auto' found.

Switch to the full-bypass mode, the peer of the other harnesses (Claude bypassPermissions, Cursor --force, Gemini --yolo). The documented replacement --sandbox workspace-write is not viable: Codex's sandbox is OS-enforced (Linux seccomp / macOS Seatbelt) and absent on Windows, where workspace-write collapses to read-only and every command is "rejected: blocked by policy". Verified end-to-end against Codex 0.150.1 on Windows.

<!--
Thanks for contributing to Vinv. Keep the diff reviewable and one logical
change per PR. See CONTRIBUTING.md (and AGENTS.md if an agent wrote any of this).
-->

What & why

The Codex harness was unusable on any machine with a recent Codex CLI. The single line exec --full-auto --skip-git-repo-check - crashed at argument-parse time because --full-auto was deprecated in Codex 0.128 and later removed from the exec subcommand. Every episode dispatched to Codex died before the model ran.

This swaps --full-auto for --dangerously-bypass-approvals-and-sandbox, which is:

The correct peer of the other CLI harnesses in harnessRunner.ts, all of which already run fully unsandboxed with zero human approval — Claude bypassPermissions, Cursor --force, Gemini --yolo. --full-auto was actually the odd one out (it kept a workspace-write sandbox).
The only mode that works cross-platform. Codex's documented replacement, --sandbox workspace-write, relies on an OS-level sandbox that doesn't exist on Windows. There it silently degrades to read-only and rejects every command — including in-workspace writes — so the fixing agent can't touch a single file. Full bypass behaves consistently on Windows, macOS, and Linux.

The commit is scoped to exactly this one line (plus its explanatory comment); no other change rides along.

Closes #54

How it was verified
Python lint — n/a (no Python touched)
Python tests — n/a (no Python touched)
Rust — n/a (index unchanged)
Extension — npm run check && npm run bundle (not run in full; see note)
End-to-end honesty contract — n/a (harness dispatch flag only)
Manual testing (described below)

What actually ran green:

The pre-commit and pre-push git hooks ran the extension TypeScript typecheck (tsc) and check-declared-deps — both passed, so the change compiles.
Live end-to-end against Codex CLI 0.150.1 on Windows 10:
Reproduced the bug: echo … | codex exec --full-auto --skip-git-repo-check - → error: unexpected argument '--full-auto' found, exit 2.
Confirmed --sandbox workspace-write is a non-fix on Windows: header reports sandbox: read-only, and an in-workspace file write is rejected: blocked by policy — file not created.
Confirmed the chosen flag works: a headless codex exec run with the new flag completed cleanly (exit 0), reported sandbox: danger-full-access, and successfully created a file in the workspace.

Reviewers should look hardest at the cross-platform reasoning — the change trades Codex's sandbox for full bypass. That's intentional and matches the existing harness contract (all CLI harnesses run unsandboxed under user opt-in), but it's the line worth scrutinizing.

Ground rules (product promises — must stay true)
No new runtime network calls (beyond the one-time embedding-model download / optional prebuilt index artifacts)
No telemetry (this diff is the flag change only; no telemetry code is included)
No new required configuration or env var (feature-level keys route through the user's coding-agent harness)
Tracer stays zero-edit (users never modify their own code to use Vinv)
AI-assisted?

Yes — diagnosis, fix, and the live Windows verification were done by an AI agent (Claude). Reviewers should focus on the sandbox trade-off described above. The author owns the diff per CONTRIBUTING.md.