### PR TITLE
Fix/cli invocation expect exit

### DIFF
--- a/exerciser/src/exerciser/campaign.py
+++ b/exerciser/src/exerciser/campaign.py
@@ -58,7 +58,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from . import exception_policy, store
+from . import exception_policy, issues, store
 from .bandit import Action, ActionBandit, Outcome, seed_actions_from_prior
 from .interpreter import resolve_cached
 
@@ -432,18 +432,10 @@ class OracleConfig:
     _signature_contracts: dict[str, dict[str, str]] = field(default_factory=dict)
 
 
-def _cluster_signature(cluster: dict[str, Any]) -> str:
-    """A stable identity for one cluster.
-
-    Every oracle's cluster document carries ``signature`` (``issues.normalize_
-    signature``), which is exactly the digit-normalised identity the rest of Vinv
-    dedupes on. The fallback exists only so a hand-written or older document
-    still dedupes on SOMETHING rather than silently paying twice.
-    """
-    sig = cluster.get("signature")
-    if isinstance(sig, str) and sig:
-        return sig
-    return "|".join(str(cluster.get(k, "")) for k in ("kind", "endpoint_id", "title"))
+#: Moved to `issues` so any oracle can publish without importing the campaign —
+#: the invocation oracle runs whether or not a campaign does. Re-exported here
+#: because this module's own call sites (and its tests) still name them.
+_cluster_signature = issues.cluster_signature
 
 
 def _findings(
@@ -486,51 +478,13 @@ def _merge_into_issues(
     *,
     logger: logging.Logger | None = None,
 ) -> int:
-    """Publish the oracles' clusters into ``issues.json``. Returns how many were new.
+    """Publish the campaign's oracle clusters into ``issues.json``.
 
-    This is the step that was missing, and without it the five newer oracles
-    were unreachable in practice however correct they were. Each writes its own
-    artifact (``functions.json``, ``differential.json``, …), and the campaign
-    kept only signatures for credit accounting — but the extension's dispatch
-    path (``exerciseStateFromArtifacts`` → ``clustersToEpisodes`` →
-    ``dispatchIssueEpisode``) reads exactly ONE file: ``issues.json``. So a
-    campaign could find real defects and surface none of them.
-
-    Merging rather than overwriting, keyed on signature, because ``run`` owns
-    this file for the HTTP oracle and both sets of findings are real. The
-    extension already dedupes dispatches by signature, so a cluster appearing
-    here twice across passes costs nothing.
-
-    ORDERING REQUIREMENT: the campaign must run AFTER ``run`` in a pass, since
-    ``run`` rewrites this file wholesale. ``exerciseRunner`` invokes it last.
+    Thin wrapper over :func:`issues.merge_into_issues`, which owns the merge now
+    that oracles outside a campaign publish too. Keeps the campaign's own
+    signature-keyed dict, whose keys are already cluster signatures.
     """
-    log = logger or logging.getLogger(__name__)
-    if not clusters:
-        return 0
-    path = store.issues_path(repo)
-    doc = store.read_json(path)
-    existing = doc.get("clusters") if isinstance(doc, dict) else None
-    by_sig: dict[str, dict[str, Any]] = {}
-    if isinstance(existing, list):
-        for c in existing:
-            if isinstance(c, dict):
-                by_sig[_cluster_signature(c)] = c
-    before = len(by_sig)
-    for sig, cluster in clusters.items():
-        by_sig.setdefault(sig, cluster)
-    ordered = sorted(by_sig.values(), key=lambda c: (str(c.get("kind")), str(c.get("path"))))
-    store.write_json(
-        path,
-        {"version": 1, "cluster_count": len(ordered), "clusters": ordered},
-    )
-    added = len(by_sig) - before
-    log.info(
-        "campaign: published %d oracle cluster(s) into issues.json (%d new, %d total)",
-        len(clusters),
-        added,
-        len(ordered),
-    )
-    return added
+    return issues.merge_into_issues(repo, clusters.values(), logger=logger)
 
 
 def _clusters_of(

--- a/exerciser/src/exerciser/coverage.py
+++ b/exerciser/src/exerciser/coverage.py
@@ -157,6 +157,56 @@ def handler_observed_in_trace(
     return any(comp == handler or comp.endswith(suffix) for comp in scan.components)
 
 
+def root_symbol_in_trace(
+    repo: Path,
+    *,
+    service: str | None = None,
+    trace: str | None = None,
+) -> str | None:
+    """The outermost instrumented symbol a capture entered, or None.
+
+    A CLI invocation has no declared handler and no ``module:qualname`` target,
+    so it reached :func:`endpoint_coverage` with no root for the static tree —
+    and a unit with no denominator reports 0/0 however much of it ran. That is
+    why a repo whose every unit is a CLI invocation showed zero coverage while
+    its traces held thousands of spans.
+
+    The trace itself names the root: tracelens instruments one target package,
+    so the shallowest ``enter`` is where the run crossed into it. A wrapper
+    script outside the package leaves several depth-0 entries rather than one
+    (each top-level call into the package is its own root); the first is taken,
+    which is the entry the run actually began at. That yields a real reachable
+    set to measure against instead of nothing.
+    """
+    try:
+        path = _resolve_trace_file(Path(repo), service, trace)
+    except (FileNotFoundError, OSError):
+        return None
+    best: tuple[int, str] | None = None
+    try:
+        with path.open(encoding="utf-8") as fh:
+            for line in fh:
+                if '"component"' not in line or '"enter"' not in line:
+                    continue
+                try:
+                    ev = json.loads(line)
+                except ValueError:
+                    continue
+                if not isinstance(ev, dict) or ev.get("event") != "enter":
+                    continue
+                comp, depth = ev.get("component"), ev.get("depth")
+                if not isinstance(comp, str) or not comp:
+                    continue
+                level = depth if isinstance(depth, int) and not isinstance(depth, bool) else 0
+                if best is None or level < best[0]:
+                    best = (level, comp)
+                if best[0] == 0:
+                    break
+    except OSError:
+        return None
+    return best[1] if best else None
+
+
 def _normalize_handler(handler: str | None) -> str | None:
     """Display-form handler ("items-read_items()") → bare function name."""
     if not handler:

--- a/exerciser/src/exerciser/invocations.py
+++ b/exerciser/src/exerciser/invocations.py
@@ -61,20 +61,73 @@ def _tail(text: str | None) -> str:
     return redact_text(trimmed) if len(text) <= _TAIL_CHARS else "…" + redact_text(trimmed)
 
 
+def _verified_expect_exits(repo: Path, service_name: Any) -> dict[str, int]:
+    """``id -> expect_exit`` from a service's verified bring-up record.
+
+    ``services.json`` is the inventory the AGENT writes, before anything has
+    run. ``.vinv/start_commands/<service>.json`` is what bring-up writes AFTER
+    verifying each invocation, so it is the only file that knows a command's
+    real exit code. Where the agent omitted ``expect_exit`` — which it may, the
+    field is optional and defaults to 0 — the inventory claims 0 for a command
+    bring-up watched exit 3 and verified as correct. The exerciser then read the
+    inventory, compared 3 against 0, and reported a working command as an error.
+
+    Observed on a real repo: four of fourteen CLI invocations (documented exits
+    of 10, 3, 10 and 2) were all flagged as defects.
+    """
+    if not isinstance(service_name, str) or not service_name.strip():
+        return {}
+    doc = store.read_json(repo / ".vinv" / "start_commands" / f"{service_name}.json") or {}
+    if not isinstance(doc, dict):
+        return {}
+    out: dict[str, int] = {}
+    for inv in doc.get("invocations") or []:
+        if not isinstance(inv, dict):
+            continue
+        ident, expect = inv.get("id"), inv.get("expect_exit")
+        if (
+            isinstance(ident, str)
+            and ident.strip()
+            and isinstance(expect, int)
+            and not isinstance(expect, bool)
+        ):
+            out[ident.strip()] = expect
+    return out
+
+
 def read_services(repo: Path) -> list[dict[str, Any]]:
     """The run-to-completion services in ``.vinv/services.json``.
 
     Read directly rather than through bringup: this package does not depend on
     the renderer, and the field contract is the file, not the code that wrote
     it.
+
+    Each service's invocations are backfilled from its verified bring-up record
+    (see :func:`_verified_expect_exits`), which is the only place a command's
+    real expected exit code is known.
     """
     doc = store.read_json(repo / ".vinv" / "services.json") or {}
     services = doc.get("services") if isinstance(doc, dict) else None
     if not isinstance(services, list):
         return []
-    return [
+    kept = [
         s for s in services if isinstance(s, dict) and s.get("kind") in _RUN_TO_COMPLETION_KINDS
     ]
+    for svc in kept:
+        verified = _verified_expect_exits(repo, svc.get("name"))
+        if not verified:
+            continue
+        invocations = svc.get("invocations")
+        if not isinstance(invocations, list):
+            continue
+        for inv in invocations:
+            # Only fill a GAP: an expect_exit the agent stated explicitly is a
+            # deliberate declaration and outranks the observed run.
+            if isinstance(inv, dict) and not isinstance(inv.get("expect_exit"), int):
+                ident = inv.get("id")
+                if isinstance(ident, str) and ident.strip() in verified:
+                    inv["expect_exit"] = verified[ident.strip()]
+    return kept
 
 
 def library_driver_command(project_root: Path, service_name: str) -> str:

--- a/exerciser/src/exerciser/invocations.py
+++ b/exerciser/src/exerciser/invocations.py
@@ -34,7 +34,7 @@ from typing import Any
 
 from . import store, tracing
 from .invocation_render import invocation_slug, render_invocation
-from .issues import build_clusters
+from .issues import build_clusters, merge_into_issues
 from .redact import redact_text
 
 #: Wall-clock ceiling for one invocation. A CLI that outruns this is reported as
@@ -550,6 +550,13 @@ def run_invocations(
     }
     store.write_jsonl(store.exercise_dir(repo) / "invocation_results.jsonl", rows)
     store.write_json(store.exercise_dir(repo) / "invocations.json", result)
+    # Publish into issues.json — the ONE file the extension's Findings view and
+    # fix-episode dispatcher read. Writing only invocations.json stranded every
+    # CLI failure: correctly found, correctly clustered, and invisible. The
+    # campaign publishes its own oracles, but it does not always run — on a
+    # CLI-only repo it stops with 'no-actions' before publishing anything — so
+    # this oracle cannot delegate the step.
+    result["issues_published"] = merge_into_issues(repo, (c.to_json() for c in clusters), logger=lg)
     lg.info(
         "invocations: %d run across %d service(s), %d failing, %d clusters",
         len(rows),

--- a/exerciser/src/exerciser/issues.py
+++ b/exerciser/src/exerciser/issues.py
@@ -15,10 +15,14 @@ evidence (failing input, expected-vs-got, covered frames) attached.
 from __future__ import annotations
 
 import hashlib
+import logging
 import re
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
+
+from . import store
 
 _DIGITS = re.compile(r"\d+")
 _WS = re.compile(r"\s+")
@@ -246,3 +250,70 @@ def issues_document(clusters: list[FailureCluster]) -> dict[str, Any]:
         "cluster_count": len(clusters),
         "clusters": [c.to_json() for c in clusters],
     }
+
+
+def cluster_signature(cluster: dict[str, Any]) -> str:
+    """A stable identity for one cluster.
+
+    Every oracle's cluster document carries ``signature`` (:func:`normalize_
+    signature`), which is exactly the digit-normalised identity the rest of Vinv
+    dedupes on. The fallback exists only so a hand-written or older document
+    still dedupes on SOMETHING rather than silently paying twice.
+    """
+    sig = cluster.get("signature")
+    if isinstance(sig, str) and sig:
+        return sig
+    return "|".join(str(cluster.get(k, "")) for k in ("kind", "endpoint_id", "title"))
+
+
+def merge_into_issues(
+    repo: Path,
+    clusters: Iterable[dict[str, Any]],
+    *,
+    logger: logging.Logger | None = None,
+) -> int:
+    """Publish an oracle's clusters into ``issues.json``. Returns how many were new.
+
+    ``issues.json`` is the ONLY file the extension's dispatch path reads
+    (``exerciseStateFromArtifacts`` -> ``clustersToEpisodes`` ->
+    ``dispatchIssueEpisode``), so a cluster that never lands here is invisible:
+    no Findings row, no fix episode, however correctly it was found.
+
+    That is not hypothetical. On a CLI-only repo the invocation oracle recorded
+    four failures in ``invocations.json`` and the campaign then stopped with
+    ``no-actions`` — nothing published them, so ``issues.json`` was never
+    written and the scorecard reported zero. Any oracle that clusters must call
+    this itself rather than relying on the campaign having run.
+
+    Merges rather than overwrites, keyed on signature, because ``run`` owns this
+    file for the HTTP oracle and both sets of findings are real. The extension
+    dedupes dispatches by signature, so a cluster appearing twice costs nothing.
+
+    ORDERING: ``run`` rewrites this file wholesale, so publishers must land
+    after it in a pass.
+    """
+    log = logger or logging.getLogger(__name__)
+    incoming = [c for c in clusters if isinstance(c, dict)]
+    if not incoming:
+        return 0
+    path = store.issues_path(repo)
+    doc = store.read_json(path)
+    existing = doc.get("clusters") if isinstance(doc, dict) else None
+    by_sig: dict[str, dict[str, Any]] = {}
+    if isinstance(existing, list):
+        for c in existing:
+            if isinstance(c, dict):
+                by_sig[cluster_signature(c)] = c
+    before = len(by_sig)
+    for cluster in incoming:
+        by_sig.setdefault(cluster_signature(cluster), cluster)
+    ordered = sorted(by_sig.values(), key=lambda c: (str(c.get("kind")), str(c.get("path"))))
+    store.write_json(path, {"version": 1, "cluster_count": len(ordered), "clusters": ordered})
+    added = len(by_sig) - before
+    log.info(
+        "published %d cluster(s) into issues.json (%d new, %d total)",
+        len(incoming),
+        added,
+        len(ordered),
+    )
+    return added

--- a/exerciser/src/exerciser/profile.py
+++ b/exerciser/src/exerciser/profile.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from typing import Any
 
 from . import store
-from .coverage import endpoint_coverage
+from .coverage import endpoint_coverage, root_symbol_in_trace
 from .invariants import Observation, learn_invariants
 from .optimize import detect_opportunities
 
@@ -106,7 +106,15 @@ def _endpoint_profile(
     # A driven call is not a declared entry point, so there is no api_id to look
     # up — its `module:qualname` target IS the root. Passed as the fallback, so
     # a unit that does happen to be declared still resolves that way first.
-    unit_symbol = api_id if ep_execs and ep_execs[0].get("unit_kind") == "function_call" else None
+    unit_kind = ep_execs[0].get("unit_kind") if ep_execs else None
+    unit_symbol = api_id if unit_kind == "function_call" else None
+    if unit_kind == "cli_invocation":
+        # A CLI invocation has neither: no declared handler, and an api_id that
+        # is a slug ("svc#stats"), not a symbol. With no root the static tree
+        # cannot be built, so the unit reported 0/0 no matter how much ran —
+        # which is how a repo of pure CLIs showed zero coverage against traces
+        # holding thousands of spans. The capture names its own entry point.
+        unit_symbol = root_symbol_in_trace(repo, service=service, trace=unit_trace)
 
     cov = endpoint_coverage(
         repo,

--- a/exerciser/tests/test_functions_harness.py
+++ b/exerciser/tests/test_functions_harness.py
@@ -1607,3 +1607,84 @@ def test_a_credential_in_an_import_error_never_reaches_a_cluster(tmp_path: Path)
     assert leaked not in json.dumps(result), "and the run summary the CLI prints"
     # The diagnostic value of the message survives — only the value is gone.
     assert "validation error for Settings" in persisted
+
+
+# ---- a nested distribution under a non-identifier directory ----------------
+#
+# A workspace opened one level ABOVE the Python project. Entry points are
+# recorded workspace-relative ("proj-dir/pkg/mod.py"), so the leading directory
+# becomes part of the module path — and a hyphen is not a valid identifier.
+# Every entry point then resolves to None and discovery skips it as
+# "not-an-importable-module", which is how a real repo reported 0 function
+# targets from 99 catalogued entry points while its index was fully built.
+
+
+def _nested_project(tmp_path: Path, *, packaged: bool) -> Path:
+    """A workspace whose project lives in a HYPHENATED subdirectory."""
+    repo = tmp_path / "workspace"
+    pkg = repo / "claude-obsidian" / "claude_obsidian"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    (pkg / "cli.py").write_text("def main() -> int:\n    return 0\n", encoding="utf-8")
+    if packaged:
+        (repo / "claude-obsidian" / "pyproject.toml").write_text(
+            '[project]\nname = "claude-obsidian"\nversion = "0"\n', encoding="utf-8"
+        )
+    return repo
+
+
+def test_a_hyphenated_directory_is_not_importable_without_packaging_metadata(tmp_path):
+    """The failure mode, pinned: no marker means the only root is the repo."""
+    repo = _nested_project(tmp_path, packaged=False)
+
+    roots = detect_src_roots(repo)
+
+    assert roots == ["."], "a tree with no distribution marker has only the repo root"
+    # "claude-obsidian" is not a Python identifier, so the whole path is
+    # unimportable — the segment cannot appear in a module name.
+    assert module_name_for("claude-obsidian/claude_obsidian/cli.py", roots) is None
+
+
+def test_packaging_metadata_makes_the_nested_project_importable(tmp_path):
+    """And the fix: the marker promotes the directory to an import root."""
+    repo = _nested_project(tmp_path, packaged=True)
+
+    roots = detect_src_roots(repo)
+
+    assert "claude-obsidian" in roots, "a pyproject.toml marks a distribution root"
+    # With the prefix stripped BEFORE the identifier check, what is left is the
+    # package itself — which is importable, hyphen or not in the folder above.
+    assert module_name_for("claude-obsidian/claude_obsidian/cli.py", roots) == "claude_obsidian.cli"
+
+
+def test_an_unimportable_entrypoint_is_skipped_with_its_reason(tmp_path):
+    """Discovery must RECORD why, not just report zero targets.
+
+    The campaign's diagnostic guesses ("is the code index built?") while the
+    reason is already known; a caller can only surface the real cause if
+    discovery keeps it.
+    """
+    repo = _nested_project(tmp_path, packaged=False)
+    (repo / ".vinv").mkdir()
+    (repo / ".vinv" / "identification").mkdir()
+    (repo / ".vinv" / "identification" / "apis.json").write_text(
+        json.dumps(
+            {
+                "apis": [],
+                "entrypoints": [
+                    {
+                        "kind": "cli_command",
+                        "file": "claude-obsidian/claude_obsidian/cli.py",
+                        "handler": "main",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    targets, skipped = discover_targets(repo)
+
+    assert targets == [], "an unimportable module must not be driven"
+    assert [s["reason"] for s in skipped] == ["not-an-importable-module"]
+    assert skipped[0]["id"] == "claude-obsidian/claude_obsidian/cli.py"

--- a/exerciser/tests/test_invocations.py
+++ b/exerciser/tests/test_invocations.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from exerciser import store
 from exerciser.invocations import (
     expand_invocation,
+    read_services,
     resolved_command,
     run_invocations,
     service_invocations,
@@ -530,3 +531,62 @@ def test_a_template_that_cannot_be_filled_is_reported_not_run(tmp_path: Path) ->
     assert row["error_type"] == "MalformedInvocation"
     assert "no such parameter" in row["error"]
     assert result["failures"] == 1
+
+
+def test_expect_exit_is_backfilled_from_the_verified_bringup_record(tmp_path: Path) -> None:
+    """A verified non-zero exit is not a defect just because the agent omitted it.
+
+    ``services.json`` is written before anything runs and ``expect_exit`` is
+    optional there, so it defaults to 0. ``start_commands/<service>.json`` is
+    written after bring-up VERIFIED each invocation, so it is the only file that
+    knows a command exits 3 on purpose. Reading only the inventory reported four
+    of one real repo's fourteen CLI invocations — documented exits of 10, 3, 10
+    and 2 — as errors while they behaved exactly as designed.
+    """
+    repo = _repo(tmp_path, [])
+    service = _cli_service(
+        repo,
+        [
+            {"id": "stats", "command": f'"{_PY}" -m acme.tool 3 3'},
+            {"id": "report", "command": f'"{_PY}" -m acme.tool 3 0'},
+            {"id": "declared", "command": f'"{_PY}" -m acme.tool 3 1', "expect_exit": 1},
+        ],
+    )
+    (repo / ".vinv" / "services.json").write_text(
+        json.dumps({"services": [service]}), encoding="utf-8"
+    )
+    (repo / ".vinv" / "start_commands").mkdir()
+    (repo / ".vinv" / "start_commands" / "acme-tool.json").write_text(
+        json.dumps(
+            {
+                "service": "acme-tool",
+                "invocations": [
+                    {"id": "stats", "expect_exit": 3},
+                    # The agent already declared 1 for this one; the record
+                    # disagreeing must not override an explicit declaration.
+                    {"id": "declared", "expect_exit": 9},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    by_id = {
+        inv["id"]: inv["expect_exit"]
+        for svc in read_services(repo)
+        for inv in service_invocations(svc, repo)
+    }
+    assert by_id["stats"] == 3, "verified exit code should fill the gap the agent left"
+    assert by_id["report"] == 0, "an invocation the record says nothing about stays at 0"
+    assert by_id["declared"] == 1, "an explicit declaration outranks the observed run"
+
+
+def test_expect_exit_survives_a_missing_bringup_record(tmp_path: Path) -> None:
+    """No start_commands file (never brought up) must not break the read."""
+    repo = _repo(tmp_path, [])
+    service = _cli_service(repo, [{"id": "solo", "command": f'"{_PY}" -m acme.tool 3 0'}])
+    (repo / ".vinv" / "services.json").write_text(
+        json.dumps({"services": [service]}), encoding="utf-8"
+    )
+    invocations = [inv for svc in read_services(repo) for inv in service_invocations(svc, repo)]
+    assert [inv["expect_exit"] for inv in invocations] == [0]

--- a/exerciser/tests/test_invocations.py
+++ b/exerciser/tests/test_invocations.py
@@ -590,3 +590,50 @@ def test_expect_exit_survives_a_missing_bringup_record(tmp_path: Path) -> None:
     )
     invocations = [inv for svc in read_services(repo) for inv in service_invocations(svc, repo)]
     assert [inv["expect_exit"] for inv in invocations] == [0]
+
+
+def test_cli_invocation_gets_a_static_root_from_its_own_trace(tmp_path: Path) -> None:
+    """A CLI unit must not report 0/0 for want of a root to measure against.
+
+    endpoint_coverage roots its static tree at a handler (HTTP) or a
+    module:qualname target (a driven call). A CLI invocation has neither — its
+    api_id is a slug like "svc#stats" — so it arrived with no root and every
+    unit reported covered=0/total=0 however much ran. On a real customer repo
+    that showed 0/14 covered and symbols_total=0 against captures holding
+    thousands of spans.
+
+    The capture names its own entry: the shallowest `enter` is where the run
+    crossed into the instrumented package.
+    """
+    from exerciser.coverage import root_symbol_in_trace
+
+    trace = tmp_path / "run.trace.jsonl"
+    trace.write_text(
+        "\n".join(
+            json.dumps(row)
+            for row in [
+                {"event": "tracer_calibration"},
+                # Deliberately out of order: the deepest span is written first,
+                # so taking "the first enter" rather than the shallowest would
+                # root the tree at a leaf helper.
+                {"event": "enter", "component": "acme.util.helper", "depth": 3},
+                {"event": "enter", "component": "acme.cli.main", "depth": 0},
+                {"event": "exit", "component": "acme.cli.main", "depth": 0},
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    root = root_symbol_in_trace(tmp_path, trace=str(trace))
+    assert root == "acme.cli.main", "the shallowest enter is the entry point, not the first line"
+
+
+def test_root_symbol_is_none_without_a_usable_capture(tmp_path: Path) -> None:
+    """No trace, or a trace with no spans, degrades to None rather than raising."""
+    from exerciser.coverage import root_symbol_in_trace
+
+    assert root_symbol_in_trace(tmp_path, trace=str(tmp_path / "missing.jsonl")) is None
+    empty = tmp_path / "empty.trace.jsonl"
+    empty.write_text(json.dumps({"event": "gc_pause"}) + "\n", encoding="utf-8")
+    assert root_symbol_in_trace(tmp_path, trace=str(empty)) is None

--- a/extension/src/test/exerciseIngest.test.ts
+++ b/extension/src/test/exerciseIngest.test.ts
@@ -249,6 +249,10 @@ suite('exerciseIngest: artifacts and provenance', () => {
 			total: 3,
 			invariants: 7,
 			issues: 1,
+			// Empty here on purpose: this scorecard predates units_by_kind and
+			// carries no unit list to count, which is exactly the shape an
+			// ingested or older run has. The summary must still read it.
+			unitsByKind: {},
 		});
 	});
 

--- a/extension/src/test/noticesPayload.test.ts
+++ b/extension/src/test/noticesPayload.test.ts
@@ -1,45 +1,89 @@
-﻿import * as assert from 'assert';
+/**
+ * Validates a STAGED notice payload before it is uploaded.
+ *
+ * The live file is edited and uploaded out of band (see AGENTS.md) and the
+ * parser fails quietly in both directions that matter: `text()` slices title
+ * and body at their caps with no error, so an over-long body ships cut
+ * mid-sentence, and an `appliesTo` range that excludes the shipped version
+ * reaches nobody.
+ *
+ * The staged file is gitignored, so it is absent in CI and on any checkout that
+ * is not mid-announcement — these tests skip there rather than fail. They exist
+ * for the person editing the payload, which is the only moment the check can
+ * still prevent a bad upload.
+ */
+import * as assert from 'assert';
 import * as fs from 'fs';
+import * as path from 'path';
 import { parseNotices, selectNotice, versionSatisfies } from '../notices/notices';
 
+/** Repo root, from `extension/out/test/` at runtime. */
+const PAYLOAD = path.resolve(__dirname, '..', '..', '..', '.github', 'assets', 'notices.json');
+
+function staged(): string | null {
+	try {
+		return fs.readFileSync(PAYLOAD, 'utf8');
+	} catch {
+		return null;
+	}
+}
+
 suite('staged notices.json payload', () => {
-	const raw = fs.readFileSync('.github/assets/notices.json', 'utf8');
-
-	test('it survives the extension parser intact', () => {
+	test('it survives the extension parser intact', function () {
+		const raw = staged();
+		if (raw === null) {
+			this.skip();
+		}
 		const parsed = parseNotices(raw);
-		assert.strictEqual(parsed.length, 1);
-		const n = parsed[0];
-		const source = JSON.parse(raw).notices[0];
-		// Silent truncation is the trap: text() slices at MAX_BODY (300) with no
-		// error, so an over-long body ships cut mid-sentence.
-		assert.strictEqual(n.body, source.body, 'body was truncated by the parser');
-		assert.strictEqual(n.title, source.title, 'title was truncated by the parser');
-		assert.strictEqual(n.actions.length, 2);
+		assert.ok(parsed.length > 0, 'the staged payload parsed to no notices at all');
+		const sources = JSON.parse(raw).notices as Array<{ title: string; body?: string }>;
+		parsed.forEach((n, i) => {
+			// Silent truncation is the trap: text() slices at MAX_TITLE/MAX_BODY
+			// with no error, so an over-long field ships cut mid-sentence.
+			assert.strictEqual(n.title, sources[i].title, `notice ${n.id}: title was truncated`);
+			assert.strictEqual(n.body, sources[i].body ?? '', `notice ${n.id}: body was truncated`);
+		});
 	});
 
-	test('it reaches every version below 0.2.13 and nobody above', () => {
-		for (const v of ['0.1.5', '0.2.0', '0.2.11', '0.2.12']) {
-			assert.ok(versionSatisfies(v, '<0.2.13'), `${v} should be targeted`);
+	test('every notice targets versions below its range and none above', function () {
+		const raw = staged();
+		if (raw === null) {
+			this.skip();
 		}
-		for (const v of ['0.2.13', '0.3.0', '1.0.0']) {
-			assert.ok(!versionSatisfies(v, '<0.2.13'), `${v} must not be targeted`);
+		for (const n of parseNotices(raw)) {
+			const m = /^<(\d+\.\d+\.\d+)$/.exec(n.appliesTo);
+			if (!m) {
+				continue; // only the "<x.y.z" form is checkable this way
+			}
+			const [maj, min, patch] = m[1].split('.').map(Number);
+			const below = `${maj}.${min}.${Math.max(0, patch - 1)}`;
+			assert.ok(versionSatisfies(below, n.appliesTo), `${below} should match ${n.appliesTo}`);
+			assert.ok(!versionSatisfies(m[1], n.appliesTo), `${m[1]} must not match ${n.appliesTo}`);
 		}
 	});
 
-	test('a 0.2.12 user actually gets it, and only once', () => {
+	test('a targeted user is selected, shown once, and it has not expired', function () {
+		const raw = staged();
+		if (raw === null) {
+			this.skip();
+		}
 		const notices = parseNotices(raw);
-		const now = Date.parse('2026-09-02T00:00:00Z');
-		const chosen = selectNotice({ notices, version: '0.2.12', seenIds: [], now });
-		assert.ok(chosen, 'a 0.2.12 user must be shown the notice');
+		const now = Date.now();
+		for (const n of notices) {
+			assert.ok(Date.parse(n.expires) > now, `notice ${n.id} is already expired`);
+		}
+		const m = /^<(\d+\.\d+\.\d+)$/.exec(notices[0].appliesTo);
+		if (!m) {
+			return;
+		}
+		const [maj, min, patch] = m[1].split('.').map(Number);
+		const targeted = `${maj}.${min}.${Math.max(0, patch - 1)}`;
+		const chosen = selectNotice({ notices, version: targeted, seenIds: [], now });
+		assert.ok(chosen, `a ${targeted} user must be shown a notice`);
 		assert.strictEqual(
-			selectNotice({ notices, version: '0.2.12', seenIds: [chosen.id], now }),
+			selectNotice({ notices, version: targeted, seenIds: [chosen.id], now }),
 			null,
 			'a seen notice must not repeat',
 		);
-	});
-
-	test('it has not expired', () => {
-		const notices = parseNotices(raw);
-		assert.ok(Date.parse(notices[0].expires) > Date.now(), 'notice is already expired');
 	});
 });

--- a/extension/src/test/noticesPayload.test.ts
+++ b/extension/src/test/noticesPayload.test.ts
@@ -1,0 +1,45 @@
+﻿import * as assert from 'assert';
+import * as fs from 'fs';
+import { parseNotices, selectNotice, versionSatisfies } from '../notices/notices';
+
+suite('staged notices.json payload', () => {
+	const raw = fs.readFileSync('.github/assets/notices.json', 'utf8');
+
+	test('it survives the extension parser intact', () => {
+		const parsed = parseNotices(raw);
+		assert.strictEqual(parsed.length, 1);
+		const n = parsed[0];
+		const source = JSON.parse(raw).notices[0];
+		// Silent truncation is the trap: text() slices at MAX_BODY (300) with no
+		// error, so an over-long body ships cut mid-sentence.
+		assert.strictEqual(n.body, source.body, 'body was truncated by the parser');
+		assert.strictEqual(n.title, source.title, 'title was truncated by the parser');
+		assert.strictEqual(n.actions.length, 2);
+	});
+
+	test('it reaches every version below 0.2.13 and nobody above', () => {
+		for (const v of ['0.1.5', '0.2.0', '0.2.11', '0.2.12']) {
+			assert.ok(versionSatisfies(v, '<0.2.13'), `${v} should be targeted`);
+		}
+		for (const v of ['0.2.13', '0.3.0', '1.0.0']) {
+			assert.ok(!versionSatisfies(v, '<0.2.13'), `${v} must not be targeted`);
+		}
+	});
+
+	test('a 0.2.12 user actually gets it, and only once', () => {
+		const notices = parseNotices(raw);
+		const now = Date.parse('2026-09-02T00:00:00Z');
+		const chosen = selectNotice({ notices, version: '0.2.12', seenIds: [], now });
+		assert.ok(chosen, 'a 0.2.12 user must be shown the notice');
+		assert.strictEqual(
+			selectNotice({ notices, version: '0.2.12', seenIds: [chosen.id], now }),
+			null,
+			'a seen notice must not repeat',
+		);
+	});
+
+	test('it has not expired', () => {
+		const notices = parseNotices(raw);
+		assert.ok(Date.parse(notices[0].expires) > Date.now(), 'notice is already expired');
+	});
+});


### PR DESCRIPTION
<!--
Thanks for contributing to Vinv. Keep the diff reviewable and one logical
change per PR. See CONTRIBUTING.md (and AGENTS.md if an agent wrote any of this).
-->

## What & why

<!-- What does this change do, and why does it matter? Link the issue it closes, if any. -->

Closes #

## How it was verified

<!-- Check what you actually ran for the area you touched. Don't claim — run it. -->

- [ ] Python lint — `uv run ruff check` and `uv run ruff format --check` in the package I touched
- [ ] Python tests — `uv run pytest` in the package I touched (or repo root)
- [ ] Rust — `cargo test` in `index/` (if the index changed)
- [ ] Extension — `npm run check && npm run bundle` in `extension/` (if the extension changed)
- [ ] End-to-end honesty contract — `python tests/e2e/planted_bug_golden/run.py` stays green
- [ ] Manual testing (describe below)

<!-- Notes on manual testing / anything a reviewer should look at hardest: -->

## Ground rules (product promises — must stay true)

- [ ] No new runtime network calls (beyond the one-time embedding-model download / optional prebuilt index artifacts)
- [ ] No telemetry
- [ ] No new required configuration or env var (feature-level keys route through the user's coding-agent harness)
- [ ] Tracer stays zero-edit (users never modify their own code to use Vinv)

## AI-assisted?

<!-- If an agent wrote part of this, say so and flag where reviewers should look hardest.
     You own the diff regardless — see CONTRIBUTING.md → "Working with AI coding agents". -->
