### PR TITLE
Feat/hourly notice check

### DIFF
--- a/extension/src/notices/notices.ts
+++ b/extension/src/notices/notices.ts
@@ -21,10 +21,16 @@
  *     even if the endpoint keeps serving it;
  *   - one per activation, and off with a single setting.
  *
- * THIS IS THE EXTENSION'S ONLY OUTBOUND REQUEST. It is a GET of a static file:
- * no query string, no identifiers, no version, nothing uploaded. All filtering
- * happens here, on the client, precisely so the request carries nothing. It
- * follows no redirects, and the URL is a constant no setting can repoint.
+ * THIS REQUEST UPLOADS NOTHING. It is a GET of a static file: no query string,
+ * no identifiers, no version. All filtering happens here, on the client,
+ * precisely so the request carries nothing. It follows no redirects, and the
+ * URL is a constant no setting can repoint.
+ *
+ * It is no longer the extension's only outbound request — usage telemetry is
+ * the other one, and it is a very different thing: it uploads. See the header
+ * of src/telemetry/index.ts for what it sends and what gates it. Keeping that
+ * distinction visible here matters, because the guarantees below are this
+ * module's, not the extension's.
  *
  * THE PAYLOAD IS UNTRUSTED. It cannot name a VS Code command — the file picks
  * from the closed set in `resolveAction`, and link targets are https on an
@@ -46,8 +52,25 @@ const LAST_FETCH_KEY = 'vinv.notices.lastFetch';
 /**
  * Minimum gap between fetches. Activation runs on every window, and a user with
  * six windows open reloading all day must not turn into six requests an hour.
+ * The stamp lives in `globalState`, which is shared across windows, so this
+ * bounds the whole machine rather than one window.
  */
-const MIN_FETCH_INTERVAL_MS = 12 * 60 * 60 * 1000;
+const MIN_FETCH_INTERVAL_MS = 60 * 60 * 1000;
+
+/**
+ * How often the check re-runs while a window stays open.
+ *
+ * Activation alone was the only trigger, which made the real reach of a notice
+ * "whenever this person next restarts their editor" — unbounded for anyone who
+ * leaves it running for days, which is most people mid-project. Lowering the
+ * fetch gap could not fix that on its own: with nothing re-invoking the check,
+ * a shorter gap only mattered to someone who was restarting anyway.
+ *
+ * The two are deliberately equal. The timer proposes, `MIN_FETCH_INTERVAL_MS`
+ * disposes: every tick still goes through the same gap check against shared
+ * state, so N windows ticking together still yield at most one request an hour.
+ */
+const CHECK_INTERVAL_MS = 60 * 60 * 1000;
 
 /** Response cap. A notices file is a few KB; anything larger is not one. */
 const MAX_BYTES = 64 * 1024;
@@ -393,13 +416,47 @@ async function runAction(action: NoticeAction): Promise<void> {
 	}
 }
 
+/** Set once the repeating check is armed for this window. */
+let repeatTimer: ReturnType<typeof setInterval> | undefined;
+
+/**
+ * Arms the repeating check, once per extension host.
+ *
+ * Idempotent because activation is not: a window reload calls in again, and a
+ * second interval would double this window's tick rate for the rest of the
+ * session. Disposed with the extension so a reload cannot leave the old timer
+ * running beside the new one.
+ */
+function armRepeatingCheck(context: vscode.ExtensionContext): void {
+	if (repeatTimer !== undefined) {
+		return;
+	}
+	repeatTimer = setInterval(() => {
+		void maybeShowNotices(context);
+	}, CHECK_INTERVAL_MS);
+	context.subscriptions.push({
+		dispose: () => {
+			if (repeatTimer !== undefined) {
+				clearInterval(repeatTimer);
+				repeatTimer = undefined;
+			}
+		},
+	});
+}
+
 /**
  * Fetches the notices file and shows at most one notice.
  *
  * Called on activation and never awaited: a slow endpoint must not delay the
- * window, and a missing one must not say anything.
+ * window, and a missing one must not say anything. The first call also arms an
+ * hourly repeat, so a notice reaches a window that stays open instead of
+ * waiting for the next editor restart.
  */
 export async function maybeShowNotices(context: vscode.ExtensionContext): Promise<void> {
+	// Armed before the enabled check, and before the interval gate returns: this
+	// is what makes the check periodic at all, and a caller that returns early
+	// today must still be checking an hour from now.
+	armRepeatingCheck(context);
 	if (!noticesEnabled()) {
 		return;
 	}

--- a/extension/src/notices/notices.ts
+++ b/extension/src/notices/notices.ts
@@ -58,7 +58,7 @@ const LAST_FETCH_KEY = 'vinv.notices.lastFetch';
  * fetch gap could not fix that on its own: with nothing re-invoking the check,
  * a shorter gap only mattered to someone who was restarting anyway.
  */
-const CHECK_INTERVAL_MS = 60 * 60 * 1000;
+export const CHECK_INTERVAL_MS = 60 * 60 * 1000;
 
 /**
  * Minimum gap between fetches. Activation runs on every window, and a user with
@@ -75,7 +75,22 @@ const CHECK_INTERVAL_MS = 60 * 60 * 1000;
  * pass, so the effect compounds rather than settling. Five minutes of slack is
  * far more than the drift and still bounds the machine to one request an hour.
  */
-const MIN_FETCH_INTERVAL_MS = CHECK_INTERVAL_MS - 5 * 60 * 1000;
+export const MIN_FETCH_INTERVAL_MS = CHECK_INTERVAL_MS - 5 * 60 * 1000;
+
+/**
+ * Whether a check running at `now` should fetch, given the last attempt.
+ *
+ * Split out from the fetch itself so the schedule is testable without a window:
+ * the bug this replaced (tick and gap equal, so every other tick returned early)
+ * was invisible in a function that also needed globalState and a toast.
+ *
+ * `lastFetch` of 0 is a fresh install with nothing stored, which fetches at
+ * once — the first activation after an install is exactly when a notice about
+ * the version just installed matters most.
+ */
+export function shouldFetchNow(now: number, lastFetch: number): boolean {
+	return now - lastFetch >= MIN_FETCH_INTERVAL_MS;
+}
 
 /** Response cap. A notices file is a few KB; anything larger is not one. */
 const MAX_BYTES = 64 * 1024;
@@ -467,7 +482,7 @@ export async function maybeShowNotices(context: vscode.ExtensionContext): Promis
 	}
 	const now = Date.now();
 	const last = context.globalState.get<number>(LAST_FETCH_KEY) ?? 0;
-	if (now - last < MIN_FETCH_INTERVAL_MS) {
+	if (!shouldFetchNow(now, last)) {
 		return;
 	}
 	// Stamped before the request, not after: an endpoint that hangs or 500s must

--- a/extension/src/notices/notices.ts
+++ b/extension/src/notices/notices.ts
@@ -50,14 +50,6 @@ const SEEN_KEY = 'vinv.notices.seen';
 const LAST_FETCH_KEY = 'vinv.notices.lastFetch';
 
 /**
- * Minimum gap between fetches. Activation runs on every window, and a user with
- * six windows open reloading all day must not turn into six requests an hour.
- * The stamp lives in `globalState`, which is shared across windows, so this
- * bounds the whole machine rather than one window.
- */
-const MIN_FETCH_INTERVAL_MS = 60 * 60 * 1000;
-
-/**
  * How often the check re-runs while a window stays open.
  *
  * Activation alone was the only trigger, which made the real reach of a notice
@@ -65,12 +57,25 @@ const MIN_FETCH_INTERVAL_MS = 60 * 60 * 1000;
  * leaves it running for days, which is most people mid-project. Lowering the
  * fetch gap could not fix that on its own: with nothing re-invoking the check,
  * a shorter gap only mattered to someone who was restarting anyway.
- *
- * The two are deliberately equal. The timer proposes, `MIN_FETCH_INTERVAL_MS`
- * disposes: every tick still goes through the same gap check against shared
- * state, so N windows ticking together still yield at most one request an hour.
  */
 const CHECK_INTERVAL_MS = 60 * 60 * 1000;
+
+/**
+ * Minimum gap between fetches. Activation runs on every window, and a user with
+ * six windows open reloading all day must not turn into six requests an hour.
+ * The stamp lives in `globalState`, which is shared across windows, so this
+ * bounds the whole machine rather than one window.
+ *
+ * DELIBERATELY SHORTER THAN `CHECK_INTERVAL_MS`, and that margin is load-
+ * bearing. The timer's origin is the moment the check was armed; the stamp is
+ * written a moment LATER, when the fetch actually starts. Equal values make the
+ * tick land a few milliseconds short of the gap every time, so the check
+ * returns early, and the next tick is an hour after that — turning an hourly
+ * check into a two-hourly one. The stamp also drifts further right on each
+ * pass, so the effect compounds rather than settling. Five minutes of slack is
+ * far more than the drift and still bounds the machine to one request an hour.
+ */
+const MIN_FETCH_INTERVAL_MS = CHECK_INTERVAL_MS - 5 * 60 * 1000;
 
 /** Response cap. A notices file is a few KB; anything larger is not one. */
 const MAX_BYTES = 64 * 1024;

--- a/extension/src/test/notices.test.ts
+++ b/extension/src/test/notices.test.ts
@@ -1,7 +1,10 @@
 import * as assert from 'assert';
 import {
+	CHECK_INTERVAL_MS,
+	MIN_FETCH_INTERVAL_MS,
 	parseNotices,
 	selectNotice,
+	shouldFetchNow,
 	versionSatisfies,
 	type Notice,
 	type NoticeAction,
@@ -222,5 +225,74 @@ suite('choosing the notice to show', () => {
 	test('among equals the file order decides', () => {
 		const chosen = pick([notice({ id: 'first' }), notice({ id: 'second' })]);
 		assert.strictEqual(chosen?.id, 'first');
+	});
+});
+
+
+suite('notice delivery schedule', () => {
+	const T0 = Date.parse('2026-09-01T09:00:00Z');
+
+	test('a fresh install fetches on its first activation', () => {
+		// Nothing stored yet, so the stamp reads 0. This is the moment a notice
+		// about the version just installed matters most; making it wait an hour
+		// would be the worst possible time to be quiet.
+		assert.strictEqual(shouldFetchNow(T0, 0), true);
+	});
+
+	test('a second window moments later does not fetch again', () => {
+		// The stamp is global, so opening five windows is still one request.
+		assert.strictEqual(shouldFetchNow(T0 + 1_000, T0), false);
+	});
+
+	test('a window left open fetches again once the gap has passed', () => {
+		assert.strictEqual(shouldFetchNow(T0 + MIN_FETCH_INTERVAL_MS, T0), true);
+		assert.strictEqual(shouldFetchNow(T0 + MIN_FETCH_INTERVAL_MS - 1, T0), false);
+	});
+
+	test('the gap is shorter than the tick, or the check silently halves', () => {
+		// Load-bearing, not cosmetic: the timer's origin is when the check was
+		// armed and the stamp is written later, when the fetch starts. Equal
+		// values make every tick land just short of the gap.
+		assert.ok(
+			MIN_FETCH_INTERVAL_MS < CHECK_INTERVAL_MS,
+			'the fetch gap must be strictly shorter than the tick interval',
+		);
+	});
+
+	test('every tick fetches, across a long uninterrupted session', () => {
+		// The regression this replaced: with tick === gap this fetched on hours
+		// 1, 3 and 5 of a six-hour session rather than every hour, because the
+		// stamp lands a few ms after the tick that wrote it — and drifts further
+		// right on each pass, so the error compounds.
+		const DRIFT_MS = 40;
+		let last = 0; // fresh install
+		const fetchedAtHour: number[] = [];
+		for (let tick = 1; tick <= 6; tick++) {
+			const now = T0 + tick * CHECK_INTERVAL_MS;
+			if (shouldFetchNow(now, last)) {
+				fetchedAtHour.push(tick);
+				last = now + DRIFT_MS;
+			}
+		}
+		assert.deepStrictEqual(fetchedAtHour, [1, 2, 3, 4, 5, 6]);
+	});
+
+	test('an upload is picked up within one tick of going live', () => {
+		// The question a release asks: someone installed, never restarted, and a
+		// notice goes up. The worst case is an upload landing just after a fetch.
+		const lastFetch = T0;
+		const uploadedAt = T0 + 1_000;
+		let seenAt: number | null = null;
+		for (let tick = 1; tick <= 4 && seenAt === null; tick++) {
+			const now = T0 + tick * CHECK_INTERVAL_MS;
+			if (shouldFetchNow(now, lastFetch)) {
+				seenAt = now;
+			}
+		}
+		assert.ok(seenAt !== null, 'the notice was never picked up');
+		assert.ok(
+			seenAt - uploadedAt <= CHECK_INTERVAL_MS,
+			`picked up ${(seenAt - uploadedAt) / 60000} minutes after upload`,
+		);
 	});
 });


### PR DESCRIPTION
<!--
Thanks for contributing to Vinv. Keep the diff reviewable and one logical
change per PR. See CONTRIBUTING.md (and AGENTS.md if an agent wrote any of this).
-->

## What & why

<!-- What does this change do, and why does it matter? Link the issue it closes, if any. -->

Closes #

## How it was verified

<!-- Check what you actually ran for the area you touched. Don't claim — run it. -->

- [ ] Python lint — `uv run ruff check` and `uv run ruff format --check` in the package I touched
- [ ] Python tests — `uv run pytest` in the package I touched (or repo root)
- [ ] Rust — `cargo test` in `index/` (if the index changed)
- [ ] Extension — `npm run check && npm run bundle` in `extension/` (if the extension changed)
- [ ] End-to-end honesty contract — `python tests/e2e/planted_bug_golden/run.py` stays green
- [ ] Manual testing (describe below)

<!-- Notes on manual testing / anything a reviewer should look at hardest: -->

## Ground rules (product promises — must stay true)

- [ ] No new runtime network calls (beyond the one-time embedding-model download / optional prebuilt index artifacts)
- [ ] No telemetry
- [ ] No new required configuration or env var (feature-level keys route through the user's coding-agent harness)
- [ ] Tracer stays zero-edit (users never modify their own code to use Vinv)

## AI-assisted?

<!-- If an agent wrote part of this, say so and flag where reviewers should look hardest.
     You own the diff regardless — see CONTRIBUTING.md → "Working with AI coding agents". -->
