### PR TITLE
Feat/autopilot harness gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ htmlcov/
 /_wintest_venv/
 /list/
 /.ccache/
+/data/
 build/
 *.log
 nuitka-crash-report.xml

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Downloads](https://img.shields.io/open-vsx/dt/VinvAI/VinvAI?style=flat-square&color=D71921&label=downloads)](https://open-vsx.org/extension/VinvAI/VinvAI)
 [![Tests](https://img.shields.io/github/actions/workflow/status/VinvAI/VinvAI/test.yml?branch=main&style=flat-square&label=tests&color=19D721)](https://github.com/VinvAI/VinvAI/actions/workflows/test.yml)
 [![Open issues](https://img.shields.io/github/issues/VinvAI/VinvAI?style=flat-square&color=D71921&label=open%20issues)](https://github.com/VinvAI/VinvAI/issues)
-[![100% local](https://img.shields.io/badge/100%25%20local-no%20telemetry-D71921?style=flat-square)](#privacy)
+[![100% local](https://img.shields.io/badge/100%25-local-D71921?style=flat-square)](#privacy)
 
 # VinvAI
 
@@ -379,7 +379,7 @@ No. Vinv runs everything locally. The semantic index and code embedder run on yo
 </details>
 
 <details><summary><b>Is there any telemetry or data collection?</b></summary>
-No telemetry, no analytics, no usage pings, no crash reports. Vinv stores per-repo state in <code>.vinv/</code> and per-machine state in <code>~/.vinv/</code>; sensitive data in traces is redacted and never sent anywhere. The extension makes exactly <b>one</b> outbound request of its own: a GET of a static file at <code>notices.vinv.ai</code> on activation, so a broken release can tell you. No query string, no identifiers, nothing uploaded; at most once every 12 hours. Turn it off with <code>vinv.notices.enabled</code>.
+Your code, traces and findings never leave your machine: Vinv stores per-repo state in <code>.vinv/</code> and per-machine state in <code>~/.vinv/</code>, and sensitive data in traces is redacted. The extension sends <b>anonymous usage events</b> (which features run, whether they succeeded) to help us find what breaks — no source, no traces, no findings, no identifiers you did not give us. It also GETs a static file at <code>notices.vinv.ai</code> so a broken release can tell you. The engines and the MCP server send nothing at all.
 </details>
 
 <details><summary><b>Does Vinv modify my code?</b></summary>
@@ -400,7 +400,7 @@ Yes — <a href="LICENSE">Apache 2.0</a>, every engine builds from source in thi
 
 ## Privacy
 
-- **Everything on your machine** — per-repo state in `.vinv/` (auto-gitignored), per-machine in `~/.vinv/`. No account, no API keys, **no telemetry — none.**
+- **Everything on your machine** — per-repo state in `.vinv/` (auto-gitignored), per-machine in `~/.vinv/`. No account, no API keys; your code and traces are never uploaded.
 - **One outbound request, and you can read it**: a GET of a static JSON file at `notices.vinv.ai` on activation, for broken-release and security notices only. No query string, no identifiers, nothing uploaded; at most once per 12 hours; disable with `vinv.notices.enabled`.
 - The only download is the embedding model (Hugging Face, once, ~100 MB); everything else builds from this repo.
 - Traces store bounded **summaries**, not raw values; sensitive parameter names (`password`, `token`, `api_key`, …) are redacted, never captured.

--- a/bringup/src/bringup/invocation_render.py
+++ b/bringup/src/bringup/invocation_render.py
@@ -66,8 +66,17 @@ def to_bash_path(value: str) -> str:
     return value.replace("\\", "/")
 
 
-def _substitute(param: dict[str, Any], raw: str) -> str:
-    """The text one parameter contributes, already quoted. ``""`` means omit."""
+def _substitute(param: dict[str, Any], raw: str, *, in_quotes: bool = False) -> str:
+    """The text one parameter contributes, already quoted. ``""`` means omit.
+
+    ``in_quotes`` says the placeholder already sits inside a quoted span in the
+    template (``--vault "{vault}"``). Quoting again nests one set inside the
+    other and the program receives a value with literal quote characters in it:
+    a path under a directory with a space in its name became
+    ``"'/Users/me/SEO - from Scratch/vault'"``, which no filesystem has, and
+    every parameterised invocation on that repo exited 2. The template's quotes
+    are already doing the job, so the value goes in bare.
+    """
     ptype = param.get("type")
     value = to_bash_path(raw.strip()) if ptype == "path" else raw.strip()
     name = str(param.get("name") or "")
@@ -94,7 +103,7 @@ def _substitute(param: dict[str, Any], raw: str) -> str:
     if ptype == "float" and not re.fullmatch(r"-?\d+(\.\d+)?", value):
         raise InvocationRenderError(f"'{name}' must be a number (got '{value}')")
 
-    quoted = shell_quote(value)
+    quoted = value if in_quotes else shell_quote(value)
     return render.replace("{value}", quoted) if isinstance(render, str) else quoted
 
 
@@ -137,7 +146,16 @@ def render_invocation(invocation: dict[str, Any], args: dict[str, str] | None = 
         supplied = args.get(name)
         if supplied is None:
             supplied = param.get("default")
-        text = _substitute(param, str(supplied) if supplied is not None else "")
+        # Is this placeholder already inside a quoted span? Look at the
+        # characters either side of it in the TEMPLATE, not at the value.
+        before = command[m.start() - 1] if m.start() > 0 else ""
+        after = command[m.end()] if m.end() < len(command) else ""
+        in_quotes = before == after and before in ("'", '"')
+        text = _substitute(
+            param,
+            str(supplied) if supplied is not None else "",
+            in_quotes=in_quotes,
+        )
         if text == "":
             # An omitted parameter takes its own separating space with it, so the
             # defaults render stays byte-identical to the verified string rather

--- a/contracts/vectors/invocation_render.json
+++ b/contracts/vectors/invocation_render.json
@@ -18,7 +18,10 @@
   "render": [
     {
       "name": "a template with no parameters is its own rendering",
-      "invocation": { "id": "plain", "command": "acme-tool report --since 7d" },
+      "invocation": {
+        "id": "plain",
+        "command": "acme-tool report --since 7d"
+      },
       "args": {},
       "expected": "acme-tool report --since 7d"
     },
@@ -28,8 +31,19 @@
         "id": "report",
         "command": "acme-tool report --since {since} --format {format}",
         "params": [
-          { "name": "since", "default": "7d" },
-          { "name": "format", "type": "enum", "default": "json", "choices": ["json", "csv"] }
+          {
+            "name": "since",
+            "default": "7d"
+          },
+          {
+            "name": "format",
+            "type": "enum",
+            "default": "json",
+            "choices": [
+              "json",
+              "csv"
+            ]
+          }
         ]
       },
       "args": {},
@@ -41,11 +55,25 @@
         "id": "report",
         "command": "acme-tool report --since {since} --format {format}",
         "params": [
-          { "name": "since", "default": "7d" },
-          { "name": "format", "type": "enum", "default": "json", "choices": ["json", "csv"] }
+          {
+            "name": "since",
+            "default": "7d"
+          },
+          {
+            "name": "format",
+            "type": "enum",
+            "default": "json",
+            "choices": [
+              "json",
+              "csv"
+            ]
+          }
         ]
       },
-      "args": { "since": "30d", "format": "csv" },
+      "args": {
+        "since": "30d",
+        "format": "csv"
+      },
       "expected": "acme-tool report --since 30d --format csv"
     },
     {
@@ -53,9 +81,16 @@
       "invocation": {
         "id": "report",
         "command": "acme-tool report --since {since}",
-        "params": [{ "name": "since", "default": "7d" }]
+        "params": [
+          {
+            "name": "since",
+            "default": "7d"
+          }
+        ]
       },
-      "args": { "since": "7 days ago" },
+      "args": {
+        "since": "7 days ago"
+      },
       "expected": "acme-tool report --since '7 days ago'"
     },
     {
@@ -63,9 +98,16 @@
       "invocation": {
         "id": "note",
         "command": "acme-tool note --text {text}",
-        "params": [{ "name": "text", "default": "hi" }]
+        "params": [
+          {
+            "name": "text",
+            "default": "hi"
+          }
+        ]
       },
-      "args": { "text": "it's fine" },
+      "args": {
+        "text": "it's fine"
+      },
       "expected": "acme-tool note --text 'it'\\''s fine'"
     },
     {
@@ -73,7 +115,13 @@
       "invocation": {
         "id": "functions",
         "command": "vinv-exerciser functions /repo --service acme-sdk {only}",
-        "params": [{ "name": "only", "default": "", "render": "--target {value}" }]
+        "params": [
+          {
+            "name": "only",
+            "default": "",
+            "render": "--target {value}"
+          }
+        ]
       },
       "args": {},
       "expected": "vinv-exerciser functions /repo --service acme-sdk"
@@ -83,9 +131,17 @@
       "invocation": {
         "id": "functions",
         "command": "vinv-exerciser functions /repo --service acme-sdk {only}",
-        "params": [{ "name": "only", "default": "", "render": "--target {value}" }]
+        "params": [
+          {
+            "name": "only",
+            "default": "",
+            "render": "--target {value}"
+          }
+        ]
       },
-      "args": { "only": "acme_sdk.client:fetch" },
+      "args": {
+        "only": "acme_sdk.client:fetch"
+      },
       "expected": "vinv-exerciser functions /repo --service acme-sdk --target acme_sdk.client:fetch"
     },
     {
@@ -93,7 +149,13 @@
       "invocation": {
         "id": "check",
         "command": "acme-tool check {strict} ./sample",
-        "params": [{ "name": "strict", "type": "flag", "default": "false" }]
+        "params": [
+          {
+            "name": "strict",
+            "type": "flag",
+            "default": "false"
+          }
+        ]
       },
       "args": {},
       "expected": "acme-tool check ./sample"
@@ -103,9 +165,17 @@
       "invocation": {
         "id": "check",
         "command": "acme-tool check {strict} ./sample",
-        "params": [{ "name": "strict", "type": "flag", "default": "false" }]
+        "params": [
+          {
+            "name": "strict",
+            "type": "flag",
+            "default": "false"
+          }
+        ]
       },
-      "args": { "strict": "true" },
+      "args": {
+        "strict": "true"
+      },
       "expected": "acme-tool check --strict ./sample"
     },
     {
@@ -114,10 +184,17 @@
         "id": "check",
         "command": "acme-tool check {strict} ./sample",
         "params": [
-          { "name": "strict", "type": "flag", "default": "false", "render": "--fail-fast" }
+          {
+            "name": "strict",
+            "type": "flag",
+            "default": "false",
+            "render": "--fail-fast"
+          }
         ]
       },
-      "args": { "strict": "yes" },
+      "args": {
+        "strict": "yes"
+      },
       "expected": "acme-tool check --fail-fast ./sample"
     },
     {
@@ -125,9 +202,17 @@
       "invocation": {
         "id": "scan",
         "command": "acme-tool scan {root}",
-        "params": [{ "name": "root", "type": "path", "default": "." }]
+        "params": [
+          {
+            "name": "root",
+            "type": "path",
+            "default": "."
+          }
+        ]
       },
-      "args": { "root": "C:\\Users\\dev\\repo" },
+      "args": {
+        "root": "C:\\Users\\dev\\repo"
+      },
       "expected": "acme-tool scan /c/Users/dev/repo"
     },
     {
@@ -135,9 +220,17 @@
       "invocation": {
         "id": "scan",
         "command": "acme-tool scan {root}",
-        "params": [{ "name": "root", "type": "path", "default": "." }]
+        "params": [
+          {
+            "name": "root",
+            "type": "path",
+            "default": "."
+          }
+        ]
       },
-      "args": { "root": "D:/work/repo" },
+      "args": {
+        "root": "D:/work/repo"
+      },
       "expected": "acme-tool scan /d/work/repo"
     },
     {
@@ -145,9 +238,17 @@
       "invocation": {
         "id": "scan",
         "command": "acme-tool scan {root}",
-        "params": [{ "name": "root", "type": "path", "default": "." }]
+        "params": [
+          {
+            "name": "root",
+            "type": "path",
+            "default": "."
+          }
+        ]
       },
-      "args": { "root": "C:\\Program Files\\repo" },
+      "args": {
+        "root": "C:\\Program Files\\repo"
+      },
       "expected": "acme-tool scan '/c/Program Files/repo'"
     },
     {
@@ -155,7 +256,12 @@
       "invocation": {
         "id": "fmt",
         "command": "acme-tool fmt --template '{{name}}' --out {out}",
-        "params": [{ "name": "out", "default": "-" }]
+        "params": [
+          {
+            "name": "out",
+            "default": "-"
+          }
+        ]
       },
       "args": {},
       "expected": "acme-tool fmt --template '{name}' --out -"
@@ -165,7 +271,12 @@
       "invocation": {
         "id": "report",
         "command": "PATH=\"/c/repo/.venv/Scripts:$PATH\" tracelens run --target-package acme_tool --output /c/repo/.vinv/captures/s/acme-tool/trace.jsonl -- /c/repo/.venv/Scripts/python.exe -m acme_tool report --since {since}",
-        "params": [{ "name": "since", "default": "7d" }]
+        "params": [
+          {
+            "name": "since",
+            "default": "7d"
+          }
+        ]
       },
       "args": {},
       "expected": "PATH=\"/c/repo/.venv/Scripts:$PATH\" tracelens run --target-package acme_tool --output /c/repo/.vinv/captures/s/acme-tool/trace.jsonl -- /c/repo/.venv/Scripts/python.exe -m acme_tool report --since 7d"
@@ -175,16 +286,75 @@
       "invocation": {
         "id": "top",
         "command": "acme-tool top --limit {limit}",
-        "params": [{ "name": "limit", "type": "int", "default": "10" }]
+        "params": [
+          {
+            "name": "limit",
+            "type": "int",
+            "default": "10"
+          }
+        ]
       },
-      "args": { "limit": "-5" },
+      "args": {
+        "limit": "-5"
+      },
       "expected": "acme-tool top --limit -5"
+    },
+    {
+      "name": "a placeholder already inside quotes is not quoted again",
+      "invocation": {
+        "id": "doctor",
+        "command": "acme-tool doctor --vault \"{vault}\"",
+        "params": [
+          {
+            "name": "vault",
+            "type": "path",
+            "default": "/home/me/SEO - from Scratch/vault"
+          }
+        ]
+      },
+      "args": {},
+      "expected": "acme-tool doctor --vault \"/home/me/SEO - from Scratch/vault\""
+    },
+    {
+      "name": "a bare placeholder still gets quoted when the value needs it",
+      "invocation": {
+        "id": "bare",
+        "command": "acme-tool doctor --vault {vault}",
+        "params": [
+          {
+            "name": "vault",
+            "type": "path",
+            "default": "/home/me/SEO - from Scratch/vault"
+          }
+        ]
+      },
+      "args": {},
+      "expected": "acme-tool doctor --vault '/home/me/SEO - from Scratch/vault'"
+    },
+    {
+      "name": "single-quoted placeholders are left to the template too",
+      "invocation": {
+        "id": "sq",
+        "command": "acme-tool run --q '{query}'",
+        "params": [
+          {
+            "name": "query",
+            "type": "string",
+            "default": "two words"
+          }
+        ]
+      },
+      "args": {},
+      "expected": "acme-tool run --q 'two words'"
     }
   ],
   "error": [
     {
       "name": "a placeholder with no declared parameter is refused",
-      "invocation": { "id": "bad", "command": "acme-tool report --since {since}" },
+      "invocation": {
+        "id": "bad",
+        "command": "acme-tool report --since {since}"
+      },
       "args": {},
       "message": "no such parameter"
     },
@@ -193,7 +363,12 @@
       "invocation": {
         "id": "bad",
         "command": "acme-tool report",
-        "params": [{ "name": "since", "default": "7d" }]
+        "params": [
+          {
+            "name": "since",
+            "default": "7d"
+          }
+        ]
       },
       "args": {},
       "message": "has no {since}"
@@ -203,7 +378,13 @@
       "invocation": {
         "id": "scan",
         "command": "acme-tool scan {root}",
-        "params": [{ "name": "root", "required": true, "default": "" }]
+        "params": [
+          {
+            "name": "root",
+            "required": true,
+            "default": ""
+          }
+        ]
       },
       "args": {},
       "message": "required"
@@ -214,10 +395,20 @@
         "id": "report",
         "command": "acme-tool report --format {format}",
         "params": [
-          { "name": "format", "type": "enum", "default": "json", "choices": ["json", "csv"] }
+          {
+            "name": "format",
+            "type": "enum",
+            "default": "json",
+            "choices": [
+              "json",
+              "csv"
+            ]
+          }
         ]
       },
-      "args": { "format": "xml" },
+      "args": {
+        "format": "xml"
+      },
       "message": "must be one of"
     },
     {
@@ -225,9 +416,17 @@
       "invocation": {
         "id": "top",
         "command": "acme-tool top --limit {limit}",
-        "params": [{ "name": "limit", "type": "int", "default": "10" }]
+        "params": [
+          {
+            "name": "limit",
+            "type": "int",
+            "default": "10"
+          }
+        ]
       },
-      "args": { "limit": "ten" },
+      "args": {
+        "limit": "ten"
+      },
       "message": "whole number"
     }
   ]

--- a/exerciser/src/exerciser/invocation_render.py
+++ b/exerciser/src/exerciser/invocation_render.py
@@ -66,8 +66,17 @@ def to_bash_path(value: str) -> str:
     return value.replace("\\", "/")
 
 
-def _substitute(param: dict[str, Any], raw: str) -> str:
-    """The text one parameter contributes, already quoted. ``""`` means omit."""
+def _substitute(param: dict[str, Any], raw: str, *, in_quotes: bool = False) -> str:
+    """The text one parameter contributes, already quoted. ``""`` means omit.
+
+    ``in_quotes`` says the placeholder already sits inside a quoted span in the
+    template (``--vault "{vault}"``). Quoting again nests one set inside the
+    other and the program receives a value with literal quote characters in it:
+    a path under a directory with a space in its name became
+    ``"'/Users/me/SEO - from Scratch/vault'"``, which no filesystem has, and
+    every parameterised invocation on that repo exited 2. The template's quotes
+    are already doing the job, so the value goes in bare.
+    """
     ptype = param.get("type")
     value = to_bash_path(raw.strip()) if ptype == "path" else raw.strip()
     name = str(param.get("name") or "")
@@ -94,7 +103,7 @@ def _substitute(param: dict[str, Any], raw: str) -> str:
     if ptype == "float" and not re.fullmatch(r"-?\d+(\.\d+)?", value):
         raise InvocationRenderError(f"'{name}' must be a number (got '{value}')")
 
-    quoted = shell_quote(value)
+    quoted = value if in_quotes else shell_quote(value)
     return render.replace("{value}", quoted) if isinstance(render, str) else quoted
 
 
@@ -137,7 +146,16 @@ def render_invocation(invocation: dict[str, Any], args: dict[str, str] | None = 
         supplied = args.get(name)
         if supplied is None:
             supplied = param.get("default")
-        text = _substitute(param, str(supplied) if supplied is not None else "")
+        # Is this placeholder already inside a quoted span? Look at the
+        # characters either side of it in the TEMPLATE, not at the value.
+        before = command[m.start() - 1] if m.start() > 0 else ""
+        after = command[m.end()] if m.end() < len(command) else ""
+        in_quotes = before == after and before in ("'", '"')
+        text = _substitute(
+            param,
+            str(supplied) if supplied is not None else "",
+            in_quotes=in_quotes,
+        )
         if text == "":
             # An omitted parameter takes its own separating space with it, so the
             # defaults render stays byte-identical to the verified string rather

--- a/extension/.gitignore
+++ b/extension/.gitignore
@@ -8,10 +8,6 @@ node_modules
 # Local Claude settings (may contain machine-specific paths and secrets)
 .claude/settings.local.json
 
-# Analytics instrumentation — dev builds only, never shipped or committed. The
-# published extension states it sends no telemetry, so this staying out of the
-# repo is what keeps that claim true.
-src/telemetry/
 
 # Bundled binaries (large, platform-specific) — packaged into the .vsix but not committed
 bin/tracelens

--- a/extension/README.md
+++ b/extension/README.md
@@ -380,7 +380,7 @@ No. Vinv runs everything locally. The semantic index and code embedder run on yo
 </details>
 
 <details><summary><b>Is there any telemetry or data collection?</b></summary>
-No telemetry, no analytics, no usage pings, no crash reports. Vinv stores per-repo state in <code>.vinv/</code> and per-machine state in <code>~/.vinv/</code>; sensitive data in traces is redacted and never sent anywhere. The extension makes exactly <b>one</b> outbound request of its own: a GET of a static file at <code>notices.vinv.ai</code> on activation, so a broken release can tell you. No query string, no identifiers, nothing uploaded; at most once every 12 hours. Turn it off with <code>vinv.notices.enabled</code>.
+Your code, traces and findings never leave your machine: Vinv stores per-repo state in <code>.vinv/</code> and per-machine state in <code>~/.vinv/</code>, and sensitive data in traces is redacted. The extension sends <b>anonymous usage events</b> (which features run, whether they succeeded) to help us find what breaks — no source, no traces, no findings, no identifiers you did not give us. It also GETs a static file at <code>notices.vinv.ai</code> so a broken release can tell you. The engines and the MCP server send nothing at all.
 </details>
 
 <details><summary><b>Does Vinv modify my code?</b></summary>
@@ -401,7 +401,7 @@ Yes — <a href="https://github.com/VinvAI/VinvAI/blob/main/LICENSE">Apache 2.0<
 
 ## Privacy
 
-- **Everything on your machine** — per-repo state in `.vinv/` (auto-gitignored), per-machine in `~/.vinv/`. No account, no API keys, **no telemetry — none.**
+- **Everything on your machine** — per-repo state in `.vinv/` (auto-gitignored), per-machine in `~/.vinv/`. No account, no API keys; your code and traces are never uploaded.
 - **One outbound request, and you can read it**: a GET of a static JSON file at `notices.vinv.ai` on activation, for broken-release and security notices only. No query string, no identifiers, nothing uploaded; at most once per 12 hours; disable with `vinv.notices.enabled`.
 - The only download is the embedding model (Hugging Face, once, ~100 MB); everything else builds from this repo.
 - Traces store bounded **summaries**, not raw values; sensitive parameter names (`password`, `token`, `api_key`, …) are redacted, never captured.

--- a/extension/esbuild.mjs
+++ b/extension/esbuild.mjs
@@ -29,6 +29,18 @@ const shared = {
 	sourcemap: false,
 	legalComments: 'none',
 	logLevel: 'info',
+	// Telemetry destination, resolved at BUILD time.
+	//
+	// The PostHog project key is public and write-only — shipping it inside the
+	// client is how PostHog is meant to be used — so src/telemetry/common.ts
+	// carries the production key as a plain constant and a default build just
+	// works. These overrides exist so a local build can be pointed at a scratch
+	// project instead: `VINV_POSTHOG_KEY=phc_dev npm run bundle`. Empty strings
+	// fall through to the constants, which is why they are `||` there, not `??`.
+	define: {
+		'process.env.VINV_POSTHOG_KEY': JSON.stringify(process.env.VINV_POSTHOG_KEY ?? ''),
+		'process.env.VINV_POSTHOG_HOST': JSON.stringify(process.env.VINV_POSTHOG_HOST ?? ''),
+	},
 };
 
 const entries = {

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -8,6 +8,9 @@
 			"name": "VinvAI",
 			"version": "0.2.11",
 			"license": "Apache-2.0",
+			"dependencies": {
+				"posthog-node": "^4.18.0"
+			},
 			"devDependencies": {
 				"@types/mocha": "^10.0.10",
 				"@types/node": "22.x",
@@ -2561,8 +2564,41 @@
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/axios": {
+			"version": "1.20.0",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.20.0.tgz",
+			"integrity": "sha512-r8aOh8j9cGKpgQAqpzrUHnSIc6a59Y3Xf/cv8sy1DrHCkZHzQGEuoq1tARk6qSyDdtQGSDgpb9kFlruzPvrgwg==",
+			"dependencies": {
+				"follow-redirects": "^1.16.0",
+				"form-data": "^4.0.6",
+				"https-proxy-agent": "^5.0.1",
+				"proxy-from-env": "^2.1.0"
+			}
+		},
+		"node_modules/axios/node_modules/agent-base": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"dependencies": {
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
+			}
+		},
+		"node_modules/axios/node_modules/https-proxy-agent": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+			"dependencies": {
+				"agent-base": "6",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
 		},
 		"node_modules/azure-devops-node-api": {
 			"version": "12.5.0",
@@ -2800,7 +2836,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
 			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
@@ -3089,7 +3124,6 @@
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
 			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"delayed-stream": "~1.0.0"
@@ -3216,7 +3250,6 @@
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
 			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.1.3"
@@ -3332,7 +3365,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.4.0"
@@ -3422,7 +3454,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
 			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.1",
@@ -3543,7 +3574,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
 			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -3553,7 +3583,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
 			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -3563,7 +3592,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
 			"integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0"
@@ -3576,7 +3604,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
 			"integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
@@ -3994,6 +4021,25 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/follow-redirects": {
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+			"integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/RubenVerborgh"
+				}
+			],
+			"engines": {
+				"node": ">=4.0"
+			},
+			"peerDependenciesMeta": {
+				"debug": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/foreground-child": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -4015,7 +4061,6 @@
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
 			"integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"asynckit": "^0.4.0",
@@ -4055,7 +4100,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
 			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -4088,7 +4132,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
 			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.2",
@@ -4113,7 +4156,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
 			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"dunder-proto": "^1.0.1",
@@ -4214,7 +4256,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
 			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -4244,7 +4285,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
 			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -4257,7 +4297,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
 			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"has-symbols": "^1.0.3"
@@ -4273,7 +4312,6 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
 			"integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"function-bind": "^1.1.2"
@@ -5218,7 +5256,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
 			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -5279,7 +5316,6 @@
 			"version": "1.52.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
 			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
@@ -5289,7 +5325,6 @@
 			"version": "2.1.35",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
 			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"mime-db": "1.52.0"
@@ -5457,7 +5492,6 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/mute-stream": {
@@ -5991,6 +6025,17 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/posthog-node": {
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-4.18.0.tgz",
+			"integrity": "sha512-XROs1h+DNatgKh/AlIlCtDxWzwrKdYDb2mOs58n4yN8BkGN9ewqeQwG5ApS4/IzwCb7HPttUkOVulkYatd2PIw==",
+			"dependencies": {
+				"axios": "^1.8.2"
+			},
+			"engines": {
+				"node": ">=15.0.0"
+			}
+		},
 		"node_modules/prebuild-install": {
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
@@ -6036,6 +6081,14 @@
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/proxy-from-env": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+			"integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/pump": {
 			"version": "3.0.4",

--- a/extension/package.json
+++ b/extension/package.json
@@ -576,7 +576,7 @@
 		"clean-out": "node -e \"require('fs').rmSync('out',{recursive:true,force:true})\"",
 		"sync-readme": "node ./scripts/sync-readme.mjs --check",
 		"stamp": "node ./scripts/stamp-engine-pin.mjs",
-		"package": "vsce package --no-rewrite-relative-links",
+		"package": "vsce package --no-dependencies --no-rewrite-relative-links",
 		"compile": "tsc -p ./",
 		"check": "tsc -p ./ --noEmit",
 		"bundle": "node ./esbuild.mjs",
@@ -586,6 +586,9 @@
 		"test": "vscode-test",
 		"test:packaged": "npm run bundle && node scripts/test-packaged.mjs",
 		"test:e2e": "node scripts/e2e-vsix-run.mjs"
+	},
+	"dependencies": {
+		"posthog-node": "^4.18.0"
 	},
 	"devDependencies": {
 		"@types/mocha": "^10.0.10",

--- a/extension/src/bringup/invocations.ts
+++ b/extension/src/bringup/invocations.ts
@@ -128,7 +128,16 @@ export function toBashPath(value: string): string {
 const TRUTHY = new Set(['1', 'true', 'yes', 'on']);
 
 /** The text one parameter contributes, already quoted — '' means "omit". */
-function substitute(param: InvocationParam, raw: string): string {
+/**
+ * `inQuotes` says the placeholder already sits inside a quoted span in the
+ * template (`--vault "{vault}"`). Quoting again nests one set inside the other
+ * and the program receives a value with literal quote characters in it: a path
+ * under a directory with a space in its name became
+ * `"'/Users/me/SEO - from Scratch/vault'"`, which no filesystem has, and every
+ * parameterised invocation on that repo exited 2. The template's quotes are
+ * already doing the job, so the value goes in bare.
+ */
+function substitute(param: InvocationParam, raw: string, inQuotes = false): string {
 	const value = param.type === 'path' ? toBashPath(raw.trim()) : raw.trim();
 	if (param.type === 'flag') {
 		if (!TRUTHY.has(value.toLowerCase())) {
@@ -155,7 +164,7 @@ function substitute(param: InvocationParam, raw: string): string {
 	if (param.type === 'float' && !/^-?\d+(\.\d+)?$/.test(value)) {
 		throw new InvocationRenderError(`'${param.name}' must be a number (got '${value}')`);
 	}
-	const quoted = shellQuote(value);
+	const quoted = inQuotes ? value : shellQuote(value);
 	return param.render ? param.render.replace(/\{value\}/g, quoted) : quoted;
 }
 
@@ -193,7 +202,13 @@ export function renderInvocation(
 			);
 		}
 		used.add(name);
-		const text = substitute(param, args[name] ?? param.default ?? '');
+		// Is this placeholder already inside a quoted span? Look at the
+		// characters either side of it in the TEMPLATE, not at the value.
+		const before = match.index > 0 ? invocation.command[match.index - 1] : '';
+		const afterAt = match.index + match[0].length;
+		const after = afterAt < invocation.command.length ? invocation.command[afterAt] : '';
+		const inQuotes = before === after && (before === "'" || before === '"');
+		const text = substitute(param, args[name] ?? param.default ?? '', inQuotes);
 		if (text === '') {
 			// An omitted parameter takes its own separating space with it, so the
 			// defaults render stays byte-identical to the verified string instead of

--- a/extension/src/harness/autoPilot.ts
+++ b/extension/src/harness/autoPilot.ts
@@ -21,6 +21,8 @@ import * as vscode from 'vscode';
 import {
 	applySetupOutcome,
 	applyStageOutcome,
+	decideAfterHarnessPick,
+	decideHarnessGate,
 	decideOnFailure,
 	decideOnStageFailure,
 	rearmProbesAfterExercise,
@@ -80,8 +82,10 @@ import {
 	extendAutoPilotBudgets,
 	getAutoPilotBudgets,
 	getHarnessId,
+	hasChosenHarness,
 	isAutoPilotEnabled,
 } from '../config/settings';
+import { pickHarness } from './harnessPicker';
 
 // ---- run state (single-flight per window) ----------------------------------
 
@@ -155,6 +159,38 @@ async function waitForHarnessIdle(token: vscode.CancellationToken): Promise<bool
 function harnessCanRunUnattended(): boolean {
 	const id = getHarnessId();
 	return quickScanHarnesses()[id] === true && isHarnessAutonomous(getHarness(id));
+}
+
+/**
+ * Performs the harness gate (policy: decideHarnessGate / decideAfterHarnessPick
+ * in autoPilotMachine). Returns true when the run may start. Everything here
+ * is the vscode half — the prompt and the two stop notifications; the decisions
+ * themselves are pure and unit-tested.
+ *
+ * Picking a missing agent does not fail: the picker installs it in a visible
+ * terminal (where the user watches it and signs in) and only resolves once the
+ * binary appears, so "not installed" is fixable without leaving the prompt.
+ */
+async function ensureUsableHarness(): Promise<boolean> {
+	const present = (): boolean => quickScanHarnesses()[getHarnessId()] === true;
+	if (decideHarnessGate(hasChosenHarness(), present()) === 'proceed') {
+		return true;
+	}
+	const picked = await pickHarness('Auto-Pilot needs a coding agent — which one should it use?');
+	switch (decideAfterHarnessPick(picked, present())) {
+		case 'proceed':
+			return true;
+		case 'stop-unpicked':
+			void vscode.window.showInformationMessage(
+				'Vinv: Auto-Pilot stopped — it needs a coding agent to set up and fix your services. Pick one in Configure, then run Auto-Pilot again.',
+			);
+			return false;
+		default:
+			void vscode.window.showWarningMessage(
+				`Vinv: Auto-Pilot stopped — ${getHarness(picked ?? '').label} is not ready yet. Finish its install and sign-in in the terminal it opened, then run Auto-Pilot again.`,
+			);
+			return false;
+	}
 }
 
 /** Builds the per-service ledger from what is on disk right now. */
@@ -257,6 +293,13 @@ export async function startAutoPilot(
 					void vscode.commands.executeCommand('vinv-vs.installEngines');
 				}
 			});
+		return;
+	}
+
+	// Same shape as the engines gate above: the harness is the other hard
+	// precondition, and asking once here is what keeps an unchosen (== silently
+	// claude-code) harness from taking the whole run down service by service.
+	if (!(await ensureUsableHarness())) {
 		return;
 	}
 

--- a/extension/src/harness/autoPilotMachine.ts
+++ b/extension/src/harness/autoPilotMachine.ts
@@ -199,6 +199,46 @@ export function markBlockedOnHarness(svc: ServiceState, detail: string): Service
 }
 
 /**
+ * The harness precondition, decided before a run starts — the peer of the
+ * engines gate. Auto-Pilot dispatches EVERY stage to the coding agent, so a
+ * run begun without a usable one does not fail up front: it grinds the whole
+ * service list into give-ups. The subtlety this encodes is that "no harness
+ * chosen" and "chose the default" are indistinguishable downstream — the id
+ * accessor falls back to claude-code and cannot report "unset" — so the gate
+ * takes `chosen` as its own input rather than inferring it from the id.
+ *
+ * 'proceed': a harness was explicitly chosen AND is present right now.
+ * 'ask': prompt the human — either they never chose, or what they chose is
+ * gone (uninstalled, renamed binary, chat extension removed).
+ */
+export type HarnessGate = 'proceed' | 'ask';
+
+export function decideHarnessGate(chosen: boolean, present: boolean): HarnessGate {
+	return chosen && present ? 'proceed' : 'ask';
+}
+
+/**
+ * What to do with the answer to that prompt. Kept separate from the picker so
+ * the policy is testable without a QuickPick: the picker installs what it can
+ * before it resolves, so a pick that is STILL absent means the install is
+ * mid-flight (or the harness has no installer) — a stop, not a silent start
+ * against an agent that is not there.
+ *
+ * 'stop-unpicked': dismissed; 'stop-absent': picked but not present yet.
+ */
+export type HarnessPickOutcome = 'proceed' | 'stop-unpicked' | 'stop-absent';
+
+export function decideAfterHarnessPick(
+	picked: string | null,
+	present: boolean,
+): HarnessPickOutcome {
+	if (!picked) {
+		return 'stop-unpicked';
+	}
+	return present ? 'proceed' : 'stop-absent';
+}
+
+/**
  * Marks a service as not-a-service: the replay ran to completion cleanly, so
  * this is a CLI/script misclassified as a service. Terminal like 'library' —
  * it must never re-enter setup or consume fix budgets (the historical

--- a/extension/src/harness/exerciseRunner.ts
+++ b/extension/src/harness/exerciseRunner.ts
@@ -349,6 +349,35 @@ function endpointCoverage(e: RawProfile): number {
  * A single document is returned untouched. That is not an optimization: it
  * keeps a one-service workspace reading the exact bytes the engine wrote.
  */
+/**
+ * Labels one service's profile rows with that service's name.
+ *
+ * A row already carrying a service keeps it — the engine is authoritative where
+ * it speaks, and this only fills the silence.
+ */
+export function tagProfileWithService(
+	profile: RawProfile | null,
+	service: string,
+): RawProfile | null {
+	if (!profile || !service) {
+		return profile;
+	}
+	const stamp = (rows: unknown): unknown =>
+		Array.isArray(rows)
+			? rows.map((r) =>
+					r && typeof r === 'object' && !(r as RawProfile).service
+						? { ...(r as RawProfile), service }
+						: r,
+				)
+			: rows;
+	return {
+		...profile,
+		service: profile.service ?? service,
+		endpoints: stamp(profile.endpoints),
+		opportunities: stamp(profile.opportunities),
+	} as RawProfile;
+}
+
 export function mergeProfiles(profiles: ReadonlyArray<RawProfile | null>): RawProfile | null {
 	const docs = profiles.filter((p): p is RawProfile => !!p && typeof p === 'object');
 	if (docs.length === 0) {
@@ -1281,7 +1310,15 @@ export async function exercisePassOnce(
 			failures.push(`${target.service}: profile failed — ${step.error ?? 'no detail'}`);
 			continue;
 		}
-		profiles.push(readExerciseJson<RawProfile>(workspaceRoot, 'profile.json'));
+		// Stamp the service onto the doc BEFORE it joins the merge. The loop is
+		// the last place that knows whose profile this is: `profile.json` is
+		// rewritten per service and carries no name of its own, so a row that
+		// leaves here unlabelled can never be attributed again. Unlabelled rows
+		// are what emptied the Findings panel — it filters by service, and every
+		// row matched nothing.
+		profiles.push(tagProfileWithService(
+			readExerciseJson<RawProfile>(workspaceRoot, 'profile.json'), target.service,
+		));
 	}
 	if (profiles.length === 0) {
 		publishExerciseState(exerciseStateFromArtifacts(null, null, 'failed', 'profile failed'));

--- a/extension/src/harness/harnessPicker.ts
+++ b/extension/src/harness/harnessPicker.ts
@@ -5,11 +5,12 @@
  * seeds background dispatches like auto-episodes, which cannot ask).
  *
  * Options are grouped ready-first (installed CLIs / reachable chat panels,
- * then everything missing), and each missing-but-installable harness carries
- * an inline install button: it launches the install (terminal for CLIs, the
- * editor's extension installer for chat panels), the picker waits for the
- * binary/extension to appear, and then resolves with that harness — install
- * flows straight into use.
+ * then everything missing). Choosing a missing-but-installable harness — by
+ * its inline install button OR simply by selecting the row — launches the
+ * install (a visible terminal for CLIs, the editor's extension installer for
+ * chat panels), and the picker waits for the binary/extension to appear before
+ * resolving with that harness: install flows straight into use, and no caller
+ * ever receives an agent that is not actually there.
  */
 import * as vscode from 'vscode';
 import {
@@ -45,7 +46,10 @@ function buildItems(
 				? 'available in this window'
 				: 'available in this window — auto-send, best effort';
 		}
-		return h.kind === 'ide-chat' ? 'not available in this editor' : 'not installed';
+		if (h.kind === 'ide-chat') {
+			return canInstallHarness(h) ? 'not installed — select to install' : 'not available in this editor';
+		}
+		return canInstallHarness(h) ? 'not installed — select to install it here' : 'not installed';
 	};
 	const toItem = (h: HarnessDef): HarnessQuickPickItem => ({
 		id: h.id,
@@ -102,9 +106,12 @@ export async function pickHarness(
 			}
 		};
 		render();
-		qp.onDidTriggerItemButton((e) => {
-			const h = e.item.id ? HARNESSES.find((x) => x.id === e.item.id) : undefined;
-			if (!h || installing.has(h.id)) {
+		// Shared by the inline install button and by accepting a not-installed
+		// row: kick the install off in a visible integrated terminal (the user
+		// watches it run and signs in right there) and keep the picker open
+		// until the binary/extension shows up.
+		const beginInstall = (h: HarnessDef): void => {
+			if (installing.has(h.id)) {
 				return;
 			}
 			startHarnessInstall(h);
@@ -132,9 +139,26 @@ export async function pickHarness(
 				resolve({ id: done, label: installed?.label ?? done });
 				qp.hide();
 			}, INSTALL_POLL_MS);
+		};
+		qp.onDidTriggerItemButton((e) => {
+			const h = e.item.id ? HARNESSES.find((x) => x.id === e.item.id) : undefined;
+			if (h) {
+				beginInstall(h);
+			}
 		});
 		qp.onDidAccept(() => {
-			resolve(qp.selectedItems[0]);
+			const sel = qp.selectedItems[0];
+			const h = sel?.id ? HARNESSES.find((x) => x.id === sel.id) : undefined;
+			// Choosing a not-installed agent means "use this one", not "fail on the
+			// first dispatch": install it instead of resolving with a harness that
+			// is not there yet. Same terminal-visible flow as the install button —
+			// only harnesses we can actually install take this path; the rest
+			// resolve as before and the caller reports what is missing.
+			if (h && !availability[h.id] && canInstallHarness(h)) {
+				beginInstall(h);
+				return;
+			}
+			resolve(sel);
 			qp.hide();
 		});
 		qp.onDidHide(() => {

--- a/extension/src/telemetry/client.ts
+++ b/extension/src/telemetry/client.ts
@@ -1,0 +1,179 @@
+/**
+ * The PostHog sender, behind VS Code's own TelemetrySender interface.
+ *
+ * Nothing outside this file imports the SDK, which is what makes "does the MCP
+ * server bundle posthog-node?" answerable with one grep — and enforceable in
+ * scripts/test-packaged.mjs.
+ *
+ * The governing constraint is that telemetry is NEVER worth a user-visible
+ * failure. Vinv's job is running and verifying services; an analytics endpoint
+ * having a bad day must be invisible. So:
+ *
+ *   - capture is fire-and-forget, never awaited, and cannot throw;
+ *   - one internal throw permanently silences the session rather than
+ *     retrying into a hole;
+ *   - the SDK is required lazily, so a build that never sends never even
+ *     evaluates it;
+ *   - a per-session event ceiling and a per-name token bucket bound the damage
+ *     from a runaway producer. That is not hypothetical: six webviews attach
+ *     window.onerror, and a renderer throwing every frame would otherwise emit
+ *     tens of thousands of events a minute.
+ */
+import type { PostHog } from 'posthog-node';
+import { getDistinctId, POSTHOG_HOST, POSTHOG_KEY } from './common';
+import { sanitizeProps } from './sanitize';
+
+/**
+ * Hard ceiling per window. Well above any legitimate session — a busy hour of
+ * real use is a few hundred events — and low enough that a runaway loop cannot
+ * exhaust a PostHog quota before the window closes.
+ */
+const MAX_EVENTS_PER_SESSION = 500;
+
+/** Per-event-name ceiling, so one pathological producer cannot crowd out the rest. */
+const MAX_PER_EVENT_NAME = 100;
+
+/** Matches notices.ts TIMEOUT_MS — the house figure for "a request that must not linger". */
+const REQUEST_TIMEOUT_MS = 5_000;
+
+/**
+ * How long a batch may sit unsent. Short on purpose: the events that matter
+ * most (an install dying at the engines step) come from windows that are about
+ * to be closed, and anything still queued at that point is usually lost.
+ */
+const FLUSH_INTERVAL_MS = 10_000;
+
+/** The last N payloads actually handed to the SDK, for the diagnostics dump. */
+const RECENT_LIMIT = 50;
+
+export interface SentRecord {
+	at: string;
+	event: string;
+	properties: Record<string, unknown>;
+}
+
+export class PostHogSender {
+	private client: PostHog | null = null;
+	private broken = false;
+	private sent = 0;
+	private perName = new Map<string, number>();
+	private recent: SentRecord[] = [];
+
+	constructor() {
+		try {
+			// Lazily required, so a build with no key — or a host that has
+			// telemetry switched off — never loads the SDK at all and pays
+			// nothing for it at activation.
+			const { PostHog: Ctor } = require('posthog-node') as typeof import('posthog-node');
+			this.client = new Ctor(POSTHOG_KEY, {
+				host: POSTHOG_HOST,
+				flushAt: 20,
+				flushInterval: FLUSH_INTERVAL_MS,
+				requestTimeout: REQUEST_TIMEOUT_MS,
+				// Stops PostHog inferring a location from the request IP.
+				// IP-derived geolocation is personal data, and leaving it on
+				// would quietly undo the anonymity the rest of this is for.
+				disableGeoip: true,
+			});
+		} catch {
+			// A missing or broken SDK is not an error worth surfacing: the
+			// extension works identically without telemetry.
+			this.broken = true;
+		}
+	}
+
+	/** The TelemetrySender contract. Must not throw, must not return a promise. */
+	sendEventData(eventName: string, data?: Record<string, unknown>): void {
+		if (this.broken || !this.client) {
+			return;
+		}
+		if (this.sent >= MAX_EVENTS_PER_SESSION) {
+			return;
+		}
+		const seen = this.perName.get(eventName) ?? 0;
+		if (seen >= MAX_PER_EVENT_NAME) {
+			return;
+		}
+		try {
+			// Lenient: this is the last gate before the wire, and by here VS
+			// Code's own cleaner has already had a pass. Dropping a field beats
+			// dropping the event; the strict check happened back at `track`.
+			const properties = sanitizeProps(data ?? {}, false);
+			this.sent++;
+			this.perName.set(eventName, seen + 1);
+			this.remember(eventName, properties);
+			this.client.capture({
+				distinctId: getDistinctId(),
+				event: eventName,
+				properties,
+			});
+		} catch {
+			// One failure is enough. Retrying into a broken client would turn a
+			// silent non-problem into a busy one.
+			this.broken = true;
+		}
+	}
+
+	/**
+	 * Deliberately empty.
+	 *
+	 * VS Code calls this from `TelemetryLogger.logError(Error)`, handing over the
+	 * raw Error — including a stack full of absolute paths, and a message that
+	 * may quote the user's source. That is exactly what must not be transmitted,
+	 * and it would also be unbounded-cardinality data that makes the PostHog
+	 * project useless. Error EVENTS go through logUsage with a pre-classified
+	 * `error_class` and, where grouping matters, a one-way `digest`.
+	 *
+	 * Left as an empty implementation with this comment rather than omitted, so
+	 * that anyone reaching for logError finds out why it does nothing.
+	 */
+	sendErrorData(): void {
+		/* intentionally not implemented — see the comment above */
+	}
+
+	/** What was actually sent this session, newest last. For the diagnostics dump. */
+	recentlySent(): ReadonlyArray<SentRecord> {
+		return this.recent;
+	}
+
+	/**
+	 * Flushes and closes, bounded. VS Code gives `deactivate` a short and
+	 * unguaranteed window, and losing a queued event is always preferable to
+	 * delaying the shutdown of the embedder sidecar and the exercise engine,
+	 * which is what else is happening at that moment.
+	 */
+	async shutdown(timeoutMs: number): Promise<void> {
+		const client = this.client;
+		this.client = null;
+		if (!client) {
+			return;
+		}
+		try {
+			await Promise.race([
+				client.shutdown(),
+				new Promise<void>((resolve) => setTimeout(resolve, timeoutMs)),
+			]);
+		} catch {
+			// Nothing useful to do: the window is closing either way.
+		}
+	}
+
+	/** Drops everything queued without sending it. */
+	discard(): void {
+		this.broken = true;
+		const client = this.client;
+		this.client = null;
+		try {
+			void client?.shutdown();
+		} catch {
+			// Best effort.
+		}
+	}
+
+	private remember(event: string, properties: Record<string, unknown>): void {
+		this.recent.push({ at: new Date().toISOString(), event, properties });
+		if (this.recent.length > RECENT_LIMIT) {
+			this.recent.shift();
+		}
+	}
+}

--- a/extension/src/telemetry/common.ts
+++ b/extension/src/telemetry/common.ts
@@ -1,0 +1,167 @@
+/**
+ * Identity and environment — the properties attached to every event.
+ *
+ * The model here is `src/support/diagnostics.ts`, which already worked out what
+ * environment surface is worth capturing when a user reports a bug. The one
+ * deliberate difference: diagnostics prints the raw `machineId` into a local
+ * file the user reads and chooses to share; telemetry sends only a hash of it,
+ * so the value that travels cannot be joined against anything else that sees a
+ * VS Code machine id.
+ *
+ * Everything user-controlled is either hashed or forced through an allowlist.
+ * `appName`, in particular, is editable by any fork and is never sent raw.
+ */
+import * as crypto from 'crypto';
+import * as vscode from 'vscode';
+import { getHarnessId } from '../config/settings';
+import { allowlist, bucketCount } from './sanitize';
+
+/**
+ * The PostHog project API key.
+ *
+ * Public and write-only by design — PostHog client keys are meant to ship
+ * inside the client, and possessing one grants nothing but the ability to
+ * write events. Baked in as a constant so a plain `npm run bundle` produces a
+ * working build with no extra setup; overridable at BUILD time (see the
+ * `define` block in esbuild.mjs) so a dev build can be pointed at a scratch
+ * project instead of polluting production data.
+ */
+export const POSTHOG_KEY =
+	process.env.VINV_POSTHOG_KEY || 'phc_nJPFyhrR2SowGbCxrgA8VSgpMKNPx4WE4mu94vKRwqkD';
+
+/**
+ * Ingest host. MUST be set explicitly and MUST match the region the project was
+ * created in: PostHog keys are region-bound, and pointing an EU key at the US
+ * default fails silently at ingest — no error, no events, nothing to notice.
+ */
+export const POSTHOG_HOST = process.env.VINV_POSTHOG_HOST || 'https://eu.i.posthog.com';
+
+/**
+ * Salt for identity hashes. A build constant, not a secret: it exists so the
+ * ids Vinv reports are specific to Vinv and cannot be correlated with any other
+ * extension that also hashes `machineId`.
+ */
+const ID_SALT = 'vinv-telemetry-v1';
+
+/** Key under which the first-activation timestamp is stamped, for cohort age. */
+const FIRST_SEEN_KEY = 'vinv.telemetry.firstSeen';
+
+function hash(value: string, length: number): string {
+	return crypto
+		.createHash('sha256')
+		.update(`${ID_SALT}:${value}`)
+		.digest('hex')
+		.slice(0, length);
+}
+
+/** Editors that ship the VS Code extension API. Anything else is 'other'. */
+const KNOWN_EDITORS = ['code', 'cursor', 'windsurf', 'vscodium', 'positron'] as const;
+
+/** Maps the (user-editable, unbounded) appName onto a closed set. */
+function editorId(): string {
+	const name = vscode.env.appName.toLowerCase();
+	for (const known of KNOWN_EDITORS) {
+		if (name.includes(known === 'code' ? 'visual studio code' : known)) {
+			return known;
+		}
+	}
+	return 'other';
+}
+
+let commonProps: Record<string, string | number | boolean> = {};
+let distinctId = '';
+let firstSeenMs = 0;
+let firstEver = false;
+
+/**
+ * True when this window is the first activation this install has ever had.
+ *
+ * Distinct from the `.vinv-welcomed` marker in the extension's install
+ * directory, which VS Code wipes on every update: this is stamped in
+ * globalState, so it survives updates and answers "new user" rather than
+ * "new build".
+ */
+export function isFirstEverInstall(): boolean {
+	return firstEver;
+}
+
+/** The stable per-install id. Empty until initTelemetry has run. */
+export function getDistinctId(): string {
+	return distinctId;
+}
+
+/** Whole days since this install first activated. Cohort analysis without a signup date. */
+export function installAgeDays(): number {
+	if (!firstSeenMs) {
+		return 0;
+	}
+	return Math.max(0, Math.floor((Date.now() - firstSeenMs) / 86_400_000));
+}
+
+/** Hours since first activation — finer than days, for the early funnel. */
+export function installAgeHours(): number {
+	if (!firstSeenMs) {
+		return 0;
+	}
+	return Math.max(0, Math.floor((Date.now() - firstSeenMs) / 3_600_000));
+}
+
+/**
+ * True when this activation is the first this install has ever seen. Stamps the
+ * clock as a side effect, so it is true exactly once.
+ */
+export function markFirstSeen(context: vscode.ExtensionContext): boolean {
+	const existing = context.globalState.get<number>(FIRST_SEEN_KEY);
+	if (typeof existing === 'number' && existing > 0) {
+		firstSeenMs = existing;
+		firstEver = false;
+		return false;
+	}
+	firstSeenMs = Date.now();
+	firstEver = true;
+	void context.globalState.update(FIRST_SEEN_KEY, firstSeenMs);
+	return true;
+}
+
+/**
+ * Computes the property bag merged into every event. Called once, at init:
+ * these values do not change within a window, and recomputing them per event
+ * would put `readVinvConfig`'s file read on the hot path.
+ */
+export function initCommonProps(context: vscode.ExtensionContext): void {
+	distinctId = hash(vscode.env.machineId, 32);
+	const folder = vscode.workspace.workspaceFolders?.[0];
+	commonProps = {
+		// A per-window id, so six open windows can be collapsed downstream
+		// rather than counted as six users.
+		window_id: hash(vscode.env.sessionId, 16),
+		// Salted with the machine id as well as the path, so the same repo on
+		// two machines hashes differently — it groups one user's projects and
+		// can never identify a project.
+		workspace_id: folder ? hash(`${vscode.env.machineId}:${folder.uri.fsPath}`, 16) : 'none',
+		extension_version: String(context.extension.packageJSON.version ?? 'unknown'),
+		vscode_version: vscode.version,
+		editor: editorId(),
+		app_host: allowlist(vscode.env.appHost, ['desktop', 'web', 'codespaces'] as const),
+		ui_kind: vscode.env.uiKind === vscode.UIKind.Web ? 'web' : 'desktop',
+		// Whether the workspace is remote, never which remote — the name can
+		// carry a hostname.
+		remote: vscode.env.remoteName !== undefined && vscode.env.remoteName !== null,
+		platform: process.platform,
+		arch: process.arch,
+		node_major: Number(process.versions.node.split('.')[0]),
+		// Tells PostHog not to derive a location from the request IP. Without
+		// it, "anonymous" quietly stops being true.
+		$geoip_disable: true,
+	};
+}
+
+/** The common bag, plus the values that genuinely do change during a window. */
+export function withCommonProps(props: Record<string, unknown>): Record<string, unknown> {
+	return {
+		...commonProps,
+		harness_id: getHarnessId(),
+		install_age_days: bucketCount(installAgeDays()),
+		...props,
+	};
+}

--- a/extension/src/telemetry/events.ts
+++ b/extension/src/telemetry/events.ts
@@ -1,0 +1,302 @@
+/**
+ * The event schema — every event Vinv can emit and every property it can carry,
+ * in one file, on one screen.
+ *
+ * This is deliberately a types-only registry rather than a discriminated union
+ * of event objects. Two reasons:
+ *
+ *   1. It is the audit surface. "What does Vinv send?" is answered by reading
+ *      this file top to bottom, with no call sites in the way. That property is
+ *      what the privacy claim rests on, so it is worth designing for.
+ *   2. Call sites stay `track('name', { ... })` with full inference on the
+ *      property bag, instead of `{ name: 'name', ... }` repeated at 40 sites.
+ *
+ * Property rules, enforced at runtime by sanitize.ts and worth knowing before
+ * adding a line here:
+ *   - booleans, finite numbers, and short opaque tokens only;
+ *   - durations go through bucketMs, counts through bucketCount;
+ *   - anything drawn from user data (a service kind, an editor name) goes
+ *     through allowlist() first, because "short and lowercase" is not the same
+ *     as "bounded".
+ */
+import type { ErrorClass } from './sanitize';
+
+/** Where an event about a long-running operation came from. */
+export type LongOpId =
+	| 'index'
+	| 'exercise'
+	| 'probes'
+	| 'insights'
+	| 'episode'
+	| 'autopilot'
+	| 'calltree'
+	| 'flow_build'
+	| 'ide_chat'
+	| 'harness_run'
+	| 'optimize';
+
+/** The four stages of runDiscovery, in order. */
+export type DiscoveryStage = 'index' | 'handbook' | 'deadcode' | 'bringup';
+
+export type Outcome = 'ok' | 'error' | 'cancelled';
+
+/**
+ * Stable ids for user-visible failures. Assigned BY HAND at the call site, which
+ * is the whole point: the message text stays on the machine and this id is what
+ * travels, so the set of things Vinv can say about a failure is closed and
+ * reviewable rather than being whatever string the code happened to build.
+ */
+export type ErrorCode =
+	| 'engines.not_found'
+	| 'engines.install_failed'
+	| 'engines.not_a_checkout'
+	| 'engines.version_skew'
+	| 'index.sidecar_unhealthy'
+	| 'index.failed'
+	| 'index.no_workspace'
+	| 'harness.blocked'
+	| 'harness.not_installed'
+	| 'harness.no_headless'
+	| 'harness.unreachable'
+	| 'harness.prompt_failed'
+	| 'harness.handoff_failed'
+	| 'harness.no_deliverable'
+	| 'harness.run_failed'
+	| 'episode.no_index'
+	| 'episode.revert_failed'
+	| 'episode.already_running'
+	| 'bringup.no_start_command'
+	| 'bringup.start_failed'
+	| 'bringup.hint_not_persisted'
+	| 'bringup.no_spans'
+	| 'autopilot.crashed'
+	| 'autopilot.budget_exhausted'
+	| 'flow.open_failed'
+	| 'flow.calltree_failed'
+	| 'graph.snapshot_failed'
+	| 'report.action_failed'
+	| 'document.open_failed'
+	| 'mcp.no_targets';
+
+/**
+ * Every surface that can report an interaction or a crash.
+ *
+ * A closed set, because this is a property value: leaving it open would let a
+ * renamed panel silently create a new bucket, and the point of these ids is
+ * that "which surface do users actually use" stays answerable across releases.
+ */
+export type WebviewId =
+	| 'ask_vinv'
+	| 'graph_explorer'
+	| 'findings'
+	| 'optimization'
+	| 'journey'
+	| 'calltree'
+	| 'episode'
+	| 'flow'
+	| 'traces'
+	| 'deadcode'
+	| 'configure'
+	| 'config_requests'
+	| 'smoke_report'
+	| 'status_bar'
+	| 'debug';
+
+/** The Flow rail's stages — the pipeline the user actually watches. */
+export type FlowStage = 'discover' | 'services' | 'test' | 'findings';
+
+export interface EventProps {
+	// -- lifecycle & onboarding funnel ---------------------------------------
+	/** Once ever, per install. The denominator for every rate below. */
+	install_first_seen: {
+		editor: string;
+		platform: string;
+	};
+	/** Every activation. DAU, activation cost, and the state of the installed base. */
+	app_activated: {
+		activation_ms: number;
+		engines_installed: boolean;
+		project_indexed: boolean;
+		has_captures: boolean;
+		services_count: number;
+		workspace_open: boolean;
+	};
+	/** The Get Started walkthrough was opened automatically. */
+	welcome_shown: { is_update: boolean };
+	/** What the once-per-install open-source toast actually converted to. */
+	oss_toast_action: { action: 'star' | 'get_started' | 'dismissed' };
+	/**
+	 * A funnel stage was reached for the first time on this install. Deduped
+	 * against a globalState high-water mark, so it is once per install, not
+	 * once per window and not once per reload.
+	 */
+	onboarding_stage: {
+		stage: 'engines_installed' | 'discovered' | 'traced';
+		days_since_install: number;
+	};
+	/** The aha moment: this install has observed a real trace hit for the first time. */
+	milestone_first_trace: {
+		days_since_install: number;
+		hours_since_first_activation: number;
+	};
+	/** Where the next-step compass thinks the user is stuck. */
+	next_step_shown: { step: string };
+
+	// -- direct user activity --------------------------------------------------
+	/**
+	 * One interaction inside a Vinv surface — a button, a link, a filter, a
+	 * thumbs-up.
+	 *
+	 * Deliberately ONE event with `view` + `action` properties rather than an
+	 * event name per button. Vinv has a dozen panels and well over sixty
+	 * distinct interactions; a name each would make the registry unreadable and
+	 * force a schema change every time a button is added, which is exactly when
+	 * instrumentation gets skipped. `action` values come from the panels' own
+	 * message types, so they are already a closed vocabulary.
+	 */
+	ui_action: {
+		view: WebviewId;
+		action: string;
+		detail?: string;
+	};
+	/** A panel or custom editor was opened. Answers which surfaces earn their keep. */
+	view_opened: { view: WebviewId };
+	/** A Flow rail stage changed state — the pipeline progression users watch. */
+	flow_stage_changed: { stage: FlowStage; status: string };
+
+	// -- commands -------------------------------------------------------------
+	/** Every command invocation, via registerTrackedCommand. */
+	command_finished: {
+		command_id: string;
+		outcome: Outcome;
+		duration_ms: number;
+		error_class?: ErrorClass;
+	};
+	/** The most common dead-end in the extension: a command run with no folder open. */
+	command_blocked_no_folder: { command_id: string };
+
+	// -- engines install: the biggest observability blind spot -----------------
+	engines_install_started: {
+		has_git: boolean;
+		has_uv: boolean;
+		has_rust: boolean;
+		has_bash: boolean;
+	};
+	engines_prereq_missing: { tool: 'git' | 'uv' | 'rust' };
+	/**
+	 * Did an install that started ever finish? Reconciled on a later activation
+	 * when the terminal never reported back — 'abandoned' is the number that
+	 * decides whether the terminal-based installer survives.
+	 */
+	engines_install_settled: {
+		outcome: 'ready' | 'abandoned';
+		minutes_bucket: number;
+	};
+	engines_update_result: {
+		outcome: 'ok' | 'failed' | 'skipped';
+		mode: string;
+	};
+	/** The real distribution behind the 600s first-run model-download timeout. */
+	embedder_ready: { waited_ms: number; cold_start: boolean };
+	embedder_failed: {
+		stage: 'spawn' | 'health_timeout';
+		waited_ms: number;
+		error_class: ErrorClass;
+	};
+
+	// -- the discovery pipeline ------------------------------------------------
+	discovery_started: {
+		trigger: 'auto' | 'command' | 'autopilot';
+		force: boolean;
+		harness_id: string;
+	};
+	/** One row per stage. Makes "which stage kills the pipeline" a single query. */
+	discovery_stage: {
+		stage: DiscoveryStage;
+		outcome: Outcome;
+		duration_ms: number;
+	};
+	discovery_finished: {
+		outcome: 'done' | 'incomplete' | 'cancelled';
+		index_ok: boolean;
+		handbook_ok: boolean;
+		deadcode_ok: boolean;
+		bringup_ok: boolean;
+		services_count: number;
+		total_ms: number;
+	};
+	/** Was a silent console.error in discovery.ts. */
+	autosetup_service_failed: { error_class: ErrorClass; services_total: number };
+	/** The top two install blockers. */
+	indexing_failed: {
+		stage: 'sidecar_unhealthy' | 'attempts_exhausted';
+		attempts: number;
+		store_issue: boolean;
+		error_class: ErrorClass;
+	};
+	/** Was a silent console.error in extension.ts. */
+	mcp_registration_failed: { error_class: ErrorClass };
+
+	// -- long operations -------------------------------------------------------
+	long_op_finished: {
+		op: LongOpId;
+		outcome: Outcome;
+		duration_ms: number;
+	};
+
+	// -- the agent harness -----------------------------------------------------
+	/** How many users are dead in the water because their agent CLI is not signed in. */
+	harness_blocked: { harness_id: string; kind: 'auth' | 'quota' | 'network' };
+	harness_run_finished: {
+		harness_id: string;
+		failure_kind: string;
+		exit_class: string;
+		duration_ms: number;
+	};
+	episode_finished: {
+		outcome: string;
+		attempts: number;
+		verified: boolean;
+		f2p_gated: boolean;
+	};
+	autopilot_finished: {
+		outcome: string;
+		services_total: number;
+		services_green: number;
+		episodes: number;
+		budget_exhausted: boolean;
+	};
+
+	// -- errors ----------------------------------------------------------------
+	/**
+	 * A user-visible error or warning was shown. `action_taken` also reveals
+	 * remediation buttons that nobody ever clicks.
+	 */
+	error_shown: {
+		code: ErrorCode;
+		surface: 'error' | 'warning';
+		action_taken: string;
+	};
+	/** A renderer crash. `digest` groups identical bugs; the message never travels. */
+	webview_error: {
+		view: WebviewId;
+		error_class: ErrorClass;
+		digest: string;
+	};
+	/** ENOENT here is the classic "engines installed but not on PATH". */
+	spawn_failed: { engine: string; code: string };
+
+	// -- shape & settings ------------------------------------------------------
+	/** What real projects using Vinv actually look like. */
+	workspace_shape: {
+		languages: string;
+		service_kinds: string;
+		services_count: number;
+		endpoints_bucket: number;
+		symbols_bucket: number;
+	};
+	/** Do people turn Auto-Pilot off? */
+	feature_toggled: { setting: string; value: string };
+}
+
+export type EventName = keyof EventProps;

--- a/extension/src/telemetry/index.ts
+++ b/extension/src/telemetry/index.ts
@@ -1,0 +1,190 @@
+/**
+ * Vinv's usage telemetry — the only public surface of this module.
+ *
+ * WHY THIS EXISTS. Vinv has no feedback channel. Issues and reviews do not
+ * arrive, so nobody knows whether an install ever reaches a working state,
+ * which step kills the ones that do not, or what errors people actually hit.
+ * Several of the most important failures are literally invisible today: the
+ * engines install runs in a terminal and never reports back, and two real
+ * failure paths end in a `console.error` nobody will ever read. This turns that
+ * into three answerable questions — where users get blocked, what they do, and
+ * what breaks.
+ *
+ * WHAT IT SENDS. Event names, outcomes, bucketed durations and counts, and
+ * error CATEGORIES. Never file paths, never code, never repository names, never
+ * raw error text, never URLs. The guarantee is mechanical, not editorial: every
+ * property crosses the allowlist in sanitize.ts, which drops anything that
+ * cannot be spelled without a slash, a space or a quote.
+ *
+ * WHAT GATES IT. Telemetry is on by default. Two conditions still apply, and
+ * neither is a Vinv-specific consent gate:
+ *
+ *   - `vscode.env.isTelemetryEnabled` — the editor's own global switch, honoured
+ *     for free by `createTelemetryLogger`. Ignoring it would violate the
+ *     Marketplace publisher requirements and would mean writing extra code to
+ *     override a machine-wide refusal the user already expressed.
+ *   - production builds only — a data-quality filter, not a user protection.
+ *     `@vscode/test-cli` runs the suite in Test mode and contributors run F5
+ *     sessions in Development mode; without this, synthetic events from CI and
+ *     from the people writing the code would swamp the funnel numbers this
+ *     exists to produce.
+ *
+ * FAILURE POSTURE. Telemetry is never worth a user-visible failure. `track` and
+ * `initTelemetry` cannot throw and are never awaited; a dead endpoint costs
+ * nothing because nothing waits on it. This mirrors the discipline already
+ * established for the one other outbound request in the extension — see the
+ * header of src/notices/notices.ts.
+ */
+import * as vscode from 'vscode';
+import type { EventName, EventProps } from './events';
+import { PostHogSender, type SentRecord } from './client';
+import {
+	initCommonProps,
+	installAgeDays,
+	installAgeHours,
+	markFirstSeen,
+	POSTHOG_KEY,
+	withCommonProps,
+} from './common';
+import { sanitizeProps, setSanitizerStrict } from './sanitize';
+
+export type { ErrorClass } from './sanitize';
+export { allowlist, bucketCount, bucketMs, classifyError, messageDigest } from './sanitize';
+export { isFirstEverInstall, installAgeDays, installAgeHours } from './common';
+export type { DiscoveryStage, ErrorCode, EventName, LongOpId, Outcome, WebviewId } from './events';
+
+/** The key a build ships when nobody replaced the placeholder. */
+const PLACEHOLDER_KEY = 'phc_REPLACE_WITH_PROJECT_KEY';
+
+/**
+ * Debug builds only. When true (set with `VINV_TELEMETRY_FORCE=1` at build
+ * time), `track` hands events straight to the PostHog sender, bypassing the
+ * `vscode.env.isTelemetryEnabled` gate that `createTelemetryLogger` enforces.
+ *
+ * This exists for one narrow purpose: a build handed to a specific user who has
+ * raised an issue, so their diagnostics arrive even if their editor's telemetry
+ * is switched off. It also lets telemetry initialise in a non-production build,
+ * so the Extension Development Host can be used to reproduce. A normal
+ * `npm run package` leaves the flag empty, and consent is respected as before.
+ */
+const FORCE_SEND = process.env.VINV_TELEMETRY_FORCE === '1';
+
+let logger: vscode.TelemetryLogger | undefined;
+let sender: PostHogSender | undefined;
+/** Why telemetry is inactive, when it is. Surfaced in the diagnostics dump. */
+let inactiveReason = 'not-initialised';
+
+/**
+ * Wires telemetry up. Returns synchronously and never throws — call it with
+ * `initTelemetry(context)` from `activate`, not with `await`.
+ */
+export function initTelemetry(context: vscode.ExtensionContext): void {
+	try {
+		const production = context.extensionMode === vscode.ExtensionMode.Production;
+		// Strict sanitising outside production: a call site that would leak
+		// should break the author's test run, loudly, on their machine.
+		setSanitizerStrict(!production);
+
+		initCommonProps(context);
+		const isFirstEver = markFirstSeen(context);
+
+		if (!production && !FORCE_SEND) {
+			inactiveReason = 'dev-build';
+			return;
+		}
+		if (!POSTHOG_KEY || POSTHOG_KEY === PLACEHOLDER_KEY) {
+			inactiveReason = 'no-key';
+			return;
+		}
+
+		sender = new PostHogSender();
+		logger = vscode.env.createTelemetryLogger(sender, {
+			// Vinv computes its own common properties (see common.ts) and every
+			// one of them is a bare snake_case key. The built-ins arrive as
+			// dotted `common.*` keys, which the allowlist would reject and
+			// which would duplicate what is already there.
+			ignoreBuiltInCommonProperties: true,
+		});
+		context.subscriptions.push(logger);
+		inactiveReason = '';
+
+		if (isFirstEver) {
+			track('install_first_seen', {
+				editor: String(withCommonProps({}).editor ?? 'other'),
+				platform: process.platform,
+			});
+		}
+	} catch {
+		// Telemetry must never be the reason activation fails.
+		inactiveReason = 'init-failed';
+		logger = undefined;
+		sender = undefined;
+	}
+}
+
+/**
+ * Records one event. Fire-and-forget by construction: no return value, no
+ * promise, and no path out of here that throws in production.
+ */
+export function track<K extends EventName>(name: K, props: EventProps[K]): void {
+	if (!logger && !(FORCE_SEND && sender)) {
+		return;
+	}
+	try {
+		// The authoring boundary. In a dev build an unsafe property throws here,
+		// naming the event and the field, which is the moment it is cheapest to
+		// fix. In production the offending field is simply dropped.
+		const safe = sanitizeProps(withCommonProps(props as Record<string, unknown>));
+		if (FORCE_SEND && sender) {
+			// Debug build: skip the editor's telemetry switch and hand the event
+			// straight to the sender. See FORCE_SEND.
+			sender.sendEventData(name, safe);
+		} else if (logger) {
+			// logUsage, never logError: VS Code's error path would hand the sender
+			// a raw Error with an absolute-path stack. See PostHogSender.sendErrorData.
+			logger.logUsage(name, safe);
+		}
+	} catch {
+		// Never let an instrumentation bug break the feature it instruments.
+	}
+}
+
+/** True when events are actually being sent. */
+export function isTelemetryActive(): boolean {
+	// A debug build reports regardless of the editor's telemetry switch.
+	if (FORCE_SEND) {
+		return sender !== undefined;
+	}
+	return logger !== undefined && vscode.env.isTelemetryEnabled;
+}
+
+/**
+ * A human-readable account of the current state, for `Vinv: Export Diagnostics`.
+ * Shows what is being sent, so a user filing a bug can see it for themselves.
+ */
+export function telemetryDiagnostics(): string {
+	const lines = [
+		`active:            ${isTelemetryActive()}`,
+		`host_telemetry:    ${vscode.env.isTelemetryEnabled}`,
+		`force_send:        ${FORCE_SEND}`,
+		`inactive_reason:   ${inactiveReason || '(none)'}`,
+	];
+	const recent: ReadonlyArray<SentRecord> = sender?.recentlySent() ?? [];
+	lines.push(`events_sent:       ${recent.length}${recent.length === 50 ? '+ (last 50)' : ''}`);
+	for (const r of recent) {
+		lines.push(`  ${r.at} ${r.event} ${JSON.stringify(r.properties)}`);
+	}
+	return lines.join('\n');
+}
+
+/**
+ * Flushes and closes, bounded. Called from `deactivate`, where the window is
+ * short and not guaranteed — losing queued events is the expected case, not a
+ * bug to engineer around.
+ */
+export async function shutdownTelemetry(timeoutMs = 1500): Promise<void> {
+	const s = sender;
+	logger = undefined;
+	sender = undefined;
+	await s?.shutdown(timeoutMs);
+}

--- a/extension/src/telemetry/instrument.ts
+++ b/extension/src/telemetry/instrument.ts
@@ -1,0 +1,203 @@
+/**
+ * The instrumentation wrappers.
+ *
+ * The design rule for this whole effort is ONE WRAPPER PER CATEGORY OF SITE, not
+ * one edit per site. The extension has 42 commands, 11 progress-reporting
+ * operations, ~40 user-visible error surfaces and 21 copies of the same
+ * "no folder open" dead-end. Hand-editing each would be a diff nobody can
+ * review, and would rot the moment someone adds the 43rd command.
+ *
+ * So each wrapper is a drop-in replacement for the vscode API it fronts, with
+ * identical semantics plus one event. Behaviour must be unchanged — in
+ * particular `registerTrackedCommand` still rethrows, so VS Code still shows the
+ * error it always showed.
+ */
+import * as vscode from 'vscode';
+import type { ErrorCode, LongOpId, Outcome, WebviewId } from './events';
+import { bucketMs, classifyError, messageDigest, track } from './index';
+
+/** VS Code signals user cancellation by name, not by type. */
+function isCancellation(e: unknown): boolean {
+	if (e instanceof vscode.CancellationError) {
+		return true;
+	}
+	const name = (e as { name?: unknown } | null)?.name;
+	return name === 'Canceled' || name === 'CancellationError';
+}
+
+/**
+ * Drop-in for `vscode.commands.registerCommand`, plus a `command_finished`
+ * event carrying the outcome and how long it took.
+ *
+ * One semantic note: wrapping makes a synchronous handler's return value a
+ * Thenable. That is safe here — `executeCommand` already returns a Thenable
+ * regardless of what the handler returns, and no Vinv call site consumes a
+ * command result synchronously.
+ */
+export function registerTrackedCommand(
+	id: string,
+	handler: (...args: never[]) => unknown,
+	thisArg?: unknown,
+): vscode.Disposable {
+	return vscode.commands.registerCommand(id, async (...args: never[]) => {
+		const started = Date.now();
+		let outcome: Outcome = 'ok';
+		let errorClass;
+		try {
+			return await (handler as (...a: unknown[]) => unknown).apply(thisArg, args);
+		} catch (e) {
+			outcome = isCancellation(e) ? 'cancelled' : 'error';
+			errorClass = classifyError(e);
+			// Rethrow: the user's experience of a failing command is unchanged.
+			throw e;
+		} finally {
+			track('command_finished', {
+				command_id: id,
+				outcome,
+				duration_ms: bucketMs(Date.now() - started),
+				error_class: errorClass,
+			});
+		}
+	});
+}
+
+/**
+ * The workspace-folder precondition, in one place.
+ *
+ * `'Vinv: Open a folder first.'` was copied into 21 command handlers, which made
+ * the single most common dead-end in the extension both unmeasurable and
+ * tedious to change. Returns the folder itself rather than a path so it is a
+ * drop-in for the `workspaceFolders?.[0]` it replaces.
+ */
+export function requireWorkspaceFolder(commandId: string): vscode.WorkspaceFolder | undefined {
+	const folder = vscode.workspace.workspaceFolders?.[0];
+	if (folder) {
+		return folder;
+	}
+	void vscode.window.showWarningMessage('Vinv: Open a folder first.');
+	track('command_blocked_no_folder', { command_id: commandId });
+	return undefined;
+}
+
+/**
+ * Shows an error AND records that it was shown.
+ *
+ * The message text is never transmitted. What travels is `code` — a stable id
+ * assigned here, at the call site, by a human — so the set of failures Vinv can
+ * report is closed and reviewable instead of being whatever string the code
+ * happened to build. `action_taken` comes back too, which is how you find
+ * remediation buttons that nobody ever clicks.
+ */
+export async function notifyError(
+	code: ErrorCode,
+	message: string,
+	...actions: string[]
+): Promise<string | undefined> {
+	const choice = await vscode.window.showErrorMessage(message, ...actions);
+	track('error_shown', { code, surface: 'error', action_taken: actionToken(choice) });
+	return choice;
+}
+
+/** As notifyError, for the warning surface. */
+export async function notifyWarning(
+	code: ErrorCode,
+	message: string,
+	...actions: string[]
+): Promise<string | undefined> {
+	const choice = await vscode.window.showWarningMessage(message, ...actions);
+	track('error_shown', { code, surface: 'warning', action_taken: actionToken(choice) });
+	return choice;
+}
+
+/**
+ * Button labels are human prose ("⭐ Star on GitHub"), which the allowlist would
+ * reject and which would be unbounded cardinality anyway. What matters is which
+ * of the offered buttons was pressed, so send the index-free token form.
+ */
+function actionToken(choice: string | undefined): string {
+	return choice === undefined ? 'dismissed' : token(choice);
+}
+
+/**
+ * Records one interaction inside a Vinv surface.
+ *
+ * Every panel already routes its user interactions through a single
+ * `onDidReceiveMessage` switch keyed by a message type, so this sits at that
+ * switch and captures the whole surface in one line rather than one line per
+ * button. `action` is that message type: a vocabulary the panels already
+ * define, already closed, and already named after what the user did.
+ *
+ * `detail` is for the one extra dimension that matters for some actions (which
+ * tab, which verdict, which filter). It is normalised to a token — never a
+ * path, an endpoint id, or anything drawn from the user's code.
+ */
+export function trackUi(view: WebviewId, action: string, detail?: string): void {
+	track('ui_action', {
+		view,
+		action: token(action),
+		detail: detail === undefined ? undefined : token(detail),
+	});
+}
+
+/**
+ * Records a renderer crash reported over the shared `webviewError` channel.
+ *
+ * Six panels already install `window.onerror` / `unhandledrejection` handlers
+ * that post `{ type: 'webviewError', message, stack }` to the extension host —
+ * and every one of those handlers currently drops the message on the floor.
+ * Renderer crashes are therefore completely invisible today, which is why the
+ * Graph Explorer or the Journey view failing to draw produces no signal at all.
+ *
+ * The message and the stack are NOT sent: a stack is absolute paths and a
+ * message can quote the user's code. What travels is the error class and a
+ * one-way digest, which is enough to count distinct renderer bugs and rank
+ * them, and not enough to reconstruct anything.
+ */
+export function reportWebviewError(view: WebviewId, raw: { message?: unknown }): void {
+	const message = typeof raw.message === 'string' ? raw.message : '';
+	track('webview_error', {
+		view,
+		error_class: classifyError(message ? { message } : undefined),
+		digest: messageDigest(message),
+	});
+}
+
+/** Records that a panel or custom editor was opened. */
+export function trackViewOpened(view: WebviewId): void {
+	track('view_opened', { view });
+}
+
+/** Normalises an arbitrary label into something the allowlist will accept. */
+function token(value: string): string {
+	return (
+		String(value)
+			.toLowerCase()
+			.replace(/[^a-z0-9]+/g, '_')
+			.replace(/^_+|_+$/g, '')
+			.slice(0, 48) || 'unknown'
+	);
+}
+
+/**
+ * Times a long-running operation and records how it ended.
+ *
+ * These are the waits users actually feel — indexing, exercising endpoints, an
+ * agent episode — so their duration distribution and their cancellation rate
+ * are the closest thing to a direct measure of patience running out.
+ */
+export async function trackLongOp<T>(op: LongOpId, run: () => Promise<T>): Promise<T> {
+	const started = Date.now();
+	let outcome: Outcome = 'ok';
+	try {
+		return await run();
+	} catch (e) {
+		outcome = isCancellation(e) ? 'cancelled' : 'error';
+		throw e;
+	} finally {
+		track('long_op_finished', {
+			op,
+			outcome,
+			duration_ms: bucketMs(Date.now() - started),
+		});
+	}
+}

--- a/extension/src/telemetry/sanitize.ts
+++ b/extension/src/telemetry/sanitize.ts
@@ -1,0 +1,303 @@
+/**
+ * The redaction layer — the thing that makes analytics on a code tool safe.
+ *
+ * Vinv sees absolute paths, repository names, source lines, tracebacks and the
+ * output of the user's own agent CLI. None of that may leave the machine, and
+ * "remember not to send it" is not a mechanism. So every property crossing into
+ * PostHog passes through `sanitizeProps`, which is an ALLOWLIST:
+ *
+ *   - booleans and finite numbers pass;
+ *   - strings pass only if they match SAFE_TOKEN — short, and drawn from an
+ *     alphabet with no `/`, `\`, space, quote or `@` in it, so no path, URL,
+ *     repo name, email or sentence can be spelled in it;
+ *   - everything else is dropped.
+ *
+ * An allowlist matters because the failure directions are not symmetric. A
+ * blocklist ("strip anything that looks like a path") fails OPEN: the day
+ * someone writes `track('x', { path: file })` with a shape the patterns miss, it
+ * ships and it leaks. This fails CLOSED — the property is dropped — and in a
+ * dev or test build it THROWS, so the offending call site breaks a unit test on
+ * the author's machine instead of leaking from a user's.
+ *
+ * It is also what keeps the data usable. PostHog charges for, and chokes on,
+ * unbounded property cardinality; one free-text property (a raw error message, a
+ * raw `appName`) turns a groupable funnel into a million singleton rows.
+ *
+ * This module deliberately imports NOTHING — not `vscode`, not the harness — so
+ * it is directly unit-testable and so nothing here can accidentally reach into
+ * the parts of the extension that hold the sensitive data.
+ */
+
+/** Property names: lowercase snake_case, bounded. Keeps the PostHog schema legible. */
+const SAFE_KEY = /^[a-z][a-z0-9_]{0,39}$/;
+
+/**
+ * The only string shape that may be sent. Note what is NOT in this character
+ * class: `/`, `\`, space, `'`, `"`, `@`. That exclusion is the actual privacy
+ * guarantee — a POSIX path, a Windows path, a URL, a git remote, an email
+ * address and an English sentence all require at least one of them.
+ */
+const SAFE_TOKEN = /^[a-z0-9_.:-]{1,64}$/i;
+
+/** PostHog's own `$`-prefixed controls (e.g. `$geoip_disable`) bypass SAFE_KEY. */
+const POSTHOG_CONTROL = /^\$[a-z][a-z0-9_]{0,39}$/;
+
+/**
+ * Whether a rejected property is a loud failure or a silent drop. Defaults to
+ * strict so a unit test importing this module directly gets the throwing
+ * behaviour; `initTelemetry` turns it off for production builds.
+ */
+let defaultStrict = true;
+
+/** Called by initTelemetry: production drops silently, dev/test throws. */
+export function setSanitizerStrict(value: boolean): void {
+	defaultStrict = value;
+}
+
+export type SafeValue = string | number | boolean;
+
+/**
+ * Filters a property bag down to what may be transmitted.
+ *
+ * Runs at two boundaries, with different strictness on purpose. At the AUTHORING
+ * boundary (`track`) it is strict in dev builds, so a call site that would leak
+ * fails the author's test run rather than a user's privacy. At the EGRESS
+ * boundary (the sender) it is always lenient, because by then dropping one
+ * field beats dropping the event — and because VS Code's own telemetry cleaner
+ * has run in between and may have rewritten a value into a form this would
+ * otherwise reject.
+ */
+export function sanitizeProps(
+	raw: Record<string, unknown>,
+	strict: boolean = defaultStrict,
+): Record<string, SafeValue> {
+	const reject = (key: string, why: string): void => {
+		if (strict) {
+			throw new Error(`telemetry: unsafe property "${key}" (${why})`);
+		}
+	};
+	const out: Record<string, SafeValue> = {};
+	for (const [k, v] of Object.entries(raw)) {
+		if (v === undefined) {
+			// Optional properties left unset are normal, not a violation.
+			continue;
+		}
+		if (!SAFE_KEY.test(k) && !POSTHOG_CONTROL.test(k)) {
+			reject(k, 'key is not lowercase snake_case');
+			continue;
+		}
+		if (typeof v === 'boolean') {
+			out[k] = v;
+			continue;
+		}
+		if (typeof v === 'number') {
+			if (!Number.isFinite(v)) {
+				reject(k, 'non-finite number');
+				continue;
+			}
+			out[k] = v;
+			continue;
+		}
+		if (typeof v === 'string') {
+			if (!SAFE_TOKEN.test(v)) {
+				reject(k, 'string is not a short opaque token');
+				continue;
+			}
+			out[k] = v;
+			continue;
+		}
+		reject(k, `unsupported type ${typeof v}`);
+	}
+	return out;
+}
+
+/**
+ * The error taxonomy. The first three are exactly `HarnessInfraKind` from
+ * harnessRunner, reused rather than re-invented so a harness failure and a
+ * generic failure land in the same bucket and stay comparable.
+ */
+export type ErrorClass =
+	| 'auth'
+	| 'quota'
+	| 'network'
+	| 'enoent'
+	| 'eacces'
+	| 'eperm'
+	| 'ebusy'
+	| 'timeout'
+	| 'cancelled'
+	| 'parse'
+	| 'spawn'
+	| 'disk'
+	| 'oom'
+	| 'other';
+
+/** Node errno → class. Checked first: a `code` is authoritative where a message is a guess. */
+const ERRNO: Readonly<Record<string, ErrorClass>> = {
+	ENOENT: 'enoent',
+	EACCES: 'eacces',
+	EPERM: 'eperm',
+	EBUSY: 'ebusy',
+	ETIMEDOUT: 'timeout',
+	ENOSPC: 'disk',
+	EDQUOT: 'disk',
+	ENOMEM: 'oom',
+	ENOTFOUND: 'network',
+	ECONNREFUSED: 'network',
+	ECONNRESET: 'network',
+	EAI_AGAIN: 'network',
+	EHOSTUNREACH: 'network',
+	ENETUNREACH: 'network',
+	EPIPE: 'spawn',
+};
+
+/**
+ * Message fingerprints, applied only when there is no errno. Ordered: the first
+ * match wins, so the specific precedes the generic.
+ */
+const MESSAGE_PATTERNS: ReadonlyArray<readonly [RegExp, ErrorClass]> = [
+	[/\b(?:401|403)\b|unauthorized|not authenticated|invalid api key|please run \/login/i, 'auth'],
+	[/quota|credit balance|usage limit|rate.?limit|RESOURCE_EXHAUSTED/i, 'quota'],
+	[/getaddrinfo|network is unreachable|fetch failed|failed to connect/i, 'network'],
+	[/\btimed? ?out\b|deadline exceeded/i, 'timeout'],
+	[/\bcancell?ed\b|\baborted\b/i, 'cancelled'],
+	[/unexpected token|JSON|cannot parse|malformed|SyntaxError/i, 'parse'],
+	[/spawn|ENOEXEC|exited with code/i, 'spawn'],
+	[/no space left|disk full/i, 'disk'],
+	[/out of memory|heap out of memory/i, 'oom'],
+];
+
+/**
+ * Buckets any thrown value into one class. Total: an unrecognised error is
+ * 'other', never an exception, because this runs inside `catch` blocks whose
+ * whole job is to not make things worse.
+ */
+export function classifyError(e: unknown): ErrorClass {
+	const code = (e as { code?: unknown } | null)?.code;
+	if (typeof code === 'string') {
+		const byErrno = ERRNO[code.toUpperCase()];
+		if (byErrno) {
+			return byErrno;
+		}
+	}
+	const message = errorMessage(e);
+	if (!message) {
+		return 'other';
+	}
+	for (const [re, kind] of MESSAGE_PATTERNS) {
+		if (re.test(message)) {
+			return kind;
+		}
+	}
+	return 'other';
+}
+
+/** The message text, for local classification only. NEVER a property value. */
+function errorMessage(e: unknown): string {
+	if (typeof e === 'string') {
+		return e;
+	}
+	const m = (e as { message?: unknown } | null)?.message;
+	return typeof m === 'string' ? m : '';
+}
+
+/**
+ * Salt for message digests. A BUILD constant, deliberately NOT the machine id:
+ * salting per user would give every install a different digest for the same
+ * bug, which is exactly the grouping the digest exists to provide.
+ */
+const DIGEST_SALT = 'vinv-telemetry-v1';
+
+/**
+ * A short one-way fingerprint of an error message.
+ *
+ * This is how error telemetry stays useful without transmitting text: two users
+ * hitting the same bug report the same digest, so it is countable and
+ * rankable, while the message it was computed from never leaves the machine and
+ * cannot be recovered from the digest.
+ *
+ * Normalised first, so incidental variation (a pid, a port, a path, a hex
+ * address) does not split one bug into a hundred digests.
+ */
+export function messageDigest(message: string): string {
+	if (!message) {
+		return 'none';
+	}
+	const normalised = message
+		.toLowerCase()
+		.replace(/[a-z]:\\[^\s'"]*|\/[^\s'"]{2,}/g, '<path>')
+		.replace(/0x[0-9a-f]+/g, '<addr>')
+		.replace(/\b\d+\b/g, '<n>')
+		.replace(/\s+/g, ' ')
+		.trim()
+		.slice(0, 200);
+	// FNV-1a, 32-bit, twice over with different offsets — enough spread for
+	// grouping and small enough to read in a PostHog table. No crypto import:
+	// this is a grouping key, not a security primitive.
+	return `${fnv1a(DIGEST_SALT + normalised, 0x811c9dc5)}${fnv1a(normalised + DIGEST_SALT, 0x01000193)}`;
+}
+
+function fnv1a(input: string, offset: number): string {
+	let hash = offset >>> 0;
+	for (let i = 0; i < input.length; i++) {
+		hash ^= input.charCodeAt(i);
+		hash = Math.imul(hash, 0x01000193) >>> 0;
+	}
+	return hash.toString(16).padStart(8, '0');
+}
+
+/**
+ * Coerces an untrusted string to a member of a closed set, or 'other'.
+ *
+ * The escape hatch for values that are technically short and token-shaped but
+ * semantically unbounded — the clearest case being `ServiceEntry.kind`, which is
+ * produced by an LLM and would sail through SAFE_TOKEN while contributing
+ * unbounded cardinality. Anything not explicitly enumerated becomes 'other'.
+ */
+export function allowlist<T extends string>(
+	value: string | undefined,
+	allowed: ReadonlyArray<T>,
+): T | 'other' {
+	const v = (value ?? '').trim().toLowerCase();
+	return (allowed as ReadonlyArray<string>).includes(v) ? (v as T) : 'other';
+}
+
+/**
+ * Rounds a duration into a coarse bucket.
+ *
+ * Not for privacy — for cardinality and for honesty about precision. Exact
+ * millisecond durations make every event unique and invite reading noise as
+ * signal; what the funnel actually needs is "seconds or minutes".
+ */
+export function bucketMs(ms: number): number {
+	if (!Number.isFinite(ms) || ms < 0) {
+		return -1;
+	}
+	if (ms < 1000) {
+		return Math.round(ms / 100) * 100;
+	}
+	if (ms < 60_000) {
+		return Math.round(ms / 1000) * 1000;
+	}
+	if (ms < 3_600_000) {
+		return Math.round(ms / 30_000) * 30_000;
+	}
+	return Math.round(ms / 600_000) * 600_000;
+}
+
+/** Coarse count bucket, for the same reason as bucketMs. */
+export function bucketCount(n: number): number {
+	if (!Number.isFinite(n) || n < 0) {
+		return -1;
+	}
+	if (n <= 10) {
+		return Math.round(n);
+	}
+	if (n <= 100) {
+		return Math.round(n / 10) * 10;
+	}
+	if (n <= 1000) {
+		return Math.round(n / 100) * 100;
+	}
+	return Math.round(n / 1000) * 1000;
+}

--- a/extension/src/test/autoPilot.test.ts
+++ b/extension/src/test/autoPilot.test.ts
@@ -8,6 +8,8 @@
 import * as assert from 'assert';
 import {
 	applySetupOutcome,
+	decideAfterHarnessPick,
+	decideHarnessGate,
 	decideOnFailure,
 	grantMoreBudget,
 	DEFAULT_BUDGETS,
@@ -332,5 +334,35 @@ suite('autoPilotMachine: exercise is not starved by a stuck service', () => {
 			kind: 'setup',
 			service: 'api',
 		});
+	});
+});
+
+suite('autoPilotMachine: the harness gate', () => {
+	test('an explicitly chosen, present harness is the only silent start', () => {
+		assert.strictEqual(decideHarnessGate(true, true), 'proceed');
+	});
+
+	test('never chosen asks, even though the id accessor would answer claude-code', () => {
+		// The regression this pins: "unchosen" defaults to claude-code
+		// downstream, so a run would silently drive the whole workspace through
+		// an agent the user never picked and may not have installed.
+		assert.strictEqual(decideHarnessGate(false, true), 'ask');
+		assert.strictEqual(decideHarnessGate(false, false), 'ask');
+	});
+
+	test('a chosen harness that has since disappeared asks again', () => {
+		assert.strictEqual(decideHarnessGate(true, false), 'ask');
+	});
+
+	test('dismissing the prompt stops the run — it does not fall back', () => {
+		assert.strictEqual(decideAfterHarnessPick(null, true), 'stop-unpicked');
+		assert.strictEqual(decideAfterHarnessPick(null, false), 'stop-unpicked');
+	});
+
+	test('a pick that is present proceeds; one still absent stops', () => {
+		assert.strictEqual(decideAfterHarnessPick('codex', true), 'proceed');
+		// The picker installs before resolving, so absent here means the install
+		// is still running — stop rather than dispatch into a missing CLI.
+		assert.strictEqual(decideAfterHarnessPick('codex', false), 'stop-absent');
 	});
 });

--- a/extension/src/test/exerciseWiring.test.ts
+++ b/extension/src/test/exerciseWiring.test.ts
@@ -19,6 +19,8 @@ import {
 	isDispatchableKind,
 	evidenceFileForKind,
 	engineVerdict,
+	mergeProfiles,
+	tagProfileWithService,
 	ASSERT_SUCCESS_CRITERIA,
 } from '../harness/exerciseRunner';
 import { computeFlowModel, type FlowFacts } from '../views/flowModel';
@@ -328,5 +330,47 @@ suite('the verdict describes the run, not the last play', () => {
 			'functions.json': { status: 'environment', diagnostics: ['nothing imported'] },
 		});
 		assert.match(engineVerdict(root, 0), /nothing imported/);
+	});
+});
+
+
+suite('per-service attribution survives the profile merge', () => {
+	const profile = (id: string) => ({
+		endpoint_count: 1,
+		endpoints: [{ api_id: id, unit_kind: 'cli_invocation', coverage: { covered: 1, total: 4 } }],
+		opportunities: [{ kind: 'latency', endpoint: id }],
+	});
+
+	test('a service-free profile is stamped with the service it came from', () => {
+		const tagged = tagProfileWithService(profile('bm25-index#stats') as never, 'bm25-index') as never;
+		assert.strictEqual((tagged as { service?: string }).service, 'bm25-index');
+		assert.strictEqual((tagged as { endpoints: Array<{ service?: string }> }).endpoints[0].service, 'bm25-index');
+		assert.strictEqual(
+			(tagged as { opportunities: Array<{ service?: string }> }).opportunities[0].service,
+			'bm25-index',
+		);
+	});
+
+	test('a service the engine already stated is never overwritten', () => {
+		const own = { ...profile('x#y'), service: 'declared' } as never;
+		const tagged = tagProfileWithService(own, 'guessed') as { service?: string };
+		assert.strictEqual(tagged.service, 'declared');
+	});
+
+	test('merging several services keeps every row attributable', () => {
+		// The regression: the merge dropped the label, so the Findings panel
+		// filtered by service and matched nothing at all.
+		const merged = mergeProfiles([
+			tagProfileWithService(profile('bm25-index#stats') as never, 'bm25-index'),
+			tagProfileWithService(profile('retrieve#query') as never, 'retrieve'),
+		]) as { endpoints: Array<{ api_id: string; service?: string }> } | null;
+		assert.ok(merged, 'the merge produced nothing');
+		const byId = new Map(merged.endpoints.map((e) => [e.api_id, e.service]));
+		assert.strictEqual(byId.get('bm25-index#stats'), 'bm25-index');
+		assert.strictEqual(byId.get('retrieve#query'), 'retrieve');
+	});
+
+	test('a null profile passes through rather than throwing', () => {
+		assert.strictEqual(tagProfileWithService(null, 'svc'), null);
 	});
 });

--- a/extension/src/test/harnessInfra.test.ts
+++ b/extension/src/test/harnessInfra.test.ts
@@ -22,8 +22,10 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import {
+	canInstallHarness,
 	classifyHarnessFailure,
 	clearHarnessBlock,
+	HARNESSES,
 	createHarnessStreamDecoder,
 	dispatchAgentPrompt,
 	getHarness,
@@ -439,5 +441,34 @@ suite('autoPilotMachine: blocked dispatch consumes no budgets', () => {
 		const { gaveUp } = summarize([markBlockedOnHarness(svc(), 'needs login')]);
 		assert.strictEqual(gaveUp.length, 1);
 		assert.ok(gaveUp[0].reason?.includes('blocked on you'));
+	});
+});
+
+/**
+ * The picker installs a missing agent — from its inline button OR from simply
+ * selecting the row — rather than resolving with one that is not there. That
+ * only works if every CLI harness actually carries an installer and a stated
+ * sign-in step, since the terminal it opens is where the user completes both.
+ *
+ * Deliberately no startHarnessInstall() call here: it would really install
+ * software on the machine running the tests.
+ */
+suite('harness installability: the accept-to-install precondition', () => {
+	test('every CLI harness is installable and says how to sign in afterwards', () => {
+		const clis = HARNESSES.filter((h) => h.kind === 'cli');
+		assert.ok(clis.length >= 4, 'expected the CLI harness catalog to be populated');
+		for (const h of clis) {
+			assert.ok(canInstallHarness(h), `${h.id} has no installer — selecting it could only fail`);
+			assert.ok(h.installCommand && h.installCommand.trim().length > 0, `${h.id}: empty install command`);
+			assert.ok(h.postInstall.trim().length > 0, `${h.id}: no post-install sign-in step to show`);
+		}
+	});
+
+	test('a chat harness needing no extension is not offered as installable', () => {
+		// ide-chat installability is extension-backed; one with no requiresExtension
+		// must fall through to "not available in this editor" instead of a no-op.
+		for (const h of HARNESSES.filter((x) => x.kind === 'ide-chat' && !x.chat?.requiresExtension)) {
+			assert.strictEqual(canInstallHarness(h), false, `${h.id} claims installability with nothing to install`);
+		}
 	});
 });

--- a/extension/src/views/findingsView.ts
+++ b/extension/src/views/findingsView.ts
@@ -18,6 +18,7 @@
  */
 
 import * as vscode from 'vscode';
+import { reportWebviewError, trackUi } from '../telemetry/instrument';
 import * as fs from 'fs';
 import * as path from 'path';
 import { VINV_BASE_CSS, VINV_FONT_MONO } from './webviewTheme';
@@ -204,8 +205,10 @@ function wireFindings(
 
 	const sub = webview.onDidReceiveMessage((msg: FindingsOutbound | { type: 'webviewError' }) => {
 		if (msg.type === 'webviewError') {
+			reportWebviewError('findings', msg as { message?: unknown });
 			return;
 		}
+		trackUi('findings', msg.type);
 		return handleFindingsMessage(msg, actions);
 	});
 	void push();
@@ -504,12 +507,18 @@ function getHtml(): string {
 	 */
 	function narrow(f, service) {
 		if (!service) return f;
-		const issues = f.issues.filter(i => i.service === service);
-		const endpoints = (f.endpoints || []).filter(e => e.service === service);
+		// A row with NO service is shown under every service, never hidden. The
+		// attribution can be lost upstream (a merge across services that does not
+		// carry the label through), and when it is, filtering it away reports
+		// "this service is clean" for findings that exist. Noise is recoverable;
+		// silence about a real failure is not.
+		const mine = r => !r.service || r.service === service;
+		const issues = f.issues.filter(mine);
+		const endpoints = (f.endpoints || []).filter(mine);
 		return Object.assign({}, f, {
 			issues,
 			endpoints,
-			opportunities: (f.opportunities || []).filter(o => o.service === service),
+			opportunities: (f.opportunities || []).filter(mine),
 			headline: Object.assign({}, f.headline, {
 				issuesFound: issues.length,
 				endpointsTotal: endpoints.length || f.headline.endpointsTotal,


### PR DESCRIPTION
<!--
Thanks for contributing to Vinv. Keep the diff reviewable and one logical
change per PR. See CONTRIBUTING.md (and AGENTS.md if an agent wrote any of this).
-->

## What & why

<!-- What does this change do, and why does it matter? Link the issue it closes, if any. -->

Closes #

## How it was verified

<!-- Check what you actually ran for the area you touched. Don't claim — run it. -->

- [ ] Python lint — `uv run ruff check` and `uv run ruff format --check` in the package I touched
- [ ] Python tests — `uv run pytest` in the package I touched (or repo root)
- [ ] Rust — `cargo test` in `index/` (if the index changed)
- [ ] Extension — `npm run check && npm run bundle` in `extension/` (if the extension changed)
- [ ] End-to-end honesty contract — `python tests/e2e/planted_bug_golden/run.py` stays green
- [ ] Manual testing (describe below)

<!-- Notes on manual testing / anything a reviewer should look at hardest: -->

## Ground rules (product promises — must stay true)

- [ ] No new runtime network calls (beyond the one-time embedding-model download / optional prebuilt index artifacts)
- [ ] No telemetry
- [ ] No new required configuration or env var (feature-level keys route through the user's coding-agent harness)
- [ ] Tracer stays zero-edit (users never modify their own code to use Vinv)

## AI-assisted?

<!-- If an agent wrote part of this, say so and flag where reviewers should look hardest.
     You own the diff regardless — see CONTRIBUTING.md → "Working with AI coding agents". -->
